### PR TITLE
Fix UITableViewHeaderFooterView deprecation warning

### DIFF
--- a/Provenance/User Interface/Themes/Theme.swift
+++ b/Provenance/User Interface/Themes/Theme.swift
@@ -225,16 +225,6 @@ public final class Theme {
             }
         }
 
-        appearance(in: [UITableViewHeaderFooterView.self]) {
-            UILabel.appearance {
-                $0.textColor = theme.settingsHeaderText
-            }
-        }
-
-        UITableViewHeaderFooterView.appearance {
-            $0.backgroundColor = theme.settingsHeaderBackground
-        }
-
         let selectedView = UIView()
         selectedView.backgroundColor = theme.defaultTintColor
 


### PR DESCRIPTION
### What does this PR do
This pull request fixes an appearance deprecation warning. Removing the relevant code seems to have little effect, the colour changes only slightly.

### How should this be manually tested
Look at the colour of the settings headers.

### Screenshots (if appropriate)
Before:
![Before](https://user-images.githubusercontent.com/2276355/82095270-08ff5700-96ff-11ea-9c90-1636cf1744c2.png)

After:
![After](https://user-images.githubusercontent.com/2276355/82095274-0b61b100-96ff-11ea-81f7-fc7b03a86924.png)