### PR TITLE
Update FPS Counter font and performance items.

### DIFF
--- a/Provenance/Emulator/PVEmulatorViewController.swift
+++ b/Provenance/Emulator/PVEmulatorViewController.swift
@@ -231,14 +231,14 @@ final class PVEmulatorViewController: PVEmulatorViewControllerRootClass, PVAudio
 
     private func initFPSLabel() {
         fpsLabel.textColor = UIColor.yellow
-        fpsLabel.text = "\(glViewController.framesPerSecond)"
         fpsLabel.translatesAutoresizingMaskIntoConstraints = false
         fpsLabel.textAlignment = .right
+        fpsLabel.isOpaque = true
         #if os(tvOS)
-            fpsLabel.font = UIFont.systemFont(ofSize: 40, weight: .bold)
+            fpsLabel.font = UIFont.monospacedDigitSystemFont(ofSize: 40, weight: .bold)
         #else
             if #available(iOS 8.2, *) {
-                fpsLabel.font = UIFont.systemFont(ofSize: 20, weight: .bold)
+                fpsLabel.font = UIFont.monospacedDigitSystemFont(ofSize: 20, weight: .bold)
             }
         #endif
         glViewController.view.addSubview(fpsLabel)


### PR DESCRIPTION
### What does this PR do

- Changed UIFont.systemFont to monospacedDigitSytemFont for more spatially stable text layout in the FPS Counter overlay.
- added in fpsLabel.isOpaque = true to help cut down on alpha blending calls for slower hardware.
- removed init of fpsLabel.text as it gets blown away later anyways.

### Any background context you want to provide

First stage of improving the FPS counter functionality and performance for > 60.0Hz devices.

### Questions
None.
