### PR TITLE
Fixes crash that can happen when launching a game.

### DIFF
--- a/Provenance/Game Library/UI/PVGameLibraryViewController.swift
+++ b/Provenance/Game Library/UI/PVGameLibraryViewController.swift
@@ -459,7 +459,7 @@ class PVGameLibraryViewController: UIViewController, UITextFieldDelegate, UINavi
 				}
 
 				// Query results have changed, so apply them to the UICollectionView
-				self.handleUpdate(forSection: section, deletions: deletions, insertions: insertions, modifications: Array(modifications.prefix(self.maxForSpecialSection)), needsInsert: needsInsert, needsDelete: needsDelete)
+                self.handleUpdate(forSection: section, deletions: self.filterRecents(deletions), insertions: self.filterRecents(insertions), modifications: self.filterRecents(modifications), needsInsert: needsInsert, needsDelete: needsDelete)
 				self.saveStatesIsEmpty = needsDelete
 			case .error(let error):
 				// An error occurred while opening the Realm file on the background worker thread
@@ -502,7 +502,7 @@ class PVGameLibraryViewController: UIViewController, UITextFieldDelegate, UINavi
                 }
 
                 // Query results have changed, so apply them to the UICollectionView
-                self.handleUpdate(forSection: section, deletions: deletions, insertions: insertions, modifications: modifications, needsInsert: needsInsert, needsDelete: needsDelete)
+                self.handleUpdate(forSection: section, deletions: self.filterRecents(deletions), insertions: self.filterRecents(insertions), modifications: self.filterRecents(modifications), needsInsert: needsInsert, needsDelete: needsDelete)
                 self.recentGamesIsEmpty = needsDelete
             case .error(let error):
                 // An error occurred while opening the Realm file on the background worker thread
@@ -533,6 +533,10 @@ class PVGameLibraryViewController: UIViewController, UITextFieldDelegate, UINavi
                 fatalError("\(error)")
             }
         }
+    }
+    
+    func filterRecents(_ changes: [Int]) -> [Int] {
+        return changes.filter { $0 < self.maxForSpecialSection }
     }
 
     func handleUpdate(forSection section: Int, deletions: [Int], insertions: [Int], modifications: [Int], needsInsert: Bool = false, needsDelete: Bool = false) {


### PR DESCRIPTION
I told @Jasarien on discord about a crash when launching a game, and proposed a fix. He then committed the fix (379023f4). Unfortunately, I found it still crashes in some circumstances and have come up with a better fix. Also, I applied the fix to not just Recently Saved, but also to Recently Played.

Btw, this is my first Pull Request ever.

----

The Recently Saved section only displays the last 6 items, but the user probably has way more states saved than that. So when the collectionView sections update, sometimes the Realm update notification wants to update items outside the first 6, but those items don't exist in the collectionView. This causes a crash.

To fix this, we filter the deletions, insertions, and modifications to only those within the first 6 items.