### PR TITLE
Media Cache: create cache folder before creating the file

### DIFF
--- a/PVLibrary/PVLibrary/Game Media/PVMediaCache.swift
+++ b/PVLibrary/PVLibrary/Game Media/PVMediaCache.swift
@@ -108,6 +108,7 @@ public final class PVMediaCache: NSObject {
         let cachePath = self.cachePath.appendingPathComponent(keyHash, isDirectory: false)
 
         do {
+            try FileManager.default.createDirectory(at: self.cachePath, withIntermediateDirectories: true, attributes: nil)
             try data.write(to: cachePath, options: [.atomic])
             return cachePath
         } catch {


### PR DESCRIPTION
While importing a Cover Art for a game, this error occurs:

```
🕐4:293.7s 🔀 VERBOSE  PVMediaCache:114.writeData(toDisk:withKey:) ↩
	☞ Failed to write image to cache path /var/mobile/Containers/Data/Application/9889053C-F49E-44A2-A4E2-FD777F12B1F5/Library/Caches/PVCache/322ACE0A55B519F17F18EFD83BD853D7 : The folder “322ACE0A55B519F17F18EFD83BD853D7” doesn’t exist.
🕐4:293.7s 🔀 VERBOSE  PVGameImporter:1299.getArtwork(forGame:) ↩
	☞ The folder “322ACE0A55B519F17F18EFD83BD853D7” doesn’t exist.
```

So, the cache folder should be created before saving the data.