### PR TITLE
Fix game description scrolling on tvOS

### DIFF
--- a/Provenance/Game Library/UI/PVGameMoreInfoViewController.swift
+++ b/Provenance/Game Library/UI/PVGameMoreInfoViewController.swift
@@ -305,9 +305,21 @@ final class PVGameMoreInfoViewController: UIViewController, GameLaunchingViewCon
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        descriptionTextView.showsVerticalScrollIndicator = true
-        descriptionTextView.flashScrollIndicators()
-        descriptionTextView.indicatorStyle = .white
+
+        #if os(iOS)
+            descriptionTextView.showsVerticalScrollIndicator = true
+            descriptionTextView.flashScrollIndicators()
+            descriptionTextView.indicatorStyle = .white
+        #endif
+
+        #if os(tvOS)
+            if descriptionTextView.contentSize.height > descriptionTextView.bounds.height {
+                descriptionTextView.isUserInteractionEnabled = true
+                descriptionTextView.isSelectable = true
+                descriptionTextView.isScrollEnabled = true
+                descriptionTextView.panGestureRecognizer.allowedTouchTypes = [NSNumber(value: UITouch.TouchType.indirect.rawValue)]
+            }
+        #endif
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -791,6 +803,14 @@ extension PVGameMoreInfoViewController: UITextViewDelegate {
         }
 
         override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
+            if context.previouslyFocusedView?.isDescendant(of: descriptionTextView) == true {
+                if descriptionTextView.contentOffset.y > 0 {
+                    UIView.animate(withDuration: 0.2, delay: 0, animations: {
+                        self.descriptionTextView.contentOffset.y = 0
+                    }, completion: nil)
+                }
+            }
+
             super.didUpdateFocus(in: context, with: coordinator)
 
 //        coordinator.addCoordinatedAnimations({ [unowned self] in


### PR DESCRIPTION
### What does this PR do
This pull request solves the problem of game descriptions on tvOS being truncated. Scrolling is enabled and and the scroll position animates to the top once the selected field changes.

In addition, iOS-specific scroll behaviour has been removed from the tvOS build as it did not function correctly.

### How should this be manually tested
Import a game with a long game description.

### Screenshots (if appropriate)

![ezgif-6-250977b350d8](https://user-images.githubusercontent.com/2276355/80926857-07966c00-8d9a-11ea-9fad-ff49fca8606a.gif)
