### PR TITLE
Issue #803: tweak logic to check touch area intersection to avoid repeated …

### DIFF
--- a/Provenance/Controller/JSButton.swift
+++ b/Provenance/Controller/JSButton.swift
@@ -144,16 +144,14 @@ class JSButton: UIView {
         let touchArea = CGRect(x: point.x - 10, y: point.y - 10, width: 20, height: 20)
 
         var pressed: Bool = self.pressed
-        if !pressed {
-            pressed = true
-            delegate?.buttonPressed(self)
-        }
-
         if !touchArea.intersects(frame) {
             if pressed {
                 pressed = false
                 delegate?.buttonReleased(self)
             }
+        } else if !pressed {
+            pressed = true
+            delegate?.buttonPressed(self)
         }
 
         self.pressed = pressed


### PR DESCRIPTION
…buttonPressed delegate method calls on touchedMoved

This affects buttons that are not part of the PVButtonGroupOverlayView, including start, select and shoulder buttons.

This addresses #803 