### PR TITLE
Fix web server alert

### DIFF
--- a/Provenance/Settings/WebServerActivatorController.swift
+++ b/Provenance/Settings/WebServerActivatorController.swift
@@ -20,25 +20,21 @@ protocol WebServerActivatorController: class {
 
     extension WebServerActivatorController where Self: UIViewController & SFSafariViewControllerDelegate {
         // Show "Web Server Active" alert view
-        func showServerActiveAlert() {
+        var webServerAlertMessage: String {
+            let webServerAddress: String = PVWebServer.shared.urlString
+            let webDavAddress: String = PVWebServer.shared.webDavURLString
             let message = """
             Read Importing ROMs wiki…
             Upload/Download files at:
 
+            \(webServerAddress)  ᵂᵉᵇᵁᴵ
+            \(webDavAddress)  ᵂᵉᵇᴰᵃᵛ
             """
-            let alert = UIAlertController(title: "Web Server Active", message: message, preferredStyle: .alert)
-            let ipField = UITextView(frame: CGRect(x: 20, y: 75, width: 231, height: 70))
-            ipField.backgroundColor = UIColor.clear
-            ipField.textAlignment = .center
-            ipField.font = UIFont.systemFont(ofSize: 13)
-            ipField.textColor = UIColor.gray
-            let ipFieldText = """
-            WebUI: \(PVWebServer.shared.urlString)
-            WebDav: \(PVWebServer.shared.webDavURLString)
-            """
-            ipField.text = ipFieldText
-            ipField.isUserInteractionEnabled = false
-            alert.view.addSubview(ipField)
+            return message
+        }
+
+        func showServerActiveAlert() {
+            let alert = UIAlertController(title: "Web Server Active", message: webServerAlertMessage, preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: "Stop", style: .cancel, handler: { (_: UIAlertAction) -> Void in
                 PVWebServer.shared.stopServers()
             }))
@@ -78,7 +74,6 @@ extension WebServerActivatorController where Self: WebServerActivatorControllerR
 
         \(webServerAddress)  ᵂᵉᵇᵁᴵ
         \(webDavAddress)  ᵂᵉᵇᴰᵃᵛ
-
         """
         return message
     }


### PR DESCRIPTION
### What does this PR do
This pull request fixes the layout of the web server alert when accessed via the settings. The style now matches the alert when initiated from the home screen.

### How should this be manually tested
Tap "Launch Web Server".

### Screenshots (if appropriate)
Before:
![Before](https://user-images.githubusercontent.com/2276355/82126989-bed6ae00-97b0-11ea-8f34-102069063f24.png)

After:
![After](https://user-images.githubusercontent.com/2276355/82126990-c1390800-97b0-11ea-9e93-2e74ed49bceb.png)
