### PR TITLE
[Spike] Update PVGLViewController.m to improve V-Sync on ProMotion Devices.

### DIFF
--- a/Provenance/Emulator/PVGLViewController.m
+++ b/Provenance/Emulator/PVGLViewController.m
@@ -231,12 +231,7 @@ struct RenderSettings {
 }
 
 - (void) updatePreferredFPS {
-    float preferredFPS = self.emulatorCore.frameInterval;
-    if (preferredFPS  < 10) {
-        WLOG(@"Cores frame interval (%f) too low. Setting to 60", preferredFPS);
-        preferredFPS = 30;
-    }
-
+      float preferredFPS = [UIScreen mainScreen].maximumFramesPerSecond;
     [self setPreferredFramesPerSecond:preferredFPS];
 }
 


### PR DESCRIPTION
### What does this PR do
This will set the device's native FPS and allow for the Emu cores to self-manage their FPS' based on their self.emulatorCore.frameInterval for a smoother sync experience. [UIScreen mainScreen].maximumFramesPerSecond will list the max device FPS for 30fps on iPhone 4, 60fps for the 5> and 120fps ProMotion devices accordingly. Should also help and work on tvOS, to regulate between 50, 59.94 and 60.0, but this is currently still untested.

(Btw noticed that the self.emulatorCore.frameInterval settings for the cores should also be revisited to report a more accurate 4-6 decimal fps, at some point.) 

### Where should the reviewer start
Check out the visual frame limiting on ProMotion devices with the Genesis Core using the scroll test on the 240p suite. The Mednafen core is not able to scale to the native Promotion FPS and is still locked to a 60fps max.

### How should this be manually tested
Swap between the old and new lines of code and check the Xcode GPU debug for reporting of the max FPS and check visually if the new version looks "smoother" on ProMotion devices.

### Any background context you want to provide
Continued process to improve the V-Sync behavior in Pv.

Any thoughts @JoeMatt @jasarien @braindx ?