### PR TITLE
Updates for SteamController v1.2

### DIFF
--- a/Provenance/Controller/PVControllerManager.swift
+++ b/Provenance/Controller/PVControllerManager.swift
@@ -150,7 +150,6 @@ final class PVControllerManager: NSObject {
         NotificationCenter.default.addObserver(self, selector: #selector(PVControllerManager.handleControllerDidConnect(_:)), name: .GCControllerDidConnect, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(PVControllerManager.handleControllerDidDisconnect(_:)), name: .GCControllerDidDisconnect, object: nil)
         UserDefaults.standard.addObserver(self as NSObject, forKeyPath: "kICadeControllerSettingKey", options: .new, context: nil)
-        SteamControllerManager.shared().scanForControllers()
         // automatically assign the first connected controller to player 1
         // prefer gamepad or extendedGamepad over a microGamepad
         assignControllers()

--- a/Provenance/Controller/PVControllerManager.swift
+++ b/Provenance/Controller/PVControllerManager.swift
@@ -213,7 +213,7 @@ final class PVControllerManager: NSObject {
                 }
             }
         }
-        
+
         ILOG("Controller connected: \(controller.vendorName ?? "No Vendor")")
         assign(controller)
     }
@@ -275,7 +275,7 @@ final class PVControllerManager: NSObject {
             controller.steamRightTrackpadRequiresClick = !controller.steamRightTrackpadRequiresClick
         case .stick:
             // toggle stick mapping between d-pad and left stick
-            if (controller.steamThumbstickMapping == .leftThumbstick) {
+            if controller.steamThumbstickMapping == .leftThumbstick {
                 controller.steamThumbstickMapping = .dPad
                 controller.steamLeftTrackpadMapping = .leftThumbstick
             } else {
@@ -286,7 +286,7 @@ final class PVControllerManager: NSObject {
             return
         }
     }
-    
+
     // MARK: - Controllers assignment
 
     func setController(_ controller: GCController?, toPlayer player: Int) {
@@ -374,7 +374,7 @@ final class PVControllerManager: NSObject {
         }
         return false
     }
-    
+
     func setSteamControllersMode(_ mode: SteamControllerMode) {
         for controller in SteamControllerManager.shared().controllers {
             controller.steamControllerMode = mode

--- a/Provenance/Controller/PVControllerManager.swift
+++ b/Provenance/Controller/PVControllerManager.swift
@@ -201,6 +201,13 @@ final class PVControllerManager: NSObject {
             return
         }
 
+        #if os(tvOS)
+        if let steamController = controller as? SteamController {
+            // PVEmulatorViewController will set to controller mode if game is running
+            steamController.steamControllerMode = .keyboardAndMouse
+        }
+        #endif
+        
         ILOG("Controller connected: \(controller.vendorName ?? "No Vendor")")
         assign(controller)
     }
@@ -338,5 +345,11 @@ final class PVControllerManager: NSObject {
             }
         }
         return false
+    }
+    
+    func setSteamControllersMode(_ mode: SteamControllerMode) {
+        for controller in SteamControllerManager.shared().controllers {
+            controller.steamControllerMode = mode
+        }
     }
 }

--- a/Provenance/Emulator/PVEmulatorViewController.swift
+++ b/Provenance/Emulator/PVEmulatorViewController.swift
@@ -127,6 +127,9 @@ final class PVEmulatorViewController: PVEmulatorViewControllerRootClass, PVAudio
 
     override func observeValue(forKeyPath keyPath: String?, of _: Any?, change _: [NSKeyValueChangeKey: Any]?, context _: UnsafeMutableRawPointer?) {
         if keyPath == "isRunning" {
+            #if os(tvOS)
+            PVControllerManager.shared.setSteamControllersMode(core.isRunning ? .gameController : .keyboardAndMouse)
+            #endif
             if core.isRunning {
                 if gameStartTime != nil {
                     ELOG("Didn't expect to get a KVO update of isRunning to true while we still have an unflushed gameStartTime variable")
@@ -732,6 +735,9 @@ extension PVEmulatorViewController {
         core.controller2 = PVControllerManager.shared.player2
         core.controller3 = PVControllerManager.shared.player3
         core.controller4 = PVControllerManager.shared.player4
+        #if os(tvOS)
+        PVControllerManager.shared.setSteamControllersMode(core.isRunning ? .gameController : .keyboardAndMouse)
+        #endif
     }
 
     // MARK: - UIScreenNotifications

--- a/Provenance/Emulator/PVEmulatorViewController.swift
+++ b/Provenance/Emulator/PVEmulatorViewController.swift
@@ -370,13 +370,12 @@ final class PVEmulatorViewController: PVEmulatorViewControllerRootClass, PVAudio
             if let aRecognizer = menuGestureRecognizer {
                 view.addGestureRecognizer(aRecognizer)
             }
-        #else
-            GCController.controllers().forEach { [unowned self] in
-                $0.controllerPausedHandler = { controller in
-                    self.controllerPauseButtonPressed(controller)
-                }
-            }
         #endif
+        GCController.controllers().filter({ $0.vendorName != "Remote" }).forEach { [unowned self] in
+            $0.controllerPausedHandler = { controller in
+                self.controllerPauseButtonPressed(controller)
+            }
+        }
     }
 
     public override func viewDidAppear(_: Bool) {
@@ -709,11 +708,13 @@ extension PVEmulatorViewController {
         if !(controller is PViCade8BitdoController || controller is PViCade8BitdoZeroController) {
             menuButton?.isHidden = true
             // In instances where the controller is connected *after* the VC has been shown, we need to set the pause handler
-            #if os(iOS)
-
+            // Except for the Apple Remote, where it's handled in the menuGestureRecognizer
+            if controller?.vendorName != "Remote" {
                 controller?.controllerPausedHandler = { [unowned self] controller in
                     self.controllerPauseButtonPressed(controller)
                 }
+            }
+            #if os(iOS)
                 if #available(iOS 11.0, *) {
                     setNeedsUpdateOfHomeIndicatorAutoHidden()
                 }

--- a/Provenance/PVAppDelegate.swift
+++ b/Provenance/PVAppDelegate.swift
@@ -97,7 +97,7 @@ final class PVAppDelegate: UIResponder, UIApplicationDelegate {
         database.refresh()
 
         SteamControllerManager.listenForConnections()
-        
+
         return true
     }
 

--- a/Provenance/PVAppDelegate.swift
+++ b/Provenance/PVAppDelegate.swift
@@ -96,6 +96,8 @@ final class PVAppDelegate: UIResponder, UIApplicationDelegate {
         let database = RomDatabase.sharedInstance
         database.refresh()
 
+        SteamControllerManager.listenForConnections()
+        
         return true
     }
 
@@ -235,9 +237,7 @@ final class PVAppDelegate: UIResponder, UIApplicationDelegate {
 
     func applicationWillEnterForeground(_: UIApplication) {}
 
-    func applicationDidBecomeActive(_: UIApplication) {
-        SteamControllerManager.shared().scanForControllers()
-    }
+    func applicationDidBecomeActive(_: UIApplication) {}
 
     func applicationWillTerminate(_: UIApplication) {}
 


### PR DESCRIPTION
### What does this PR do
* Handle reconnection of Steam controllers transparently 
* Allow using the Steam controller to navigate the UI (on tvOS)
* Restore Steam button combinations to toggle controls (they were removed from the library):
    * Steam + left pad click: toggle requiring click for input on left pad 
    * Steam + right pad click: toggle requiring click for input on right pad 
    * Steam + d-pad click: toggle d-pad and left trackpad mapping
* Use paused handler for all controllers except apple remote
   * This allows the controller menu button to work on MFi/Xbox/PS4 controllers too

### Where should the reviewer start

### How should this be manually tested
I've tested the following on iOS and tvOS 13.3:
* Steam Controller is detected automatically after it reconnects
* Steam Controller allows navigating the UI on tvOS
* Menu button behaves correctly on Steam Controller, Apple Remote, and Xbox Controller (should be the same as MFi)