### PR TITLE
Add in dropshadow for fps indicator

### DIFF
--- a/Provenance/Emulator/PVEmulatorViewController.swift
+++ b/Provenance/Emulator/PVEmulatorViewController.swift
@@ -237,7 +237,7 @@ final class PVEmulatorViewController: PVEmulatorViewControllerRootClass, PVAudio
         fpsLabel.layer.masksToBounds = false
         fpsLabel.layer.shadowRadius = 1.0
         fpsLabel.layer.shadowOpacity = 1.0
-        fpsLabel.layer.shadowOffset = CGSize (width: 1, height:2)
+        fpsLabel.layer.shadowOffset = CGSize (width: 1, height: 2)
         #if os(tvOS)
             fpsLabel.font = UIFont.systemFont(ofSize: 40, weight: .bold)
         #else

--- a/Provenance/Emulator/PVEmulatorViewController.swift
+++ b/Provenance/Emulator/PVEmulatorViewController.swift
@@ -234,6 +234,10 @@ final class PVEmulatorViewController: PVEmulatorViewControllerRootClass, PVAudio
         fpsLabel.text = "\(glViewController.framesPerSecond)"
         fpsLabel.translatesAutoresizingMaskIntoConstraints = false
         fpsLabel.textAlignment = .right
+        fpsLabel.layer.masksToBounds = false
+        fpsLabel.layer.shadowRadius = 1.0
+        fpsLabel.layer.shadowOpacity = 1.0
+        fpsLabel.layer.shadowOffset = CGSize (width: 1, height:2)
         #if os(tvOS)
             fpsLabel.font = UIFont.systemFont(ofSize: 40, weight: .bold)
         #else


### PR DESCRIPTION
Add in a simple drop shadow on the fps label for increased readability over bright or yellow backgrounds.