### PR TITLE
Mednafen: Fixes crash on disk operations like opening cd images for release build

### DIFF
--- a/Mednafen/PVMednafen.xcodeproj/project.pbxproj
+++ b/Mednafen/PVMednafen.xcodeproj/project.pbxproj
@@ -10212,33 +10212,6 @@
 				OTHER_CFLAGS = (
 					"$(inherited)",
 					"-mfpu=neon",
-					"-fwrapv",
-					"-fprefetch-loop-arrays",
-					"-fjump-tables",
-					"-fomit-frame-pointer",
-					"-ftree-vectorize",
-					"-DHAVE_MKDIR",
-					"-DMEDNAFEN_VERSION=\\\"1.21.1\\\"",
-					"-DPACKAGE=\\\"mednafen\\\"",
-					"-DMEDNAFEN_VERSION_NUMERIC=0x00102101",
-					"-DPSS_STYLE=1",
-					"-DMPC_FIXED_POINT",
-					"-DARCH_ARM",
-					"-DSTDC_HEADERS",
-					"-DICONV_CONST=",
-					"-DLSB_FIRST",
-					"-D__STDC_LIMIT_MACROS",
-					"-DSIZEOF_DOUBLE=8",
-					"-DSIZEOF_CHAR=1",
-					"-DSIZEOF_SHORT=2",
-					"-DSIZEOF_INT=4",
-					"-DSIZEOF_LONG=8",
-					"-DSIZEOF_LONG_LONG=8",
-					"-DSIZEOF_OFF_T=8",
-					"-DSIZEOF_VOID_P=8",
-					"-DSIZEOF_SIZE_T=8",
-					"-DSIZEOF_PTRDIFF_T=8",
-					"-disable-lsr",
 					"-Wall",
 					"-Wshadow",
 					"-Wempty-body",
@@ -10246,10 +10219,8 @@
 					"-Wvla",
 					"-Wvariadic-macros",
 					"-Wdisabled-optimization",
-					"-mllvm",
-					"-disable-lsr",
-					"-mcmodel=small",
 				);
+				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
@@ -11827,6 +11798,7 @@
 					"\"$(SRCROOT)/../PVSupport/Carthage/Build/iOS\"",
 				);
 				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 3;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					LSB_FIRST,
 					"$(inherited)",

--- a/Mednafen/PVMednafen.xcodeproj/project.pbxproj
+++ b/Mednafen/PVMednafen.xcodeproj/project.pbxproj
@@ -10215,7 +10215,6 @@
 					"-fwrapv",
 					"-fprefetch-loop-arrays",
 					"-fjump-tables",
-					"-fomit-frame-pointer",
 					"-ftree-vectorize",
 					"-DHAVE_MKDIR",
 					"-DMEDNAFEN_VERSION=\\\"1.21.1\\\"",

--- a/Mednafen/PVMednafen.xcodeproj/project.pbxproj
+++ b/Mednafen/PVMednafen.xcodeproj/project.pbxproj
@@ -10212,6 +10212,33 @@
 				OTHER_CFLAGS = (
 					"$(inherited)",
 					"-mfpu=neon",
+					"-fwrapv",
+					"-fprefetch-loop-arrays",
+					"-fjump-tables",
+					"-fomit-frame-pointer",
+					"-ftree-vectorize",
+					"-DHAVE_MKDIR",
+					"-DMEDNAFEN_VERSION=\\\"1.21.1\\\"",
+					"-DPACKAGE=\\\"mednafen\\\"",
+					"-DMEDNAFEN_VERSION_NUMERIC=0x00102101",
+					"-DPSS_STYLE=1",
+					"-DMPC_FIXED_POINT",
+					"-DARCH_ARM",
+					"-DSTDC_HEADERS",
+					"-DICONV_CONST=",
+					"-DLSB_FIRST",
+					"-D__STDC_LIMIT_MACROS",
+					"-DSIZEOF_DOUBLE=8",
+					"-DSIZEOF_CHAR=1",
+					"-DSIZEOF_SHORT=2",
+					"-DSIZEOF_INT=4",
+					"-DSIZEOF_LONG=8",
+					"-DSIZEOF_LONG_LONG=8",
+					"-DSIZEOF_OFF_T=8",
+					"-DSIZEOF_VOID_P=8",
+					"-DSIZEOF_SIZE_T=8",
+					"-DSIZEOF_PTRDIFF_T=8",
+					"-disable-lsr",
 					"-Wall",
 					"-Wshadow",
 					"-Wempty-body",
@@ -10219,8 +10246,10 @@
 					"-Wvla",
 					"-Wvariadic-macros",
 					"-Wdisabled-optimization",
+					"-mllvm",
+					"-disable-lsr",
+					"-mcmodel=small",
 				);
-				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
@@ -11798,7 +11827,6 @@
 					"\"$(SRCROOT)/../PVSupport/Carthage/Build/iOS\"",
 				);
 				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_OPTIMIZATION_LEVEL = 3;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					LSB_FIRST,
 					"$(inherited)",


### PR DESCRIPTION
I changed the PVMednafen project to use the same compiler flags for release builds as debug builds. In my testing it does not seem to affect performance.

I believe this was happening only on an iPhone XS Max. My iPhone 7 Plus on iOS 12 seems ok so not sure why this is device-specific

This fixes #1001 