### PR TITLE
Set default game speed with preferredAction in alert

### DIFF
--- a/Provenance/Emulator/PVEmulatorViewController.swift
+++ b/Provenance/Emulator/PVEmulatorViewController.swift
@@ -630,12 +630,16 @@ final class PVEmulatorViewController: PVEmulatorViewControllerRootClass, PVAudio
         }
         let speeds = ["Slow", "Normal", "Fast"]
         speeds.enumerated().forEach { idx, title in
-            actionSheet.addAction(UIAlertAction(title: title, style: .default, handler: { (_: UIAlertAction) -> Void in
+            let action = UIAlertAction(title: title, style: .default, handler: { (_: UIAlertAction) -> Void in
                 self.core.gameSpeed = GameSpeed(rawValue: idx) ?? .normal
                 self.core.setPauseEmulation(false)
                 self.isShowingMenu = false
                 self.enableContorllerInput(false)
-            }))
+            })
+            actionSheet.addAction(action)
+            if idx == self.core.gameSpeed.rawValue {
+                actionSheet.preferredAction = action
+            }
         }
         present(actionSheet, animated: true, completion: { () -> Void in
             PVControllerManager.shared.iCadeController?.refreshListener()


### PR DESCRIPTION
### What does this PR do
This pull request selects the current game speed when the game speed alert is displayed. By default the "Slow" option is selected, regardless of what the current state is.

With this change, "Normal" is selected when no game speed has been set. This is also useful when choosing "Game Speed" by accident instead of "Save States".

### Where should the reviewer start
Look at the game speed UIAlertController.

### How should this be manually tested
Start a NES game and choose "Game State".