### PR TITLE
Fix for iCade + MFi Controller Conflict (tvOS)

### DIFF
--- a/Provenance/Emulator/PVEmulatorViewController.m
+++ b/Provenance/Emulator/PVEmulatorViewController.m
@@ -72,6 +72,11 @@ void uncaughtExceptionHandler(NSException *exception)
 
 - (void)dealloc
 {
+    if (self.menuGestureRecognizer) {
+        [[UIApplication sharedApplication].keyWindow removeGestureRecognizer:self.menuGestureRecognizer];
+        [self setMenuGestureRecognizer:nil];
+    }
+    
     [self.emulatorCore stopEmulation]; //Leave emulation loop first
     [self.gameAudio stopAudio];
 
@@ -334,11 +339,11 @@ void uncaughtExceptionHandler(NSException *exception)
 #if TARGET_OS_TV
     // Adding a tap gesture recognizer for the menu type will override the default 'back' functionality of tvOS
     if (!_menuGestureRecognizer) {
-        _menuGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(controllerPauseButtonPressed:)];
-        _menuGestureRecognizer.allowedPressTypes = @[@(UIPressTypeMenu)];
+        self.menuGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(controllerPauseButtonPressed:)];
+        self.menuGestureRecognizer.allowedPressTypes = @[@(UIPressTypeMenu)];
+        
+        [[UIApplication sharedApplication].keyWindow addGestureRecognizer:self.menuGestureRecognizer];
     }
-    
-    [self.view addGestureRecognizer:_menuGestureRecognizer];
 #else
 	__weak PVEmulatorViewController *weakSelf = self;
 	for (GCController *controller in [GCController controllers])


### PR DESCRIPTION
On the Apple TV the Menu or Home button didn't work as expected while in emulation mode. Instead of showing the pause menu the app jumped into background. In order to change this UITapGestureRecognizer hast to be listening on the keyWindow of the App instead of the current view. The UITapGestureRecognizer should also be removed in dealloc.