### PR TITLE
Add space between AnalogMode

### DIFF
--- a/Provenance/Emulator/PVEmulatorViewController~tvOS.swift
+++ b/Provenance/Emulator/PVEmulatorViewController~tvOS.swift
@@ -70,7 +70,7 @@ extension PVEmulatorViewController {
                 }))
             }
             if player1.extendedGamepad != nil || wantsStartSelectInMenu {
-                actionsheet.addAction(UIAlertAction(title: "P1 AnalogMode", style: .default, handler: { (_: UIAlertAction) -> Void in
+                actionsheet.addAction(UIAlertAction(title: "P1 Analog Mode", style: .default, handler: { (_: UIAlertAction) -> Void in
                     self.core.setPauseEmulation(false)
                     self.isShowingMenu = false
                     self.controllerViewController?.pressAnalogMode(forPlayer: 0)
@@ -101,7 +101,7 @@ extension PVEmulatorViewController {
                     })
                     self.enableContorllerInput(false)
                 }))
-                actionsheet.addAction(UIAlertAction(title: "P2 AnalogMode", style: .default, handler: { (_: UIAlertAction) -> Void in
+                actionsheet.addAction(UIAlertAction(title: "P2 Analog Mode", style: .default, handler: { (_: UIAlertAction) -> Void in
                     self.core.setPauseEmulation(false)
                     self.isShowingMenu = false
                     self.controllerViewController?.pressAnalogMode(forPlayer: 1)


### PR DESCRIPTION
### What does this PR do
Adds a space between "AnalogMode" to match the behaviour on iOS.

### How should this be manually tested
Open the action sheet when using a controller.

### Any background context you want to provide
This change was already made for iOS: https://github.com/Provenance-Emu/Provenance/commit/435d60810b2afc3ac44344d30650af3e87f5d438.