### PR TITLE
Update PVGLViewController.m to decouple Image Smoothing from Fragment shader.

### DIFF
--- a/Provenance/Emulator/PVGLViewController.m
+++ b/Provenance/Emulator/PVGLViewController.m
@@ -318,7 +318,7 @@ struct PVVertex
 	glGenTextures(1, &texture);
 	glBindTexture(GL_TEXTURE_2D, texture);
 	glTexImage2D(GL_TEXTURE_2D, 0, [self.emulatorCore internalPixelFormat], self.emulatorCore.bufferSize.width, self.emulatorCore.bufferSize.height, 0, [self.emulatorCore pixelFormat], [self.emulatorCore pixelType], self.emulatorCore.videoBuffer);
-	if ([[PVSettingsModel sharedInstance] imageSmoothing] || [[PVSettingsModel sharedInstance] crtFilterEnabled])
+	if ([[PVSettingsModel sharedInstance] imageSmoothing])
 	{
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);


### PR DESCRIPTION
Restores the previous "Image Smoothing" behavior from being always enabled and softening the results when using the CRT Shader. The feature can now be applied separate from the CRT Shader allowing for explicit pixel accurate rendering without filtering when using the Fragment shader render path in Provenance.