### PR TITLE
Fix settings tab bar title

### DIFF
--- a/Provenance/Settings/PVSettingsViewController.swift
+++ b/Provenance/Settings/PVSettingsViewController.swift
@@ -35,6 +35,7 @@ final class PVSettingsViewController: PVQuickTableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        splitViewController?.title = "Settings"
         generateTableViewViewModels()
         tableView.reloadData()
 
@@ -46,6 +47,7 @@ final class PVSettingsViewController: PVQuickTableViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        splitViewController?.title = "Settings"
         do {
             try reachability.startNotifier()
         } catch {


### PR DESCRIPTION
### What does this PR do
This pull request ensures the "Settings" tab bar title appears correctly after navigating to some secondary level settings. Navigating to "Systems" or "Manage Conflicts" will change the tab bar title, it needs to be set again after navigating back.

### Where should the reviewer start
Compare with the original [settings controller](https://github.com/Provenance-Emu/Provenance/blame/develop/ProvenanceTV/PVTVSettingsViewController.swift#L36), which seems to be unused.

### How should this be manually tested
Navigate to Settings, Systems and back again.

### Screenshots (if appropriate)
Before:
<img width="300" alt="Screen Shot 2020-05-14 at 17 51 09" src="https://user-images.githubusercontent.com/2276355/81956597-cd379500-960b-11ea-88ae-33dbf5435ac0.png">

After:
<img width="300" alt="Screen Shot 2020-05-14 at 17 57 53" src="https://user-images.githubusercontent.com/2276355/81957156-8007f300-960c-11ea-984f-076f013bcb4e.png">

### Questions
Secondary settings menus are somewhat inconsistent, some change the tab bar title (Systems, Manage Conflicts) and some show the view controller title (Core Options, Licenses). The view controller title is problematic it is out of the safe zone and can be truncated. Should the tab bar title be changed instead of using the view controller title?