### PR TITLE
Fix EmulatorVC modal presentation style on iOS 13

### DIFF
--- a/Provenance/Game Library/UI/GameLaunchingViewController.swift
+++ b/Provenance/Game Library/UI/GameLaunchingViewController.swift
@@ -572,6 +572,7 @@ extension GameLaunchingViewController where Self: UIViewController {
     private func presentEMUVC(_ emulatorViewController: PVEmulatorViewController, withGame game: PVGame, loadingSaveState saveState: PVSaveState? = nil) {
         // Present the emulator VC
         emulatorViewController.modalTransitionStyle = .crossDissolve
+        emulatorViewController.modalPresentationStyle = .fullScreen
         emulatorViewController.glViewController.view.isHidden = saveState != nil
 
         present(emulatorViewController, animated: true) { () -> Void in


### PR DESCRIPTION
Opt-out of the new card style modals on iOS 13 because the swipe-to-dismiss behavior interferes with the controls, and I'm pretty sure swipe-to-dismiss also prevents proper cleanup / save states.

I'm guessing there are other places in the app that might need a similar treatment, but so far this is the only one I've noticed where it's definitely needed.

Fixes #1236 