### PR TITLE
Save state tweaks 

### DIFF
--- a/Provenance.xcodeproj/project.pbxproj
+++ b/Provenance.xcodeproj/project.pbxproj
@@ -170,6 +170,10 @@
 		42BC83A917E6775E00E9A607 /* PVGameLibrarySectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42BC83A817E6775E00E9A607 /* PVGameLibrarySectionHeaderView.swift */; };
 		42E63F0617DE78AB005802B0 /* UIImage+Scaling.m in Sources */ = {isa = PBXBuildFile; fileRef = 42E63F0517DE78AB005802B0 /* UIImage+Scaling.m */; };
 		7556CF7A19DC15C1007F8F97 /* Default.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7556CF7919DC15C1007F8F97 /* Default.xib */; };
+		9257B03A20A6E3FC008C03F2 /* Banner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9257B03920A6E3FC008C03F2 /* Banner.swift */; };
+		9257B03B20A6E3FC008C03F2 /* Banner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9257B03920A6E3FC008C03F2 /* Banner.swift */; };
+		9257B03E20A6EDF4008C03F2 /* PVBannerUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9257B03D20A6EDF4008C03F2 /* PVBannerUtils.swift */; };
+		9257B03F20A6EDF4008C03F2 /* PVBannerUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9257B03D20A6EDF4008C03F2 /* PVBannerUtils.swift */; };
 		B302BFA420825ADC0029CEDB /* PVMupen64PlusVideoGlideN64.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B302BFA320825ADC0029CEDB /* PVMupen64PlusVideoGlideN64.framework */; };
 		B302BFA520825ADC0029CEDB /* PVMupen64PlusVideoGlideN64.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B302BFA320825ADC0029CEDB /* PVMupen64PlusVideoGlideN64.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B3081C092080693100C5E77B /* PViCadeMocuteController.m in Sources */ = {isa = PBXBuildFile; fileRef = B3081C072080693000C5E77B /* PViCadeMocuteController.m */; };
@@ -1083,6 +1087,8 @@
 		42E63F0417DE78AB005802B0 /* UIImage+Scaling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+Scaling.h"; sourceTree = "<group>"; };
 		42E63F0517DE78AB005802B0 /* UIImage+Scaling.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+Scaling.m"; sourceTree = "<group>"; };
 		7556CF7919DC15C1007F8F97 /* Default.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = Default.xib; sourceTree = "<group>"; };
+		9257B03920A6E3FC008C03F2 /* Banner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Banner.swift; sourceTree = "<group>"; };
+		9257B03D20A6EDF4008C03F2 /* PVBannerUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PVBannerUtils.swift; sourceTree = "<group>"; };
 		AA9B6EDD1D70981000422E5F /* PVPSXControllerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PVPSXControllerViewController.swift; sourceTree = "<group>"; };
 		B302BFA320825ADC0029CEDB /* PVMupen64PlusVideoGlideN64.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PVMupen64PlusVideoGlideN64.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B3081C072080693000C5E77B /* PViCadeMocuteController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PViCadeMocuteController.m; sourceTree = "<group>"; };
@@ -1699,6 +1705,7 @@
 		1A1237F217CA279900CEC788 /* User Interface */ = {
 			isa = PBXGroup;
 			children = (
+				9257B03C20A6ED6C008C03F2 /* Notification Banner */,
 				B3B923A1202D2EAE00580FFC /* Themes */,
 				1AB95FFF17C5640A00D3E392 /* Provenance.storyboard */,
 				7556CF7919DC15C1007F8F97 /* Default.xib */,
@@ -2160,6 +2167,15 @@
 				378F4A141B63F2240065FA39 /* Reachability.m */,
 			);
 			path = Reachability;
+			sourceTree = "<group>";
+		};
+		9257B03C20A6ED6C008C03F2 /* Notification Banner */ = {
+			isa = PBXGroup;
+			children = (
+				9257B03920A6E3FC008C03F2 /* Banner.swift */,
+				9257B03D20A6EDF4008C03F2 /* PVBannerUtils.swift */,
+			);
+			path = "Notification Banner";
 			sourceTree = "<group>";
 		};
 		AA9B6EDB1D7097C400422E5F /* PSX */ = {
@@ -3067,7 +3083,6 @@
 				ORGANIZATIONNAME = Provenance;
 				TargetAttributes = {
 					1A3D409317B2DCE4004DFFFC = {
-						DevelopmentTeam = 63497P68S6;
 						LastSwiftMigration = 0920;
 					};
 					1AD481B31BA350A400FDA50A = {
@@ -3087,7 +3102,6 @@
 					};
 					B3E21D6A203211BE009939D3 = {
 						CreatedOnToolsVersion = 9.2;
-						DevelopmentTeam = 63497P68S6;
 						ProvisioningStyle = Automatic;
 					};
 					BE9FDCB61C210B9E0046DF0E = {
@@ -3381,6 +3395,7 @@
 				42BC83A917E6775E00E9A607 /* PVGameLibrarySectionHeaderView.swift in Sources */,
 				B349AF0F1E9ABCF900ACD416 /* PpmdDecoder.cpp in Sources */,
 				B349AF591E9ABCFA00ACD416 /* LzmaSDKObjCError.mm in Sources */,
+				9257B03E20A6EDF4008C03F2 /* PVBannerUtils.swift in Sources */,
 				B349AF331E9ABCF900ACD416 /* Sha256Reg.cpp in Sources */,
 				B349AEFD1E9ABCF900ACD416 /* CopyCoder.cpp in Sources */,
 				B349AEA71E9ABCF900ACD416 /* 7zRegister.cpp in Sources */,
@@ -3445,6 +3460,7 @@
 				B3D8DCFC206EAA9E008FAC42 /* Schema.swift in Sources */,
 				B3BE96872055F40000281880 /* PVFile.swift in Sources */,
 				B35E6C31207ED7050040709A /* AppearanceStyleHelpers.swift in Sources */,
+				9257B03A20A6E3FC008C03F2 /* Banner.swift in Sources */,
 				B349AED51E9ABCF900ACD416 /* LockedStream.cpp in Sources */,
 				B3F64ED2205CD20800C273C7 /* PVButtonGroupOverlayView.swift in Sources */,
 				B3D8DD28206EAA9E008FAC42 /* Error.swift in Sources */,
@@ -3605,6 +3621,7 @@
 				B349AF681E9ABCFA00ACD416 /* LzmaSDKObjCMutableItem.mm in Sources */,
 				1AD481F31BA3549700FDA50A /* NSFileManager+Hashing.m in Sources */,
 				B349AF5C1E9ABCFA00ACD416 /* LzmaSDKObjCExtern.mm in Sources */,
+				9257B03F20A6EDF4008C03F2 /* PVBannerUtils.swift in Sources */,
 				B349AE721E9ABCF900ACD416 /* LzmaDec.c in Sources */,
 				B3D8DD31206EAA9E008FAC42 /* SwiftVersion.swift in Sources */,
 				B349AF161E9ABCF900ACD416 /* 7zAes.cpp in Sources */,
@@ -3701,6 +3718,7 @@
 				B349AF261E9ABCF900ACD416 /* CrcReg.cpp in Sources */,
 				B349AEA01E9ABCF900ACD416 /* 7zHeader.cpp in Sources */,
 				B36954E12094391B009D958D /* PVLibrary.swift in Sources */,
+				9257B03B20A6E3FC008C03F2 /* Banner.swift in Sources */,
 				B3D8DD01206EAA9E008FAC42 /* Util.swift in Sources */,
 				B3BE96912056025B00281880 /* PVSaveState.swift in Sources */,
 				B349AEF21E9ABCF900ACD416 /* BcjCoder.cpp in Sources */,
@@ -4127,8 +4145,8 @@
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = 63497P68S6;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = R72X3BF4KE;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
@@ -4173,7 +4191,7 @@
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = 63497P68S6;
+				DEVELOPMENT_TEAM = R72X3BF4KE;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
@@ -4591,8 +4609,8 @@
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = 63497P68S6;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = R72X3BF4KE;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
@@ -4643,7 +4661,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = 63497P68S6;
+				DEVELOPMENT_TEAM = R72X3BF4KE;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Frameworks/Realm-iOS",
@@ -4684,7 +4702,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = 63497P68S6;
+				DEVELOPMENT_TEAM = R72X3BF4KE;
 				ENABLE_NS_ASSERTIONS = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4725,7 +4743,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = 63497P68S6;
+				DEVELOPMENT_TEAM = R72X3BF4KE;
 				ENABLE_NS_ASSERTIONS = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Provenance/Emulator/PVEmulatorViewController.swift
+++ b/Provenance/Emulator/PVEmulatorViewController.swift
@@ -802,6 +802,7 @@ class PVEmulatorViewController: PVEmulatorViewControllerRootClass, PVAudioDelega
 			self.core.setPauseEmulation(false)
 			self.isShowingMenu = false
 			self.enableContorllerInput(false)
+            PVBannerUtils.showSaveStateBanner(message: "Save state loaded.")
 		}
 
 		if core.projectVersion != state.createdWithCoreVersion {
@@ -825,11 +826,17 @@ class PVEmulatorViewController: PVEmulatorViewControllerRootClass, PVAudioDelega
 
 	func saveStatesViewControllerCreateNewState(_ saveStatesViewController: PVSaveStatesViewController) throws {
 		try createNewSaveState(auto: false, screenshot: saveStatesViewController.screenshot)
+        dismiss(animated: true) {
+            PVBannerUtils.showSaveStateBanner(message: "State saved.")
+        }
 	}
 
     func saveStatesViewControllerOverwriteState(_ saveStatesViewController: PVSaveStatesViewController, state: PVSaveState) throws {
         try createNewSaveState(auto: false, screenshot: saveStatesViewController.screenshot)
 		try PVSaveState.delete(state)
+        dismiss(animated: true) {
+            PVBannerUtils.showSaveStateBanner(message: "Save state overwritten.")
+        }
     }
 
 	func saveStatesViewController(_ saveStatesViewController: PVSaveStatesViewController, load state: PVSaveState) {

--- a/Provenance/Game Library/UI/PVGameLibraryViewController.swift
+++ b/Provenance/Game Library/UI/PVGameLibraryViewController.swift
@@ -1947,6 +1947,7 @@ extension PVGameLibraryViewController : SaveStateCollectionDelegate {
 	func didSelectSaveState(_ saveState: PVSaveState) {
 		let cell = collectionView?.cellForItem(at: IndexPath(row: 0, section: saveStateSection))
 		load(saveState.game, sender: cell, core: saveState.core, saveState: saveState)
+        PVBannerUtils.showSaveStateBanner(message: "State loaded.")
 	}
 }
 

--- a/Provenance/User Interface/Notification Banner/Banner.swift
+++ b/Provenance/User Interface/Notification Banner/Banner.swift
@@ -1,0 +1,408 @@
+//
+//  Banner.swift
+//
+//  Created by Harlan Haskins on 7/27/15.
+//  Copyright (c) 2015 Bryx. All rights reserved.
+//
+
+import UIKit
+
+private enum BannerState {
+    case showing, hidden, gone
+}
+
+/// Wheter the banner should appear at the top or the bottom of the screen.
+///
+/// - Top: The banner will appear at the top.
+/// - Bottom: The banner will appear at the bottom.
+public enum BannerPosition {
+    case top, bottom
+}
+
+/// A level of 'springiness' for Banners.
+///
+/// - None: The banner will slide in and not bounce.
+/// - Slight: The banner will bounce a little.
+/// - Heavy: The banner will bounce a lot.
+public enum BannerSpringiness {
+    case none, slight, heavy
+    fileprivate var springValues: (damping: CGFloat, velocity: CGFloat) {
+        switch self {
+        case .none: return (damping: 1.0, velocity: 1.0)
+        case .slight: return (damping: 0.7, velocity: 1.5)
+        case .heavy: return (damping: 0.6, velocity: 2.0)
+        }
+    }
+}
+
+/// Banner is a dropdown notification view that presents above the main view controller, but below the status bar.
+open class Banner: UIView {
+    @objc class func topWindow() -> UIWindow? {
+        for window in UIApplication.shared.windows.reversed() {
+            if window.windowLevel == UIWindowLevelNormal && window.isKeyWindow && window.frame != CGRect.zero { return window }
+        }
+        return nil
+    }
+    
+    private let contentView = UIView()
+    private let labelView = UIView()
+    private let backgroundView = UIView()
+    
+    /// How long the slide down animation should last.
+    @objc open var animationDuration: TimeInterval = 0.4
+    
+    /// The preferred style of the status bar during display of the banner. Defaults to `.LightContent`.
+    ///
+    /// If the banner's `adjustsStatusBarStyle` is false, this property does nothing.
+    @objc open var preferredStatusBarStyle = UIStatusBarStyle.lightContent
+    
+    /// Whether or not this banner should adjust the status bar style during its presentation. Defaults to `false`.
+    @objc open var adjustsStatusBarStyle = false
+    
+    /// Wheter the banner should appear at the top or the bottom of the screen. Defaults to `.Top`.
+    open var position = BannerPosition.top
+
+    /// How 'springy' the banner should display. Defaults to `.Slight`
+    open var springiness = BannerSpringiness.slight
+    
+    /// The color of the text as well as the image tint color if `shouldTintImage` is `true`.
+    @objc open var textColor = UIColor.white {
+        didSet {
+            resetTintColor()
+        }
+    }
+    
+    /// The height of the banner. Default is 80.
+    @objc open var minimumHeight: CGFloat = 80
+    
+    /// Whether or not the banner should show a shadow when presented.
+    @objc open var hasShadows = true {
+        didSet {
+            resetShadows()
+        }
+    }
+    
+    /// The color of the background view. Defaults to `nil`.
+    override open var backgroundColor: UIColor? {
+        get { return backgroundView.backgroundColor }
+        set { backgroundView.backgroundColor = newValue }
+    }
+    
+    /// The opacity of the background view. Defaults to 0.95.
+    override open var alpha: CGFloat {
+        get { return backgroundView.alpha }
+        set { backgroundView.alpha = newValue }
+    }
+    
+    /// A block to call when the uer taps on the banner.
+    @objc open var didTapBlock: (() -> ())?
+    
+    /// A block to call after the banner has finished dismissing and is off screen.
+    @objc open var didDismissBlock: (() -> ())?
+    
+    /// Whether or not the banner should dismiss itself when the user taps. Defaults to `true`.
+    @objc open var dismissesOnTap = true
+    
+    /// Whether or not the banner should dismiss itself when the user swipes up. Defaults to `true`.
+    @objc open var dismissesOnSwipe = true
+    
+    /// Whether or not the banner should tint the associated image to the provided `textColor`. Defaults to `true`.
+    @objc open var shouldTintImage = true {
+        didSet {
+            resetTintColor()
+        }
+    }
+    
+    /// The label that displays the banner's title.
+    @objc open let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.preferredFont(forTextStyle: UIFontTextStyle.headline)
+        label.numberOfLines = 0
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+        }()
+    
+    /// The label that displays the banner's subtitle.
+    @objc open let detailLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.preferredFont(forTextStyle: UIFontTextStyle.subheadline)
+        label.numberOfLines = 0
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+        }()
+    
+    /// The image on the left of the banner.
+    @objc let image: UIImage?
+    
+    /// The image view that displays the `image`.
+    @objc open let imageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.contentMode = .scaleAspectFit
+        return imageView
+        }()
+    
+    private var bannerState = BannerState.hidden {
+        didSet {
+            if bannerState != oldValue {
+                forceUpdates()
+            }
+        }
+    }
+    
+    /// A Banner with the provided `title`, `subtitle`, and optional `image`, ready to be presented with `show()`.
+    ///
+    /// - parameter title: The title of the banner. Optional. Defaults to nil.
+    /// - parameter subtitle: The subtitle of the banner. Optional. Defaults to nil.
+    /// - parameter image: The image on the left of the banner. Optional. Defaults to nil.
+    /// - parameter backgroundColor: The color of the banner's background view. Defaults to `UIColor.blackColor()`.
+    /// - parameter didTapBlock: An action to be called when the user taps on the banner. Optional. Defaults to `nil`.
+    @objc public required init(title: String? = nil, subtitle: String? = nil, image: UIImage? = nil, backgroundColor: UIColor = UIColor.black, didTapBlock: (() -> ())? = nil) {
+        self.didTapBlock = didTapBlock
+        self.image = image
+        super.init(frame: CGRect.zero)
+        resetShadows()
+        addGestureRecognizers()
+        initializeSubviews()
+        resetTintColor()
+        imageView.image = image
+        titleLabel.text = title
+        detailLabel.text = subtitle
+        backgroundView.backgroundColor = backgroundColor
+        backgroundView.alpha = 0.95
+    }
+    
+    private func forceUpdates() {
+      guard let superview = superview, let showingConstraint = showingConstraint, let hiddenConstraint = hiddenConstraint else { return }
+        switch bannerState {
+        case .hidden:
+            superview.removeConstraint(showingConstraint)
+            superview.addConstraint(hiddenConstraint)
+        case .showing:
+            superview.removeConstraint(hiddenConstraint)
+            superview.addConstraint(showingConstraint)
+        case .gone:
+            superview.removeConstraint(hiddenConstraint)
+            superview.removeConstraint(showingConstraint)
+            superview.removeConstraints(commonConstraints)
+        }
+        setNeedsLayout()
+        setNeedsUpdateConstraints()
+        // Managing different -layoutIfNeeded behaviours among iOS versions (for more, read the UIKit iOS 10 release notes)
+        if #available(iOS 10.0, *) {
+            superview.layoutIfNeeded()
+        } else {
+            layoutIfNeeded()
+        }
+        updateConstraintsIfNeeded()
+    }
+  
+    @objc internal func didTap(_ recognizer: UITapGestureRecognizer) {
+        if dismissesOnTap {
+            dismiss()
+        }
+        didTapBlock?()
+    }
+    
+    @objc internal func didSwipe(_ recognizer: UISwipeGestureRecognizer) {
+        if dismissesOnSwipe {
+            dismiss()
+        }
+    }
+    
+    private func addGestureRecognizers() {
+        addGestureRecognizer(UITapGestureRecognizer(target: self, action:  #selector(Banner.didTap(_:))))
+        let swipe = UISwipeGestureRecognizer(target: self, action: #selector(Banner.didSwipe(_:)))
+        swipe.direction = .up
+        addGestureRecognizer(swipe)
+    }
+    
+    private func resetTintColor() {
+        titleLabel.textColor = textColor
+        detailLabel.textColor = textColor
+        imageView.image = shouldTintImage ? image?.withRenderingMode(.alwaysTemplate) : image
+        imageView.tintColor = shouldTintImage ? textColor : nil
+    }
+    
+    private func resetShadows() {
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOpacity = self.hasShadows ? 0.5 : 0.0
+        layer.shadowOffset = CGSize(width: 0, height: 0)
+        layer.shadowRadius = 4
+    }
+  
+    private var contentTopOffsetConstraint: NSLayoutConstraint!
+    private var minimumHeightConstraint: NSLayoutConstraint!
+  
+    private func initializeSubviews() {
+        let views = [
+            "backgroundView": backgroundView,
+            "contentView": contentView,
+            "imageView": imageView,
+            "labelView": labelView,
+            "titleLabel": titleLabel,
+            "detailLabel": detailLabel
+        ]
+        translatesAutoresizingMaskIntoConstraints = false
+        addSubview(backgroundView)
+        minimumHeightConstraint = backgroundView.constraintWithAttribute(.height, .greaterThanOrEqual, to: minimumHeight)
+        addConstraint(minimumHeightConstraint) // Arbitrary, but looks nice.
+        addConstraints(backgroundView.constraintsEqualToSuperview())
+        backgroundView.backgroundColor = backgroundColor
+        backgroundView.addSubview(contentView)
+        labelView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(labelView)
+        labelView.addSubview(titleLabel)
+        labelView.addSubview(detailLabel)
+        backgroundView.addConstraints(NSLayoutConstraint.defaultConstraintsWithVisualFormat("H:|[contentView]|", views: views))
+        backgroundView.addConstraint(contentView.constraintWithAttribute(.bottom, .equal, to: .bottom, of: backgroundView))
+        contentTopOffsetConstraint = contentView.constraintWithAttribute(.top, .equal, to: .top, of: backgroundView)
+        backgroundView.addConstraint(contentTopOffsetConstraint)
+        let leftConstraintText: String
+        if image == nil {
+            leftConstraintText = "|"
+        } else {
+            contentView.addSubview(imageView)
+            contentView.addConstraint(imageView.constraintWithAttribute(.leading, .equal, to: contentView, constant: 15.0))
+            contentView.addConstraint(imageView.constraintWithAttribute(.centerY, .equal, to: contentView))
+            imageView.addConstraint(imageView.constraintWithAttribute(.width, .equal, to: 25.0))
+            imageView.addConstraint(imageView.constraintWithAttribute(.height, .equal, to: .width))
+            leftConstraintText = "[imageView]"
+        }
+        let constraintFormat = "H:\(leftConstraintText)-(15)-[labelView]-(8)-|"
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addConstraints(NSLayoutConstraint.defaultConstraintsWithVisualFormat(constraintFormat, views: views))
+        contentView.addConstraints(NSLayoutConstraint.defaultConstraintsWithVisualFormat("V:|-(>=1)-[labelView]-(>=1)-|", views: views))
+        backgroundView.addConstraints(NSLayoutConstraint.defaultConstraintsWithVisualFormat("H:|[contentView]-(<=1)-[labelView]", options: .alignAllCenterY, views: views))
+        
+        for view in [titleLabel, detailLabel] {
+            let constraintFormat = "H:|[label]-(8)-|"
+            contentView.addConstraints(NSLayoutConstraint.defaultConstraintsWithVisualFormat(constraintFormat, options: NSLayoutFormatOptions(), metrics: nil, views: ["label": view]))
+        }
+        labelView.addConstraints(NSLayoutConstraint.defaultConstraintsWithVisualFormat("V:|-(10)-[titleLabel][detailLabel]-(10)-|", views: views))
+    }
+    
+    required public init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private var showingConstraint: NSLayoutConstraint?
+    private var hiddenConstraint: NSLayoutConstraint?
+    private var commonConstraints = [NSLayoutConstraint]()
+    
+    override open func didMoveToSuperview() {
+        super.didMoveToSuperview()
+        guard let superview = superview, bannerState != .gone else { return }
+        commonConstraints = self.constraintsWithAttributes([.width], .equal, to: superview)
+        superview.addConstraints(commonConstraints)
+
+        switch self.position {
+            case .top:
+                showingConstraint = self.constraintWithAttribute(.top, .equal, to: .top, of: superview)
+                let yOffset: CGFloat = -7.0 // Offset the bottom constraint to make room for the shadow to animate off screen.
+                hiddenConstraint = self.constraintWithAttribute(.bottom, .equal, to: .top, of: superview, constant: yOffset)
+            case .bottom:
+                showingConstraint = self.constraintWithAttribute(.bottom, .equal, to: .bottom, of: superview)
+                let yOffset: CGFloat = 7.0 // Offset the bottom constraint to make room for the shadow to animate off screen.
+                hiddenConstraint = self.constraintWithAttribute(.top, .equal, to: .bottom, of: superview, constant: yOffset)
+        }
+    }
+  
+    open override func layoutSubviews() {
+      super.layoutSubviews()
+      adjustHeightOffset()
+      layoutIfNeeded()
+    }
+  
+    private func adjustHeightOffset() {
+      guard let superview = superview else { return }
+      if superview === Banner.topWindow() && self.position == .top {
+        let statusBarSize = UIApplication.shared.statusBarFrame.size
+        let heightOffset = min(statusBarSize.height, statusBarSize.width) // Arbitrary, but looks nice.
+        contentTopOffsetConstraint.constant = heightOffset
+        minimumHeightConstraint.constant = statusBarSize.height > 0 ? minimumHeight : 40
+      } else {
+        contentTopOffsetConstraint.constant = 0
+        minimumHeightConstraint.constant = 0
+      }
+    }
+  
+    /// Shows the banner. If a view is specified, the banner will be displayed at the top of that view, otherwise at top of the top window. If a `duration` is specified, the banner dismisses itself automatically after that duration elapses.
+    /// - parameter view: A view the banner will be shown in. Optional. Defaults to 'nil', which in turn means it will be shown in the top window. duration A time interval, after which the banner will dismiss itself. Optional. Defaults to `nil`.
+    open func show(_ view: UIView? = nil, duration: TimeInterval? = nil) {
+        let viewToUse = view ?? Banner.topWindow()
+        guard let view = viewToUse else {
+            print("[Banner]: Could not find view. Aborting.")
+            return
+        }
+        view.addSubview(self)
+        forceUpdates()
+        let (damping, velocity) = self.springiness.springValues
+        let oldStatusBarStyle = UIApplication.shared.statusBarStyle
+        if adjustsStatusBarStyle {
+          UIApplication.shared.setStatusBarStyle(preferredStatusBarStyle, animated: true)
+        }
+        UIView.animate(withDuration: animationDuration, delay: 0.0, usingSpringWithDamping: damping, initialSpringVelocity: velocity, options: .allowUserInteraction, animations: {
+            self.bannerState = .showing
+            }, completion: { finished in
+                guard let duration = duration else { return }
+                DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + DispatchTimeInterval.milliseconds(Int(1000.0 * duration))) {
+                    self.dismiss(self.adjustsStatusBarStyle ? oldStatusBarStyle : nil)
+                }
+        })
+    }
+  
+    /// Dismisses the banner.
+    open func dismiss(_ oldStatusBarStyle: UIStatusBarStyle? = nil) {
+        let (damping, velocity) = self.springiness.springValues
+        UIView.animate(withDuration: animationDuration, delay: 0.0, usingSpringWithDamping: damping, initialSpringVelocity: velocity, options: .allowUserInteraction, animations: {
+            self.bannerState = .hidden
+            if let oldStatusBarStyle = oldStatusBarStyle {
+                UIApplication.shared.setStatusBarStyle(oldStatusBarStyle, animated: true)
+            }
+            }, completion: { finished in
+                self.bannerState = .gone
+                self.removeFromSuperview()
+                self.didDismissBlock?()
+        })
+    }
+}
+
+extension NSLayoutConstraint {
+    @objc class func defaultConstraintsWithVisualFormat(_ format: String, options: NSLayoutFormatOptions = NSLayoutFormatOptions(), metrics: [String: AnyObject]? = nil, views: [String: AnyObject] = [:]) -> [NSLayoutConstraint] {
+        return NSLayoutConstraint.constraints(withVisualFormat: format, options: options, metrics: metrics, views: views)
+    }
+}
+
+extension UIView {
+    @objc func constraintsEqualToSuperview(_ edgeInsets: UIEdgeInsets = UIEdgeInsets.zero) -> [NSLayoutConstraint] {
+        self.translatesAutoresizingMaskIntoConstraints = false
+        var constraints = [NSLayoutConstraint]()
+        if let superview = self.superview {
+            constraints.append(self.constraintWithAttribute(.leading, .equal, to: superview, constant: edgeInsets.left))
+            constraints.append(self.constraintWithAttribute(.trailing, .equal, to: superview, constant: edgeInsets.right))
+            constraints.append(self.constraintWithAttribute(.top, .equal, to: superview, constant: edgeInsets.top))
+            constraints.append(self.constraintWithAttribute(.bottom, .equal, to: superview, constant: edgeInsets.bottom))
+        }
+        return constraints
+    }
+    
+    @objc func constraintWithAttribute(_ attribute: NSLayoutAttribute, _ relation: NSLayoutRelation, to constant: CGFloat, multiplier: CGFloat = 1.0) -> NSLayoutConstraint {
+        self.translatesAutoresizingMaskIntoConstraints = false
+        return NSLayoutConstraint(item: self, attribute: attribute, relatedBy: relation, toItem: nil, attribute: .notAnAttribute, multiplier: multiplier, constant: constant)
+    }
+    
+    @objc func constraintWithAttribute(_ attribute: NSLayoutAttribute, _ relation: NSLayoutRelation, to otherAttribute: NSLayoutAttribute, of item: AnyObject? = nil, multiplier: CGFloat = 1.0, constant: CGFloat = 0.0) -> NSLayoutConstraint {
+        self.translatesAutoresizingMaskIntoConstraints = false
+        return NSLayoutConstraint(item: self, attribute: attribute, relatedBy: relation, toItem: item ?? self, attribute: otherAttribute, multiplier: multiplier, constant: constant)
+    }
+    
+    @objc func constraintWithAttribute(_ attribute: NSLayoutAttribute, _ relation: NSLayoutRelation, to item: AnyObject, multiplier: CGFloat = 1.0, constant: CGFloat = 0.0) -> NSLayoutConstraint {
+        self.translatesAutoresizingMaskIntoConstraints = false
+        return NSLayoutConstraint(item: self, attribute: attribute, relatedBy: relation, toItem: item, attribute: attribute, multiplier: multiplier, constant: constant)
+    }
+    
+    func constraintsWithAttributes(_ attributes: [NSLayoutAttribute], _ relation: NSLayoutRelation, to item: AnyObject, multiplier: CGFloat = 1.0, constant: CGFloat = 0.0) -> [NSLayoutConstraint] {
+        return attributes.map { self.constraintWithAttribute($0, relation, to: item, multiplier: multiplier, constant: constant) }
+    }
+}

--- a/Provenance/User Interface/Notification Banner/PVBannerUtils.swift
+++ b/Provenance/User Interface/Notification Banner/PVBannerUtils.swift
@@ -1,0 +1,17 @@
+//
+//  PVBannerUtils.swift
+//  Provenance
+//
+//  Created by Yoshi Sugawara on 5/11/18.
+//  Copyright © 2018 Provenance. All rights reserved.
+//
+
+import UIKit
+
+class PVBannerUtils: NSObject {
+    class func showSaveStateBanner(message: String) {
+        let banner = Banner(title: message, subtitle: nil, image: nil, backgroundColor: Theme.currentTheme.gameLibraryBackground)
+        banner.tintColor = Theme.currentTheme.defaultTintColor
+        banner.show(duration: 2.0)
+    }
+}


### PR DESCRIPTION
Dismiss save state controller immediately after saving state; show notification banner when state loaded/saved/overwritten

I added a simple notification banner class from:
https://github.com/bryx-inc/BRYXBanner

I was thinking of implementing quick-load and quick-save states, and I thought having this simple notification banner would be useful and provide some much needed feedback.

I also thought it was more convenient to get right back into the game when saving/overwriting states.