### PR TITLE
Add “Files” support to info.plist

### DIFF
--- a/Provenance/Provenance-Info.plist
+++ b/Provenance/Provenance-Info.plist
@@ -82,5 +82,7 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
+	<key>UISupportsDocumentBrowser</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Allows navigation to file system structure via "Files" interface. Sorta convenient, as it allows copying saves and ROM's to and from iCloud Drive.