### PR TITLE
Reverted custom emulator options alert update

### DIFF
--- a/Provenance.xcodeproj/project.pbxproj
+++ b/Provenance.xcodeproj/project.pbxproj
@@ -144,7 +144,6 @@
 		378F4A0D1B63D7CD0065FA39 /* GCDWebUploader.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 378F49FD1B63D7CD0065FA39 /* GCDWebUploader.bundle */; };
 		378F4A0E1B63D7CD0065FA39 /* GCDWebUploader.m in Sources */ = {isa = PBXBuildFile; fileRef = 378F49FF1B63D7CD0065FA39 /* GCDWebUploader.m */; };
 		378F4A111B63DCF00065FA39 /* PVWebServer.m in Sources */ = {isa = PBXBuildFile; fileRef = 378F4A101B63DCF00065FA39 /* PVWebServer.m */; };
-		423BB97B17DD35B10048F457 /* AssetsLibrary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 423BB97A17DD35B10048F457 /* AssetsLibrary.framework */; };
 		42BC83A917E6775E00E9A607 /* PVGameLibrarySectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42BC83A817E6775E00E9A607 /* PVGameLibrarySectionHeaderView.swift */; };
 		7556CF7A19DC15C1007F8F97 /* Default.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7556CF7919DC15C1007F8F97 /* Default.xib */; };
 		B302BFA420825ADC0029CEDB /* PVMupen64PlusVideoGlideN64.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B302BFA320825ADC0029CEDB /* PVMupen64PlusVideoGlideN64.framework */; };
@@ -511,6 +510,7 @@
 		B3FD869D2313836B00A9DDF6 /* RxRelay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3FD869C2313836B00A9DDF6 /* RxRelay.framework */; };
 		BE9FDCBD1C210B9F0046DF0E /* ServiceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE9FDCBC1C210B9F0046DF0E /* ServiceProvider.swift */; };
 		BE9FDCC91C210C470046DF0E /* PVRecentGame+TopShelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE9FDCC81C210C470046DF0E /* PVRecentGame+TopShelf.swift */; };
+		C13CC82923CABE2800463EDD /* Photos.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C13CC82823CABE2800463EDD /* Photos.framework */; };
 		C665CD8421FEC68E00C834C6 /* GCControllerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C665CD8321FEC68E00C834C6 /* GCControllerExtensions.swift */; };
 		C665CD8521FEC68E00C834C6 /* GCControllerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C665CD8321FEC68E00C834C6 /* GCControllerExtensions.swift */; };
 		C6C125C020B0826900DC045B /* UILabel+Theming.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C125BF20B0826900DC045B /* UILabel+Theming.swift */; };
@@ -1038,6 +1038,7 @@
 		BE9FDCC81C210C470046DF0E /* PVRecentGame+TopShelf.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PVRecentGame+TopShelf.swift"; sourceTree = "<group>"; };
 		BE9FDCCC1C21109B0046DF0E /* Provenance.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = Provenance.entitlements; sourceTree = "<group>"; };
 		BE9FDCCD1C21194B0046DF0E /* TopShelf.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = TopShelf.entitlements; sourceTree = "<group>"; };
+		C13CC82823CABE2800463EDD /* Photos.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Photos.framework; path = System/Library/Frameworks/Photos.framework; sourceTree = SDKROOT; };
 		C665CD8321FEC68E00C834C6 /* GCControllerExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GCControllerExtensions.swift; sourceTree = "<group>"; };
 		C6C125BF20B0826900DC045B /* UILabel+Theming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Theming.swift"; sourceTree = "<group>"; };
 		C6E8F64C2095CAE4003CC2D9 /* SubtleVolume.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubtleVolume.swift; sourceTree = "<group>"; };
@@ -1067,6 +1068,7 @@
 				B316B4D9219265AB00693472 /* PVVirtualJaguar.framework in Frameworks */,
 				B3F5A92321A68BDB000BB0A5 /* RxGesture.framework in Frameworks */,
 				B3F5A92421A68BDB000BB0A5 /* RxDataSources.framework in Frameworks */,
+				C13CC82923CABE2800463EDD /* Photos.framework in Frameworks */,
 				B3F5A92521A68BDB000BB0A5 /* Differentiator.framework in Frameworks */,
 				B3B10483218F20FE00210C39 /* RxCocoa.framework in Frameworks */,
 				B3DE5B1421B102F20066069E /* ProvenanceShared.framework in Frameworks */,
@@ -1091,7 +1093,6 @@
 				1AD4BC6F1BFD38D6007D6C7C /* AVFoundation.framework in Frameworks */,
 				B3CDEECD21D4D0D0000C55F7 /* ZipArchive.framework in Frameworks */,
 				B3CB85BF1E9BFB07009155A6 /* PVPokeMini.framework in Frameworks */,
-				423BB97B17DD35B10048F457 /* AssetsLibrary.framework in Frameworks */,
 				1A4869DD17C8D60C0019F6D2 /* CFNetwork.framework in Frameworks */,
 				B316B4DF219269C600693472 /* PVYabause.framework in Frameworks */,
 				1A4869DE17C8D60C0019F6D2 /* MobileCoreServices.framework in Frameworks */,
@@ -1339,6 +1340,7 @@
 		1A3D409617B2DCE4004DFFFC /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				C13CC82823CABE2800463EDD /* Photos.framework */,
 				B3FD869A2313835D00A9DDF6 /* RxRelay.framework */,
 				B3FD869C2313836B00A9DDF6 /* RxRelay.framework */,
 				B3CDEED821D4D84E000C55F7 /* BitByteData.framework */,

--- a/Provenance/Emulator/PVEmulatorViewController~iOS.swift
+++ b/Provenance/Emulator/PVEmulatorViewController~iOS.swift
@@ -249,7 +249,10 @@ extension PVEmulatorViewController {
         core.setPauseEmulation(true)
         isShowingMenu = true
 
-        let actionSheet = EmulatorActionController()
+        //let actionSheet = EmulatorActionController()
+        
+        let actionSheet = UIAlertController(title: "Game Options", message: nil, preferredStyle: .actionSheet)
+        
 
         if traitCollection.userInterfaceIdiom == .pad {
             actionSheet.popoverPresentationController?.sourceView = menuButton
@@ -257,16 +260,16 @@ extension PVEmulatorViewController {
         }
 
         if PVControllerManager.shared.iCadeController != nil {
-            actionSheet.addAction(Action("Disconnect iCade", style: .default) { _ in
+            actionSheet.addAction(UIAlertAction(title: "Disconnect iCade", style: .default, handler: { action in
                 NotificationCenter.default.post(name: .GCControllerDidDisconnect, object: PVControllerManager.shared.iCadeController)
                 self.core.setPauseEmulation(false)
                 self.isShowingMenu = false
                 self.enableContorllerInput(false)
-            })
+            }))
         }
 
         if core is CoreOptional {
-            actionSheet.addAction(Action("Core Options", style: .default, handler: { _ in
+            actionSheet.addAction(UIAlertAction(title: "Core Options", style: .default, handler: { action in
                 self.showCoreOptions()
             }))
         }
@@ -283,7 +286,7 @@ extension PVEmulatorViewController {
             if player1.extendedGamepad != nil || wantsStartSelectInMenu, !hideP1MenuActions {
                 // left trigger bound to Start
                 // right trigger bound to Select
-                actionSheet.addAction(Action("P1 Start", style: .default, handler: { _ in
+                actionSheet.addAction(UIAlertAction(title: "P1 Start", style: .default, handler: { action in
                     self.core.setPauseEmulation(false)
                     self.isShowingMenu = false
                     self.controllerViewController?.pressStart(forPlayer: 0)
@@ -292,7 +295,7 @@ extension PVEmulatorViewController {
                     })
                     self.enableContorllerInput(false)
                 }))
-                actionSheet.addAction(Action("P1 Select", style: .default, handler: { _ in
+                actionSheet.addAction(UIAlertAction(title: "P1 Select", style: .default, handler: { action in
                     self.core.setPauseEmulation(false)
                     self.isShowingMenu = false
                     self.controllerViewController?.pressSelect(forPlayer: 0)
@@ -303,7 +306,7 @@ extension PVEmulatorViewController {
                 }))
             }
             if player1.extendedGamepad != nil || wantsStartSelectInMenu {
-                actionSheet.addAction(Action("P1 AnalogMode", style: .default, handler: { _ in
+                actionSheet.addAction(UIAlertAction(title: "P1 Analog Mode", style: .default, handler: { action in
                     self.core.setPauseEmulation(false)
                     self.isShowingMenu = false
                     self.controllerViewController?.pressAnalogMode(forPlayer: 0)
@@ -316,7 +319,7 @@ extension PVEmulatorViewController {
         }
         if let player2 = controllerManager.player2 {
             if player2.extendedGamepad != nil || wantsStartSelectInMenu {
-                actionSheet.addAction(Action("P2 Start", style: .default, handler: { _ in
+                actionSheet.addAction(UIAlertAction(title: "P2 Start", style: .default, handler: { action in
                     self.core.setPauseEmulation(false)
                     self.isShowingMenu = false
                     self.controllerViewController?.pressStart(forPlayer: 1)
@@ -325,7 +328,7 @@ extension PVEmulatorViewController {
                     })
                     self.enableContorllerInput(false)
                 }))
-                actionSheet.addAction(Action("P2 Select", style: .default, handler: { _ in
+                actionSheet.addAction(UIAlertAction(title: "P2 Select", style: .default, handler: { action in
                     self.core.setPauseEmulation(false)
                     self.isShowingMenu = false
                     self.controllerViewController?.pressSelect(forPlayer: 1)
@@ -334,7 +337,7 @@ extension PVEmulatorViewController {
                     })
                     self.enableContorllerInput(false)
                 }))
-                actionSheet.addAction(Action("P2 AnalogMode", style: .default, handler: { _ in
+                actionSheet.addAction(UIAlertAction(title: "P2 Analog Mode", style: .default, handler: { action in
                     self.core.setPauseEmulation(false)
                     self.isShowingMenu = false
                     self.controllerViewController?.pressAnalogMode(forPlayer: 1)
@@ -346,7 +349,7 @@ extension PVEmulatorViewController {
             }
         }
         if let swappableCore = core as? DiscSwappable, swappableCore.currentGameSupportsMultipleDiscs {
-            actionSheet.addAction(Action("Swap Disc", style: .default, handler: { _ in
+            actionSheet.addAction(UIAlertAction(title: "Swap Disc", style: .default, handler: { action in
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: {
                     self.showSwapDiscsMenu()
                 })
@@ -355,7 +358,7 @@ extension PVEmulatorViewController {
 
         if let actionableCore = core as? CoreActions, let actions = actionableCore.coreActions {
             actions.forEach { coreAction in
-                actionSheet.addAction(Action(coreAction.title, style: .default, handler: { _ in
+                actionSheet.addAction(UIAlertAction(title: coreAction.title, style: .destructive, handler: { action in
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: {
                         actionableCore.selected(action: coreAction)
                         self.core.setPauseEmulation(false)
@@ -369,11 +372,11 @@ extension PVEmulatorViewController {
             }
         }
         #if os(iOS)
-            actionSheet.addAction(Action("Save Screenshot", style: .default, handler: { _ in
+            actionSheet.addAction(UIAlertAction(title: "Save Screenshot", style: .default, handler: { action in
                 self.perform(#selector(self.takeScreenshot), with: nil, afterDelay: 0.1)
             }))
         #endif
-        actionSheet.addAction(Action("Game Info", style: .default, handler: { _ in
+        actionSheet.addAction(UIAlertAction(title: "Game Info", style: .default, handler: { action in
             let sb = UIStoryboard(name: "Provenance", bundle: nil)
             let moreInfoViewContrller = sb.instantiateViewController(withIdentifier: "gameMoreInfoVC") as? PVGameMoreInfoViewController
             moreInfoViewContrller?.game = self.game
@@ -384,15 +387,15 @@ extension PVEmulatorViewController {
             self.isShowingMenu = false
             self.enableContorllerInput(false)
         }))
-        actionSheet.addAction(Action("Game Speed", style: .default, handler: { _ in
+        actionSheet.addAction(UIAlertAction(title: "Game Speed", style: .default, handler: { action in
             self.perform(#selector(self.showSpeedMenu), with: nil, afterDelay: 0.1)
         }))
         if core.supportsSaveStates {
-            actionSheet.addAction(Action("Save States", style: .default, handler: { _ in
+            actionSheet.addAction(UIAlertAction(title: "Save States", style: .default, handler: { action in
                 self.perform(#selector(self.showSaveStateMenu), with: nil, afterDelay: 0.1)
             }))
         }
-        actionSheet.addAction(Action("Reset", style: .default, handler: { _ in
+        actionSheet.addAction(UIAlertAction(title: "Reset", style: .default, handler: { action in
             if PVSettingsModel.shared.autoSave, self.core.supportsSaveStates {
                 self.autoSaveState { result in
                     switch result {
@@ -416,19 +419,29 @@ extension PVEmulatorViewController {
         shouldSave = shouldSave && abs(game.saveStates.sorted(byKeyPath: "date", ascending: true).last?.date.timeIntervalSinceNow ?? minutes(2)) > minutes(1)
 
         // Add Non-Saving quit first
-        let quitTitle = shouldSave ? "Quit (without save)" : "Quit"
-        actionSheet.addAction(Action(quitTitle, style: shouldSave ? .default : .destructive, handler: { _ in
+        let quitTitle = shouldSave ? "Quit (without saving)" : "Quit"
+        actionSheet.addAction(UIAlertAction(title: quitTitle, style: .destructive, handler: { action in
             self.quit(optionallySave: false)
         }))
 
         // If save and quit is an option, add it last with different style
         if shouldSave {
-            actionSheet.addAction(Action("Save & Quit", style: .destructive, handler: { _ in
+            actionSheet.addAction(UIAlertAction(title: "Save & Quit", style: .destructive, handler: { action in
                 self.quit(optionallySave: true)
             }))
         }
+        
+        actionSheet.addAction(UIAlertAction(title: "Resume", style: .default, handler: { action in
+            actionSheet.dismiss(animated: true) {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    self.core.setPauseEmulation(false)
+                    self.isShowingMenu = false
+                    self.enableContorllerInput(false)
+                }
+            }
+        }))
 
-        actionSheet.cancelBlock = {
+        if actionSheet.isBeingDismissed {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 self.core.setPauseEmulation(false)
                 self.isShowingMenu = false


### PR DESCRIPTION
### What does this PR do
This PR reverts the alert when hitting pause in game to the default Apple alert, it also swaps the 'alert' for an 'actionSheet' which presents from the bottom, separating alerts from other functions.

Not noticed but it also swaps ALAssetLibrary to PHPhotoLibrary, fixing deprecations and improving support for iOS 12+

### Where should the reviewer start

### How should this be manually tested

### Any background context you want to provide

### What are the relevant tickets
No related tickets, discussion was between Sev and myself

### Screenshots (if appropriate)

### Questions
