### PR TITLE
Update controller mappings, Poke, NES , GB ,  

### DIFF
--- a/PVGB/GB/PVGBEmulatorCore.mm
+++ b/PVGB/GB/PVGBEmulatorCore.mm
@@ -259,11 +259,27 @@ const int GBMap[] = {gambatte::InputGetter::UP, gambatte::InputGetter::DOWN, gam
         (dpad.left.isPressed || pad.leftThumbstick.left.isPressed) ? gb_pad[0] |= GBMap[PVGBButtonLeft] : gb_pad[0] &= ~GBMap[PVGBButtonLeft];
         (dpad.right.isPressed || pad.leftThumbstick.right.isPressed) ? gb_pad[0] |= GBMap[PVGBButtonRight] : gb_pad[0] &= ~GBMap[PVGBButtonRight];
 
+/*
+        Begin remapping Gameboy buttons on extended controllers.
+        Per Apple's documentation (Table 1-2):
+ https://developer.apple.com/library/archive/documentation/ServicesDiscovery/Conceptual/GameControllerPG/IncorporatingControllersintoYourDesign/IncorporatingControllersintoYourDesign.html
+ 
+        First, the disused code:
+ 
         pad.buttonA.isPressed ? gb_pad[0] |= GBMap[PVGBButtonB] : gb_pad[0] &= ~GBMap[PVGBButtonB];
         pad.buttonB.isPressed ? gb_pad[0] |= GBMap[PVGBButtonA] : gb_pad[0] &= ~GBMap[PVGBButtonA];
 
         (pad.buttonX.isPressed || pad.leftShoulder.isPressed || pad.leftTrigger.isPressed) ? gb_pad[0] |= GBMap[PVGBButtonStart] : gb_pad[0] &= ~GBMap[PVGBButtonStart];
-        (pad.buttonY.isPressed || pad.rightShoulder.isPressed || pad.rightTrigger.isPressed) ? gb_pad[0] |= GBMap[PVGBButtonSelect] : gb_pad[0] &= ~GBMap[PVGBButtonSelect];
+         (pad.buttonY.isPressed || pad.rightShoulder.isPressed || pad.rightTrigger.isPressed) ? gb_pad[0] |= GBMap[PVGBButtonSelect] : gb_pad[0] &= ~GBMap[PVGBButtonSelect];
+
+        
+        "Corrected", more in-line with user expectations:
+*/
+        pad.buttonX.isPressed ? gb_pad[0] |= GBMap[PVGBButtonB] : gb_pad[0] &= ~GBMap[PVGBButtonB];
+        pad.buttonA.isPressed ? gb_pad[0] |= GBMap[PVGBButtonA] : gb_pad[0] &= ~GBMap[PVGBButtonA];
+        
+        pad.buttonB.isPressed ? gb_pad[0] |= GBMap[PVGBButtonStart] : gb_pad[0] &= ~GBMap[PVGBButtonStart];
+        pad.buttonY.isPressed ? gb_pad[0] |= GBMap[PVGBButtonSelect] : gb_pad[0] &= ~GBMap[PVGBButtonSelect];
     }
     else if ([self.controller1 gamepad])
     {
@@ -275,13 +291,30 @@ const int GBMap[] = {gambatte::InputGetter::UP, gambatte::InputGetter::DOWN, gam
         dpad.left.isPressed ? gb_pad[0] |= GBMap[PVGBButtonLeft] : gb_pad[0] &= ~GBMap[PVGBButtonLeft];
         dpad.right.isPressed ? gb_pad[0] |= GBMap[PVGBButtonRight] : gb_pad[0] &= ~GBMap[PVGBButtonRight];
 
+/*
+        Repeating the same for controllers without thumbsticks or triggers.
+                
         pad.buttonA.isPressed ? gb_pad[0] |= GBMap[PVGBButtonB] : gb_pad[0] &= ~GBMap[PVGBButtonB];
         pad.buttonB.isPressed ? gb_pad[0] |= GBMap[PVGBButtonA] : gb_pad[0] &= ~GBMap[PVGBButtonA];
 
         (pad.buttonX.isPressed || pad.leftShoulder.isPressed) ? gb_pad[0] |= GBMap[PVGBButtonStart] : gb_pad[0] &= ~GBMap[PVGBButtonStart];
         (pad.buttonY.isPressed || pad.rightShoulder.isPressed) ? gb_pad[0] |= GBMap[PVGBButtonSelect] : gb_pad[0] &= ~GBMap[PVGBButtonSelect];
-    }
+ */
+        pad.buttonX.isPressed ? gb_pad[0] |= GBMap[PVGBButtonB] : gb_pad[0] &= ~GBMap[PVGBButtonB];
+        pad.buttonA.isPressed ? gb_pad[0] |= GBMap[PVGBButtonA] : gb_pad[0] &= ~GBMap[PVGBButtonA];
+
+//      Removed the shoulder buttons to avoid accidental button presses.
+        pad.buttonB.isPressed ? gb_pad[0] |= GBMap[PVGBButtonStart] : gb_pad[0] &= ~GBMap[PVGBButtonStart];
+        pad.buttonY.isPressed ? gb_pad[0] |= GBMap[PVGBButtonSelect] : gb_pad[0] &= ~GBMap[PVGBButtonSelect];
+ }
 #if TARGET_OS_TV
+/*
+        Going to have to trust that this is correct for the Siri
+        Remote, as the documentation refers to it by button number,
+        not letters.  See (Figure 1-3):
+
+ https://developer.apple.com/library/archive/documentation/ServicesDiscovery/Conceptual/GameControllerPG/IncorporatingControllersintoYourDesign/IncorporatingControllersintoYourDesign.html#//apple_ref/doc/uid/TP40013276-CH4-SW4
+*/
     else if ([self.controller1 microGamepad])
     {
         GCMicroGamepad *pad = [self.controller1 microGamepad];

--- a/PVGBA/GBA/PVGBAEmulatorCore.mm
+++ b/PVGBA/GBA/PVGBAEmulatorCore.mm
@@ -301,6 +301,13 @@ bool systemReadJoypads()
                 (gamepad.dpad.left.isPressed || gamepad.leftThumbstick.left.isPressed) ? pad[playerIndex] |= KEY_LEFT : pad[playerIndex] &= ~KEY_LEFT;
                 (gamepad.dpad.right.isPressed || gamepad.leftThumbstick.right.isPressed) ? pad[playerIndex] |= KEY_RIGHT : pad[playerIndex] &= ~KEY_RIGHT;
 
+/*
+                Begin remapping Gameboy buttons on extended controllers.
+                Per Apple's documentation (Table 1-2):
+https://developer.apple.com/library/archive/documentation/ServicesDiscovery/Conceptual/GameControllerPG/IncorporatingControllersintoYourDesign/IncorporatingControllersintoYourDesign.html
+                
+                First, the disused code:
+
                 gamepad.buttonA.isPressed ? pad[playerIndex] |= KEY_BUTTON_B : pad[playerIndex] &= ~KEY_BUTTON_B;
                 gamepad.buttonB.isPressed ? pad[playerIndex] |= KEY_BUTTON_A : pad[playerIndex] &= ~KEY_BUTTON_A;
 
@@ -309,6 +316,17 @@ bool systemReadJoypads()
 
                 (gamepad.buttonX.isPressed || gamepad.leftTrigger.isPressed) ? pad[playerIndex] |= KEY_BUTTON_START : pad[playerIndex] &= ~KEY_BUTTON_START;
                 (gamepad.buttonY.isPressed || gamepad.rightTrigger.isPressed) ? pad[playerIndex] |= KEY_BUTTON_SELECT : pad[playerIndex] &= ~KEY_BUTTON_SELECT;
+*/
+
+                gamepad.buttonX.isPressed ? pad[playerIndex] |= KEY_BUTTON_B : pad[playerIndex] &= ~KEY_BUTTON_B;
+                gamepad.buttonA.isPressed ? pad[playerIndex] |= KEY_BUTTON_A : pad[playerIndex] &= ~KEY_BUTTON_A;
+
+                (gamepad.leftShoulder.isPressed || gamepad.leftTrigger.isPressed) ? pad[playerIndex] |= KEY_BUTTON_L : pad[playerIndex] &= ~KEY_BUTTON_L;
+                (gamepad.rightShoulder.isPressed || gamepad.rightTrigger.isPressed) ? pad[playerIndex] |= KEY_BUTTON_R : pad[playerIndex] &= ~KEY_BUTTON_R;
+
+                gamepad.buttonB.isPressed ? pad[playerIndex] |= KEY_BUTTON_START : pad[playerIndex] &= ~KEY_BUTTON_START;
+                gamepad.buttonY.isPressed ? pad[playerIndex] |= KEY_BUTTON_SELECT : pad[playerIndex] &= ~KEY_BUTTON_SELECT;
+
             }
             else if ([controller gamepad])
             {
@@ -320,6 +338,10 @@ bool systemReadJoypads()
                 gamepad.dpad.left.isPressed ? pad[playerIndex] |= KEY_LEFT : pad[playerIndex] &= ~KEY_LEFT;
                 gamepad.dpad.right.isPressed ? pad[playerIndex] |= KEY_RIGHT : pad[playerIndex] &= ~KEY_RIGHT;
 
+/*
+                Repeating the same for gamepads without thumbsticks
+                or triggers
+                
                 gamepad.buttonA.isPressed ? pad[playerIndex] |= KEY_BUTTON_B : pad[playerIndex] &= ~KEY_BUTTON_B;
                 gamepad.buttonB.isPressed ? pad[playerIndex] |= KEY_BUTTON_A : pad[playerIndex] &= ~KEY_BUTTON_A;
 
@@ -328,8 +350,25 @@ bool systemReadJoypads()
 
                 gamepad.buttonX.isPressed ? pad[playerIndex] |= KEY_BUTTON_START : pad[playerIndex] &= ~KEY_BUTTON_START;
                 gamepad.buttonY.isPressed ? pad[playerIndex] |= KEY_BUTTON_SELECT : pad[playerIndex] &= ~KEY_BUTTON_SELECT;
+*/
+
+                gamepad.buttonX.isPressed ? pad[playerIndex] |= KEY_BUTTON_B : pad[playerIndex] &= ~KEY_BUTTON_B;
+                gamepad.buttonA.isPressed ? pad[playerIndex] |= KEY_BUTTON_A : pad[playerIndex] &= ~KEY_BUTTON_A;
+
+                gamepad.leftShoulder.isPressed ? pad[playerIndex] |= KEY_BUTTON_L : pad[playerIndex] &= ~KEY_BUTTON_L;
+                gamepad.rightShoulder.isPressed ? pad[playerIndex] |= KEY_BUTTON_R : pad[playerIndex] &= ~KEY_BUTTON_R;
+
+                gamepad.buttonB.isPressed ? pad[playerIndex] |= KEY_BUTTON_START : pad[playerIndex] &= ~KEY_BUTTON_START;
+                gamepad.buttonY.isPressed ? pad[playerIndex] |= KEY_BUTTON_SELECT : pad[playerIndex] &= ~KEY_BUTTON_SELECT;
+                
             }
 #if TARGET_OS_TV
+/*
+            Going to have to trust that this is correct for the Siri
+            Remote, as the documentation refers to it by button number,
+            not letters.  See (Figure 1-3):
+https://developer.apple.com/library/archive/documentation/ServicesDiscovery/Conceptual/GameControllerPG/IncorporatingControllersintoYourDesign/IncorporatingControllersintoYourDesign.html#//apple_ref/doc/uid/TP40013276-CH4-SW4
+*/
             else if ([controller microGamepad])
             {
                 GCMicroGamepad *gamepad = [controller microGamepad];

--- a/PVNES/NES/PVNESEmulatorCore.mm
+++ b/PVNES/NES/PVNESEmulatorCore.mm
@@ -300,6 +300,12 @@ const int NESMap[] = {JOY_UP, JOY_DOWN, JOY_LEFT, JOY_RIGHT, JOY_A, JOY_B, JOY_S
         }
 
         if ([controller extendedGamepad])
+/*
+        Re-mapped buttons to align with Apple's documentation on the topic.
+        Please see Table 1-2 for more information:
+
+https://developer.apple.com/library/archive/documentation/ServicesDiscovery/Conceptual/GameControllerPG/IncorporatingControllersintoYourDesign/IncorporatingControllersintoYourDesign.html#//apple_ref/doc/uid/TP40013276-CH4-SW4
+ */
         {
             GCExtendedGamepad *gamepad = [controller extendedGamepad];
             GCControllerDirectionPad *dpad = [gamepad dpad];
@@ -309,11 +315,12 @@ const int NESMap[] = {JOY_UP, JOY_DOWN, JOY_LEFT, JOY_RIGHT, JOY_A, JOY_B, JOY_S
             (dpad.left.isPressed || gamepad.leftThumbstick.left.isPressed) ? pad[playerIndex][0] |= JOY_LEFT << playerShift : pad[playerIndex][0] &= ~JOY_LEFT << playerShift;
             (dpad.right.isPressed || gamepad.leftThumbstick.right.isPressed) ? pad[playerIndex][0] |= JOY_RIGHT << playerShift : pad[playerIndex][0] &= ~JOY_RIGHT << playerShift;
 
-            (gamepad.buttonX.isPressed || gamepad.buttonY.isPressed) ? pad[playerIndex][0] |= JOY_B << playerShift : pad[playerIndex][0] &= ~JOY_B << playerShift;
-            (gamepad.buttonA.isPressed || gamepad.buttonB.isPressed) ? pad[playerIndex][0] |= JOY_A << playerShift : pad[playerIndex][0] &= ~JOY_A << playerShift;
+            gamepad.buttonX.isPressed ? pad[playerIndex][0] |= JOY_B << playerShift : pad[playerIndex][0] &= ~JOY_B << playerShift;
+            gamepad.buttonA.isPressed ? pad[playerIndex][0] |= JOY_A << playerShift : pad[playerIndex][0] &= ~JOY_A << playerShift;
 
-            (gamepad.leftShoulder.isPressed || gamepad.leftTrigger.isPressed) ? pad[playerIndex][0] |= JOY_START << playerShift : pad[playerIndex][0] &= ~JOY_START << playerShift;
-            (gamepad.rightShoulder.isPressed || gamepad.rightTrigger.isPressed) ? pad[playerIndex][0] |= JOY_SELECT << playerShift : pad[playerIndex][0] &= ~JOY_SELECT << playerShift;
+  //        Removed Shoulder and Triggers to avoid accidental button presses.
+            gamepad.buttonY.isPressed ? pad[playerIndex][0] |= JOY_SELECT << playerShift : pad[playerIndex][0] &= ~JOY_SELECT << playerShift;
+            gamepad.buttonB.isPressed ? pad[playerIndex][0] |= JOY_START << playerShift : pad[playerIndex][0] &= ~JOY_START << playerShift;
         }
         else if ([controller gamepad])
         {
@@ -325,13 +332,21 @@ const int NESMap[] = {JOY_UP, JOY_DOWN, JOY_LEFT, JOY_RIGHT, JOY_A, JOY_B, JOY_S
             dpad.left.isPressed ? pad[playerIndex][0] |= JOY_LEFT << playerShift : pad[playerIndex][0] &= ~JOY_LEFT << playerShift;
             dpad.right.isPressed ? pad[playerIndex][0] |= JOY_RIGHT << playerShift : pad[playerIndex][0] &= ~JOY_RIGHT << playerShift;
 
-            (gamepad.buttonX.isPressed || gamepad.buttonY.isPressed) ? pad[playerIndex][0] |= JOY_B << playerShift : pad[playerIndex][0] &= ~JOY_B << playerShift;
-            (gamepad.buttonA.isPressed || gamepad.buttonB.isPressed) ? pad[playerIndex][0] |= JOY_A << playerShift : pad[playerIndex][0] &= ~JOY_A << playerShift;
+            gamepad.buttonX.isPressed ? pad[playerIndex][0] |= JOY_B << playerShift : pad[playerIndex][0] &= ~JOY_B << playerShift;
+            gamepad.buttonA.isPressed ? pad[playerIndex][0] |= JOY_A << playerShift : pad[playerIndex][0] &= ~JOY_A << playerShift;
 
-            gamepad.leftShoulder.isPressed ? pad[playerIndex][0] |= JOY_START << playerShift : pad[playerIndex][0] &= ~JOY_START << playerShift;
-            gamepad.rightShoulder.isPressed ? pad[playerIndex][0] |= JOY_SELECT << playerShift : pad[playerIndex][0] &= ~JOY_SELECT << playerShift;
+//          Removed shoulder buttons to avoid accidental button presses.
+            gamepad.buttonY.isPressed ? pad[playerIndex][0] |= JOY_SELECT << playerShift : pad[playerIndex][0] &= ~JOY_SELECT << playerShift;
+            gamepad.buttonB.isPressed ? pad[playerIndex][0] |= JOY_START << playerShift : pad[playerIndex][0] &= ~JOY_START << playerShift;
         }
 #if TARGET_OS_TV
+/*
+        Going to have to trust that this is correct for the Siri
+        Remote, as the documentation refers to it by button number,
+        not letters.  See (Figure 1-3):
+
+https://developer.apple.com/library/archive/documentation/ServicesDiscovery/Conceptual/GameControllerPG/IncorporatingControllersintoYourDesign/IncorporatingControllersintoYourDesign.html#//apple_ref/doc/uid/TP40013276-CH4-SW4
+*/
         else if ([controller microGamepad])
         {
             GCMicroGamepad *gamepad = [controller microGamepad];

--- a/PVPokeMini/PokeMini/PVPokeMiniEmulatorCore.m
+++ b/PVPokeMini/PokeMini/PVPokeMiniEmulatorCore.m
@@ -368,7 +368,10 @@ int saveEEPROM(const char *filename)
             self.controller1.extendedGamepad.valueChangedHandler = ^(GCExtendedGamepad * _Nonnull gamepad, GCControllerElement * _Nonnull element) {
                 __strong PVPokeMiniEmulatorCore* strongSelf = weakSelf;
                 
-                // Buttons
+                // Buttons, see pages 10 and 11:
+// https://www.pokemon-mini.net/download/manuals/Pokemon-Mini-Manual.pdf
+                
+                // A on the MFI extended Gamepad is also A in-game
                 if (element == gamepad.buttonA) {
                     if (strongSelf->controllerState.a != gamepad.buttonA.isPressed) {
                         JoystickButtonsEvent(PVPMButtonA, gamepad.buttonA.isPressed ? 1 : 0);
@@ -376,39 +379,62 @@ int saveEEPROM(const char *filename)
                         DLog(@"A %@", strongSelf->controllerState.a ? @"Pressed" : @"Unpressed");
                     }
                 }
-                else if (element == gamepad.buttonB) {
-                    if (strongSelf->controllerState.b != gamepad.buttonB.isPressed) {
-                        JoystickButtonsEvent(PVPMButtonB, gamepad.buttonB.isPressed ? 1 : 0);
-                        strongSelf->controllerState.b = gamepad.buttonB.isPressed;
+/*
+                X is B, per Apple's Documentation
+                Please see Table 1-2:
+https://developer.apple.com/library/archive/documentation/ServicesDiscovery/Conceptual/GameControllerPG/IncorporatingControllersintoYourDesign/IncorporatingControllersintoYourDesign.html#//apple_ref/doc/uid/TP40013276-CH4-SW4
+  */
+                else if (element == gamepad.buttonX) {
+                    if (strongSelf->controllerState.b != gamepad.buttonX.isPressed) {
+                        JoystickButtonsEvent(PVPMButtonB, gamepad.buttonX.isPressed ? 1 : 0);
+                        strongSelf->controllerState.b = gamepad.buttonX.isPressed;
                         DLog(@"B %@", strongSelf->controllerState.b ? @"Pressed" : @"Unpressed");
                     }
                 }
-                else if (element == gamepad.buttonX) {
-                    if (strongSelf->controllerState.c != gamepad.buttonX.isPressed) {
-                        JoystickButtonsEvent(PVPMButtonC, gamepad.buttonX.isPressed ? 1 : 0);
-                        strongSelf->controllerState.c = gamepad.buttonX.isPressed;
+                // Setting both Right Shoulder and Trigger to map to C.
+                else if (element == gamepad.rightTrigger  {
+                    if (strongSelf->controllerState.c != gamepad.rightTrigger.isPressed) {
+                        JoystickButtonsEvent(PVPMButtonC, gamepad.rightTrigger.isPressed ? 1 : 0);
+                        strongSelf->controllerState.c = gamepad.rightTrigger.isPressed;
                         DLog(@"C %@", strongSelf->controllerState.c ? @"Pressed" : @"Unpressed");
                     }
                 }
-                // Extra buttons
-                else if (element == gamepad.leftTrigger) {
-                    if (strongSelf->controllerState.menu != gamepad.leftTrigger.isPressed) {
-                        JoystickButtonsEvent(PVPMButtonMenu, gamepad.leftTrigger.isPressed ? 1 : 0);
-                        strongSelf->controllerState.menu = gamepad.leftTrigger.isPressed;
+                else if (element == gamepad.rightShoulder  {
+                    if (strongSelf->controllerState.c != gamepad.rightShoulder.isPressed) {
+                        JoystickButtonsEvent(PVPMButtonC, gamepad.rightShoulder.isPressed ? 1 : 0);
+                        strongSelf->controllerState.c = gamepad.rightShoulder.isPressed;
+                        DLog(@"C %@", strongSelf->controllerState.c ? @"Pressed" : @"Unpressed");
+                    }
+                }
+                // B brings up the menu
+                else if (element == gamepad.buttonB) {
+                    if (strongSelf->controllerState.menu != gamepad.buttonB.isPressed) {
+                        JoystickButtonsEvent(PVPMButtonMenu, gamepad.buttonB.isPressed ? 1 : 0);
+                        strongSelf->controllerState.menu = gamepad.buttonB.isPressed;
                         DLog(@"Menu %@", strongSelf->controllerState.menu ? @"Pressed" : @"Unpressed");
                     }
                 }
-                else if (element == gamepad.rightTrigger) {
-                    if (strongSelf->controllerState.shake != gamepad.rightTrigger.isPressed) {
-                        JoystickButtonsEvent(PVPMButtonShake, gamepad.rightTrigger.isPressed ? 1 : 0);
-                        strongSelf->controllerState.shake = gamepad.rightTrigger.isPressed;
+                // Setting both Left Shoulder and Trigger to "Shake"
+                else if (element == gamepad.leftTrigger) {
+                    if (strongSelf->controllerState.shake != gamepad.leftTrigger.isPressed) {
+                        JoystickButtonsEvent(PVPMButtonShake, gamepad.leftTrigger.isPressed ? 1 : 0);
+                        strongSelf->controllerState.shake = gamepad.leftTrigger.isPressed;
                         DLog(@"Shake %@", strongSelf->controllerState.shake ? @"Pressed" : @"Unpressed");
                     }
                 }
-                else if (element == gamepad.leftShoulder) {
-                    if (strongSelf->controllerState.power != gamepad.leftShoulder.isPressed) {
-                        JoystickButtonsEvent(PVPMButtonPower, gamepad.leftShoulder.isPressed ? 1 : 0);
-                        strongSelf->controllerState.power = gamepad.leftShoulder.isPressed;
+               else if (element == gamepad.leftShoulder) {
+                    if (strongSelf->controllerState.shake != gamepad.leftShoulder.isPressed) {
+                        JoystickButtonsEvent(PVPMButtonShake, gamepad.leftShoulder.isPressed ? 1 : 0);
+                        strongSelf->controllerState.shake = gamepad.leftShoulder.isPressed;
+                        DLog(@"Shake %@", strongSelf->controllerState.shake ? @"Pressed" : @"Unpressed");
+                    }
+                }
+ 
+                // Y is Power
+                else if (element == gamepad.buttonY) {
+                    if (strongSelf->controllerState.power != gamepad.buttonY.isPressed) {
+                        JoystickButtonsEvent(PVPMButtonPower, gamepad.buttonY.isPressed ? 1 : 0);
+                        strongSelf->controllerState.power = gamepad.buttonY.isPressed;
                         DLog(@"Power %@", strongSelf->controllerState.power ? @"Pressed" : @"Unpressed");
                     }
                 }
@@ -427,47 +453,55 @@ int saveEEPROM(const char *filename)
             self.controller1.gamepad.valueChangedHandler = ^(GCGamepad * _Nonnull gamepad, GCControllerElement * _Nonnull element) {
                 __strong PVPokeMiniEmulatorCore* strongSelf = weakSelf;
 
-                    // Buttons
+                // Buttons matching the above, we just don't have
+                // Thumbsticks or triggers.
                 if (element == gamepad.buttonA) {
                     if (strongSelf->controllerState.a != gamepad.buttonA.isPressed) {
                         JoystickButtonsEvent(PVPMButtonA, gamepad.buttonA.isPressed ? 1 : 0);
                         strongSelf->controllerState.a = gamepad.buttonA.isPressed;
                     }
                 }
-                else if (element == gamepad.buttonB) {
-                    if (strongSelf->controllerState.b != gamepad.buttonB.isPressed) {
-                        JoystickButtonsEvent(PVPMButtonB, gamepad.buttonB.isPressed ? 1 : 0);
-                        strongSelf->controllerState.b = gamepad.buttonB.isPressed;
-                    }
-                }
                 else if (element == gamepad.buttonX) {
-                    if (strongSelf->controllerState.c != gamepad.buttonX.isPressed) {
-                        JoystickButtonsEvent(PVPMButtonC, gamepad.buttonX.isPressed ? 1 : 0);
-                        strongSelf->controllerState.c = gamepad.buttonX.isPressed;
-                    }
-                }
-                // Extra buttons
-                else if (element == gamepad.buttonX) {
-                    if (strongSelf->controllerState.menu != gamepad.buttonX.isPressed) {
-                        JoystickButtonsEvent(PVPMButtonMenu, gamepad.buttonX.isPressed ? 1 : 0);
-                        strongSelf->controllerState.menu = gamepad.buttonX.isPressed;
+                    if (strongSelf->controllerState.b != gamepad.buttonX.isPressed) {
+                        JoystickButtonsEvent(PVPMButtonB, gamepad.buttonX.isPressed ? 1 : 0);
+                        strongSelf->controllerState.b = gamepad.buttonX.isPressed;
                     }
                 }
                 else if (element == gamepad.rightShoulder) {
-                    if (strongSelf->controllerState.shake != gamepad.rightShoulder.isPressed) {
-                        JoystickButtonsEvent(PVPMButtonShake, gamepad.rightShoulder.isPressed ? 1 : 0);
-                        strongSelf->controllerState.shake = gamepad.rightShoulder.isPressed;
+                    if (strongSelf->controllerState.c != gamepad.rightShoulder.isPressed) {
+                        JoystickButtonsEvent(PVPMButtonC, gamepad.rightShoulder.isPressed ? 1 : 0);
+                        strongSelf->controllerState.c = gamepad.rightShoulder.isPressed;
+                    }
+                }
+                // Extra buttons
+                else if (element == gamepad.buttonB) {
+                    if (strongSelf->controllerState.menu != gamepad.buttonB.isPressed) {
+                        JoystickButtonsEvent(PVPMButtonMenu, gamepad.buttonB.isPressed ? 1 : 0);
+                        strongSelf->controllerState.menu = gamepad.buttonB.isPressed;
                     }
                 }
                 else if (element == gamepad.leftShoulder) {
-                    if (strongSelf->controllerState.power != gamepad.leftShoulder.isPressed) {
-                        JoystickButtonsEvent(PVPMButtonPower, gamepad.leftShoulder.isPressed ? 1 : 0);
-                        strongSelf->controllerState.power = gamepad.leftShoulder.isPressed;
+                    if (strongSelf->controllerState.shake != gamepad.leftShoulder.isPressed) {
+                        JoystickButtonsEvent(PVPMButtonShake, gamepad.leftShoulder.isPressed ? 1 : 0);
+                        strongSelf->controllerState.shake = gamepad.leftShoulder.isPressed;
+                    }
+                }
+                else if (element == gamepad.buttonY) {
+                    if (strongSelf->controllerState.power != gamepad.buttonY.isPressed) {
+                        JoystickButtonsEvent(PVPMButtonPower, gamepad.buttonY.isPressed ? 1 : 0);
+                        strongSelf->controllerState.power = gamepad.buttonY.isPressed;
                     }
                 }
             };
         }
 #if TARGET_OS_TV
+/*
+        Going to have to trust that this is correct for the Siri
+        Remote, as the documentation refers to it by button number,
+        not letters.  See (Figure 1-3):
+
+https://developer.apple.com/library/archive/documentation/ServicesDiscovery/Conceptual/GameControllerPG/IncorporatingControllersintoYourDesign/IncorporatingControllersintoYourDesign.html#//apple_ref/doc/uid/TP40013276-CH4-SW4
+*/
         else if ([self.controller1 microGamepad]) {
             GCMicroGamepad *microGamepad = [self.controller1 microGamepad];
             

--- a/Provenance.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Provenance.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
### What does this PR do
Attempts to align PV controllers use with that of both Apple's documentation, and the original
controller layout.

### Where should the reviewer start
I only altered the Gameboy, GBA, NES, and PokeMini .mm source files.  It's pretty straightforward.

### How should this be manually tested
I'm pretty sure that unless there are upstream core changes that I missed, you should be able to plug these in and build without any trouble, but then I'm an XCode/github neophyte.  Just trying to help.

### Any background context you want to provide
https://github.com/Provenance-Emu/Provenance/issues/56

Not a fix by any stretch, but a pretty significant band-aid.  The main reason people want to re-map the buttons is because they don't align to expectations.  These changes should correct for that.

### What are the relevant tickets
https://github.com/Provenance-Emu/Provenance/issues/56

### Screenshots (if appropriate)

### Questions
Just that if there's anything I'm doing wrong with this whole process, let me know.  I'm not great with compiled software, but I'll be happy to do what I can.