### PR TITLE
Set default ratio of Mupen64plus to 4:3 (AppleTV)

### DIFF
--- a/Cores/Mupen64Plus/MupenGameCore.m
+++ b/Cores/Mupen64Plus/MupenGameCore.m
@@ -664,7 +664,7 @@ static void ConfigureGLideN64(NSString *romFolder) {
 
     if(RESIZE_TO_FULLSCREEN) {
         #if TARGET_OS_TV
-            aspectRatio = 2;
+            aspectRatio = 1;
         #else
             aspectRatio = 3;
         #endif


### PR DESCRIPTION
### What does this PR do

This commit change the default aspect ratio of Mupen64plus to 4:3 (value: 1) on Apple TV.

### Where should the reviewer start

### How should this be manually tested

Launch an N64 game with Mupen64plus core on Apple TV build.

### Any background context you want to provide

On AppleTV build, the Mupen64plus default aspect ratio was 16:3 (value: 2), therefore image looked stretched.

### What are the relevant tickets

### Screenshots (if appropriate)

### Questions
