### PR TITLE
Adding 'bin' to PSX's PVSupportedExtensions

### DIFF
--- a/PVLibrary/PVLibrary/Resources/systems.plist
+++ b/PVLibrary/PVLibrary/Resources/systems.plist
@@ -201,6 +201,7 @@
 		<array>
 			<string>cue</string>
 			<string>ccd</string>
+			<string>bin</string>
 		</array>
 		<key>PVControlLayout</key>
 		<array>


### PR DESCRIPTION
Allows Provenance to import zips with bin files