### PR TITLE
Add spacing before tick

### DIFF
--- a/Provenance/Emulator/CoreOptionsViewController.swift
+++ b/Provenance/Emulator/CoreOptionsViewController.swift
@@ -77,7 +77,7 @@ final class CoreOptionsViewController: QuickTableViewController {
                                                                  values.forEach { value in
                                                                      var title = value.title
                                                                      if currentSelection == value.title {
-                                                                         title += "✔︎ "
+                                                                         title += " ✔︎"
                                                                      }
                                                                      let action = UIAlertAction(title: title, style: .default, handler: { _ in
                                                                          self.core.setValue(value.title, forOption: option)


### PR DESCRIPTION
### What does this PR do
This pull request adds spacing before the tick and removes the superfluous space after.

### Screenshots (if appropriate)
Before:
![Before](https://user-images.githubusercontent.com/2276355/82129431-0cf4ad00-97c3-11ea-8cf1-60155d33c0d4.png)

After:
![After](https://user-images.githubusercontent.com/2276355/82129432-10883400-97c3-11ea-9a0d-c0e2cc780438.png)
