### PR TITLE
Correct Core version reported for Genesis Core.

### DIFF
--- a/Cores/Genesis-Plus-GX/PVGenesis/Core.plist
+++ b/Cores/Genesis-Plus-GX/PVGenesis/Core.plist
@@ -19,6 +19,6 @@
 	<key>PVProjectURL</key>
 	<string>https://github.com/ekeeke/Genesis-Plus-GX</string>
 	<key>PVProjectVersion</key>
-	<string>1.7.1</string>
+	<string>1.7.4</string>
 </dict>
 </plist>


### PR DESCRIPTION
When the Core was updated to 1.7.4 this marker was left at the previous 1.7.1. This minor PR fixes this.