### PR TITLE
tweak precision for blit shader

### DIFF
--- a/Provenance/Utilities/shaders/blit/blit_fragment.glsl
+++ b/Provenance/Utilities/shaders/blit/blit_fragment.glsl
@@ -1,5 +1,5 @@
 #ifdef GL_ES
-precision mediump float;
+precision lowp float;
 #endif
 
 #if __VERSION__ < 300
@@ -8,7 +8,7 @@ precision mediump float;
 
 uniform sampler2D EmulatedImage;
 
-varying highp vec2 fTexCoord;
+varying lowp vec2 fTexCoord;
 
 void main( void )
 {


### PR DESCRIPTION
Minor precision tweaks to blit shader for squeezing out extra bit of GPU performance on the lower end of the supported iOS hardware stack such as the iPad Air 1 by setting to lowp instead of mediump/highp.