### PR TITLE
Fix iOS settings table appearance

### DIFF
--- a/Provenance/User Interface/Themes/Theme.swift
+++ b/Provenance/User Interface/Themes/Theme.swift
@@ -194,7 +194,7 @@ public final class Theme {
         }
 
         // Settings
-        appearance(in: [SettingsTableView.self]) {
+        appearance(inAny: [PVSettingsViewController.self, SystemsSettingsTableViewController.self, CoreOptionsViewController.self, SettingsTableView.self, PVAppearanceViewController.self, PVCoresTableViewController.self]) {
             UITableViewCell.appearance {
                 $0.backgroundColor = theme.settingsCellBackground
                 $0.textLabel?.backgroundColor = theme.settingsCellBackground


### PR DESCRIPTION
### What does this PR do
This pull request applies the correct UITableView appearance for the `PVSettingsViewController` view and related views. Previously it only applied to the appearance view.

### How should this be manually tested
Open the settings.

### Screenshots (if appropriate)
Before:
![Before](https://user-images.githubusercontent.com/2276355/82092912-6f35ab00-96fa-11ea-8fe6-95dd16d61134.png)

After:
![After](https://user-images.githubusercontent.com/2276355/82092931-7492f580-96fa-11ea-8963-7ca4696ad07c.png)

### Questions
Is this the best way to apply the appearance to the `PVSettingsViewController`? The text colour for a Mupen64Plus setting still has the wrong text colour:

<img width="375" alt="Mupen" src="https://user-images.githubusercontent.com/2276355/82092906-6a70f700-96fa-11ea-9058-e6be8b8c4185.png">
