### PR TITLE
Prevent deadlocking when saving state for mupenplus64 core

### DIFF
--- a/PVSupport/PVSupport/PVEmulatorCore.m
+++ b/PVSupport/PVSupport/PVEmulatorCore.m
@@ -139,7 +139,7 @@ NSString *const PVEmulatorCoreErrorDomain = @"com.provenance-emu.EmulatorCore.Er
 
 -(void)stopHaptic {
     if (!NSThread.isMainThread) {
-        dispatch_sync(dispatch_get_main_queue(), ^{
+        dispatch_async(dispatch_get_main_queue(), ^{
             [self stopHaptic];
         });
         return;


### PR DESCRIPTION
Small change to prevent deadlocking when saving save state for the n64 mupenplus core.

I changed to use `dispatch_async` but is there any reason to keep `dispatch_sync`? I think its maybe because the mupencore creates its own thread group when doing the async save state process. I hope its not harmful to the other cores.