### PR TITLE
Update Screenshot function to write PNG instead of JPEG

### DIFF
--- a/Provenance/Emulator/PVEmulatorViewController.swift
+++ b/Provenance/Emulator/PVEmulatorViewController.swift
@@ -874,14 +874,14 @@ final class PVEmulatorViewController: PVEmulatorViewControllerRootClass, PVAudio
 				UIImageWriteToSavedPhotosAlbum(screenshot, nil, nil, nil)
 			})
 
-			if let jpegData = screenshot.jpegData(compressionQuality: 0.5) {
+			if let pngData = screenshot.pngData() {
 
 				let dateString = PVEmulatorConfiguration.string(fromDate: Date())
 
-				let fileName = game.title  + " - " + dateString + ".jpeg"
+				let fileName = game.title  + " - " + dateString + ".png"
 				let imageURL = PVEmulatorConfiguration.screenshotsPath(forGame: game).appendingPathComponent(fileName, isDirectory: false)
 				do {
-					try jpegData.write(to: imageURL)
+					try pngData.write(to: imageURL)
 					try RomDatabase.sharedInstance.writeTransaction {
 						let newFile = PVImageFile(withURL: imageURL, relativeRoot: .iCloud)
 						game.screenShots.append(newFile)


### PR DESCRIPTION
Write out PNG's instead of JPEG's for the Screenshot function. Gets us all of the RGBA channels as a 8888 pixel type for much better quality images at a much smaller size. 
Ex. A Genesis Sonic 2 title screen Screenshot at 2048x1536 as PNG is 243KB whilst the original JPEG at 50% lossy compression is 344KB.