### PR TITLE
CI - Add autosquash and merge CI action

### DIFF
--- a/.github/workflows/autosquash.yml
+++ b/.github/workflows/autosquash.yml
@@ -1,0 +1,36 @@
+name: Autosquash
+on:
+  check_run:
+    types:
+      # Check runs completing successfully can unblock the
+      # corresponding pull requests and make them mergeable.
+      - completed
+  pull_request:
+    types:
+      # A closed pull request makes the checks on the other
+      # pull request on the same base outdated.
+      - closed
+      # Adding the autosquash label to a pull request can
+      # trigger an update or a merge.
+      - labeled
+  pull_request_review:
+    types:
+      # Review approvals can unblock the pull request and
+      # make it mergeable.
+      - submitted
+  # Success statuses can unblock the corresponding
+  # pull requests and make them mergeable.
+  status: {}
+
+jobs:
+  autosquash:
+    name: Autosquash
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: tibdex/autosquash@v2
+        with:
+          # We can't use the built-in secrets.GITHUB_TOKEN yet because of this limitation:
+          # https://github.community/t5/GitHub-Actions/Triggering-a-new-workflow-from-another-workflow/td-p/31676
+          # In the meantime, use a personal access token with repo access.
+          # See https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line
+          github_token: ${{ secrets.AUTOSQUASH_TOKEN }}

--- a/.github/workflows/autosquash.yml
+++ b/.github/workflows/autosquash.yml
@@ -27,7 +27,7 @@ jobs:
     name: Autosquash
     runs-on: ubuntu-18.04
     steps:
-      - uses: tibdex/autosquash@v2
+      - uses: tibdex/autosquash@v2.0.1 # https://github.com/tibdex/autosquash
         with:
           # We can't use the built-in secrets.GITHUB_TOKEN yet because of this limitation:
           # https://github.community/t5/GitHub-Actions/Triggering-a-new-workflow-from-another-workflow/td-p/31676

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ report.xml
 /.folio
 .DS_Store
 xcshareddata
+.build
+.swiftpm

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,76 +1,20 @@
 disabled_rules:
-  - switch_case_alignment
   - block_based_kvo
-  - multiple_closures_with_trailing_closure
   - colon
-  - force_cast
-  - type_name
-  - discarded_notification_center_observer
-  - force_try
-  #- identifier_name_min_length
-  - identifier_name
   - control_statement
-  - line_length
-  - type_body_length
-  - todo
-  - file_length
   - cyclomatic_complexity
-  - unused_closure_parameter
-  # - trailing_newline
-  # - opening_brace
-  # - empty_count
-  # - comma
-  # - trailing_semicolon
-  # - function_body_length
+  - discarded_notification_center_observer
+  - file_length
+  - function_parameter_count
+  - generic_type_name
+  - identifier_name
+  - multiple_closures_with_trailing_closure
   - nesting
-  # - conditional_binding_cascade
-  # - variable_name_max_length
-  # - operator_whitespace
-  # - legacy_constant
-  # - return_arrow_whitespace
-  # - trailing_whitespace
-  # - closing_brace
-  # - statement_position
-  # - legacy_constructor
-  # - valid_docs
-  # - missing_docs
-  # - leading_whitespace
-  # - redundant_optional_initialization
-  # - unused_optional_initialization
-  # - unused_optional_binding
-  # - void_return
-  # - implicit_getter
-  # - mark
-  # - notification_center_detachment
-  # - for_where
-  # - vertical_whitespace
-  # - empty_parameters
-  # - class_delegate_protocol
-  # - syntactic_sugar
-  # - function_parameter_count
-  # - trailing_comma
-  # - weak_delegate
-  # - redundant_string_enum_value
-  # - unused_enumerated
-  # - empty_enum_arguments
-  # - shorthand_operator
-  # - empty_parentheses_with_trailing_closure
-  # - closure_parameter_position
-  # - redundant_discardable_let
-  # - large_tuple
-  # - vertical_parameter_alignment
-  # - compiler_protocol_init
-  # - private_over_fileprivate
-excluded: # paths to ignore during linting. overridden byincluded.
-  - Carthage
-  - PVSupport/Carthage
-  - PVLibrary/Carthage
-  - Pods
-  - Cores
-  - Scripts
-  - fastlane
-  - build
-  - archive
+  - switch_case_alignment
+  - todo
+  - type_name
+  - unused_closure_parameter
+
 # parameterized rules can be customized from this configuration file
 line_length: 200
 # parameterized rules are first parameterized as a warning level, then error level.
@@ -91,3 +35,56 @@ function_body_length:
 large_tuple:
   - 4 # warning
   - 6 # error
+
+opt_in_rules:
+  - empty_count
+  - force_unwrapping
+
+included:
+  - Provenance
+  - Provenance Tests
+  - ProvenanceShared
+  - ProvenanceShared-tvOS
+  - ProvenanceTV
+  - PVLibrary
+  - PVSupport
+  - Spotlight
+  - TopShelf
+
+excluded: # paths to ignore during linting. overridden byincluded.
+  - Carthage
+  - PVSupport/Carthage
+  - PVLibrary/Carthage
+  - Pods
+  - Cores
+  - Scripts
+  - fastlane
+  - build
+  - archive
+
+analyzer_rules: # Rules run by `swiftlint analyze` (experimental)
+  - explicit_self
+
+# Override these rules to be warnings for now
+force_cast: warning
+force_try: warning
+empty_count: warning
+
+reporter: "xcode" # reporter type (xcode, json, csv, checkstyle, junit)
+
+custom_rules:
+  placeholders_in_comments:
+    included: ".*\\.swift"
+    name: "No Placeholders in Comments"
+    regex: "<#([^#]+)#>"
+    match_kinds:
+      - comment
+      - doccomment
+    message: "Placeholder left in comment."
+  tiles_deprecated:
+    included: ".*\\.swift"
+    name: "Tiles are deprecated in favor of Frame"
+    regex: "([T,t]ile$|^[T,t]il[e,es])"
+    message: "Tiles are deprecated in favor of Frame"
+    severity: warning
+


### PR DESCRIPTION
# Overview

Adds a GitHub action bot to automatically squash and merge approved pull requests

## Requirements

1. Code owners approvals meet setting for repo
2. Any required tests/checks in GitHub repo settings are passed
3. Pull request has the `autosquash` label

## Detail

This action runs on PR open, update etc. It will only execute though if all pre-conditions are met which are configured in the settings from GitHub.

The GitHub API has a flag called 'mergable" which means there are no conflicts, all peer reviews and automation bots are passed etc. Basically, does the PR have a green checkmark.

If so, this bot will squash and merge the PR.

## Why squash and merge

1. The history is maintained in the meta-comments
2. Squash is easier than rebase for XCode projects with Apple's shitty Xcode project format which is a pain in the butt to rebase
3. Why rebase and not merge though? The main reason is the clarity of reading history. A bunch of merges to and from developing into a feature branch are difficult to follow. The small changes are largely irrelevant once a feature branch is merged into master/develop, and in the event of regression, it's easier to find the 1  squash commit to undoing rather than tracing a zig-zag of merges between a feature branch and develop.