### PR TITLE
fastlane: Fix missing options variable

### DIFF
--- a/fastlane/Fastfile+Carthage
+++ b/fastlane/Fastfile+Carthage
@@ -1,5 +1,5 @@
 desc 'Lane to run bootstrap carthage in new checkout for iOS only'
-lane :carthage_bootstrap_ios do |_options|
+lane :carthage_bootstrap_ios do |options|
   use_binaries = options.fetch(:use_binaries, true)
   use_ssh = options.fetch(:use_ssh, false)
   use_rome = options.fetch(:use_rome, true)
@@ -12,7 +12,7 @@ lane :carthage_bootstrap_ios do |_options|
 end
 
 desc 'Lane to run bootstrap carthage in new checkout for tvOS only'
-lane :carthage_bootstrap_tvos do |_options|
+lane :carthage_bootstrap_tvos do |options|
   use_binaries = options.fetch(:use_binaries, true)
   use_ssh = options.fetch(:use_ssh, false)
   use_rome = options.fetch(:use_rome, true)
@@ -105,7 +105,7 @@ lane :carthage_update do |options|
 end
 
 desc 'Lane to update all carthage dependencies to latest versions for iOS only'
-lane :carthage_update_ios do |_options|
+lane :carthage_update_ios do |options|
   use_binaries = options.fetch(:use_binaries, true)
   use_ssh = options.fetch(:use_ssh, false)
   use_rome = options.fetch(:use_rome, true)
@@ -117,7 +117,7 @@ lane :carthage_update_ios do |_options|
 end
 
 desc 'Lane to update all carthage dependencies to latest versions for tvOS only'
-lane :carthage_update_tvos do |_options|
+lane :carthage_update_tvos do |options|
   use_binaries = options.fetch(:use_binaries, true)
   use_ssh = options.fetch(:use_ssh, false)
   use_rome = options.fetch(:use_rome, true)


### PR DESCRIPTION
Small fix to Carthage Fastfile.

Fixes:

```
[02:26:48]: fastlane finished with errors

[!] Could not find action, lane or variable 'options'. Check out the documentation for more details: https://docs.fastlane.tools/actions
make: *** [update_carthage_dependencies_ios] Error 1
```

Can confirm `develop` branch works on Apple TV 4K and the Snes9x & co works again with the reverted double buffer changes, nice work! 🎉