### PR TITLE
[tvOS] Fix background of controller selection in settings

### DIFF
--- a/ProvenanceTV/Base.lproj/Provenance.storyboard
+++ b/ProvenanceTV/Base.lproj/Provenance.storyboard
@@ -885,7 +885,7 @@ This is a test</string>
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="66" sectionHeaderHeight="40" sectionFooterHeight="40" id="0Cx-LN-DBW">
                         <rect key="frame" x="0.0" y="0.0" width="1285" height="1080"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <prototypes>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="controllerCell" textLabel="JNb-CJ-NyQ" detailTextLabel="nQR-Qa-dFK" style="IBUITableViewCellStyleValue1" id="kNM-iQ-BlL">
                                 <rect key="frame" x="0.0" y="80" width="1150" height="66"/>


### PR DESCRIPTION
Just a small fix reverting the background of the controller selection background to its default color. This default color is then compatible with both the light and the dark theme. See attached screenshots.

Hope you don't mind me just doing this small fix 🙂.

| | Before | After |
|:---:|:---:|:---:|
| Light | ![simulator screen shot - apple tv - 2018-03-31 at 20 05 35](https://user-images.githubusercontent.com/342095/38166158-8a19bfae-351f-11e8-9437-2c09cbfe15fd.png) | ![simulator screen shot - apple tv - 2018-03-31 at 20 07 25](https://user-images.githubusercontent.com/342095/38166159-8a32dc00-351f-11e8-9b5b-f89b35d504d7.png) |
| Dark | ![simulator screen shot - apple tv - 2018-03-31 at 20 05 09](https://user-images.githubusercontent.com/342095/38166157-89ff6c6c-351f-11e8-9f13-d2b0be834be5.png) | ![simulator screen shot - apple tv - 2018-03-31 at 20 07 56](https://user-images.githubusercontent.com/342095/38166160-8a4c8d9e-351f-11e8-8c5a-d8bc192b624f.png) |
