### PR TITLE
Clean game description during import

### DIFF
--- a/PVLibrary/PVLibrary/Importer/Services/GameImporter.swift
+++ b/PVLibrary/PVLibrary/Importer/Services/GameImporter.swift
@@ -961,7 +961,9 @@ public extension GameImporter {
                 }
 
                 if let gameDescription = chosenResult["gameDescription"] as? String, !gameDescription.isEmpty, overwrite || game.gameDescription == nil {
-                    game.gameDescription = gameDescription
+                    let options = [NSAttributedString.DocumentReadingOptionKey.documentType: NSAttributedString.DocumentType.html]
+                    let htmlDecodedGameDescription = try! NSMutableAttributedString(data: gameDescription.data(using: .utf8)!, options: options, documentAttributes: nil)
+                    game.gameDescription = htmlDecodedGameDescription.string
                 }
 
                 if let boxBackURL = chosenResult["boxBackURL"] as? String, !boxBackURL.isEmpty, overwrite || game.boxBackArtworkURL == nil {

--- a/PVLibrary/PVLibrary/Importer/Services/GameImporter.swift
+++ b/PVLibrary/PVLibrary/Importer/Services/GameImporter.swift
@@ -963,7 +963,7 @@ public extension GameImporter {
                 if let gameDescription = chosenResult["gameDescription"] as? String, !gameDescription.isEmpty, overwrite || game.gameDescription == nil {
                     let options = [NSAttributedString.DocumentReadingOptionKey.documentType: NSAttributedString.DocumentType.html]
                     let htmlDecodedGameDescription = try! NSMutableAttributedString(data: gameDescription.data(using: .utf8)!, options: options, documentAttributes: nil)
-                    game.gameDescription = htmlDecodedGameDescription.string
+                    game.gameDescription = htmlDecodedGameDescription.string.replacingOccurrences(of: "(\\.|\\!|\\?)([A-Z][A-Za-z\\s]{2,})", with: "$1\n\n$2", options: .regularExpression)
                 }
 
                 if let boxBackURL = chosenResult["boxBackURL"] as? String, !boxBackURL.isEmpty, overwrite || game.boxBackArtworkURL == nil {


### PR DESCRIPTION
### What does this PR do
The data in the `openvgdb.sqlite` contains many errors from when the data was collected. HTML entities are still encoded and all paragraphs in the game descriptions were removed.
This PR decodes the HTML entities and restores paragraphs that had been removed.

HTML entities are removed by extending the String class, the [HTMLEntities](https://github.com/IBM-Swift/swift-html-entities) framework was tested but didn't seem worth it to add a whole framework. There are 2530 HTML entities in the game descriptions.

Paragraphs are restored by checking for a capital letter directly after a `.`, `!` or `?`, there must be at least a couple of normal letters after, this prevents false positives such as `U.S.`. There are a total of 6283 collapsed paragraphs in the game descriptions.

### How should this be manually tested
Import a game.