### PR TITLE
Fix SwitchRow subtitles

### DIFF
--- a/Provenance/Emulator/CoreOptionsViewController.swift
+++ b/Provenance/Emulator/CoreOptionsViewController.swift
@@ -60,7 +60,8 @@ final class CoreOptionsViewController: QuickTableViewController {
             let rows: [TableRow] = $0.options.map { option in
                 switch option {
                 case let .bool(display, defaultValue):
-                    return SwitchRow(text: display.title, detailText: .none, switchValue: core.valueForOption(Bool.self, option.key) ?? defaultValue, action: { _ in
+                    let detailText: DetailText = display.description != nil ? DetailText.subtitle(display.description!) : .none
+                    return SwitchRow(text: display.title, detailText: detailText, switchValue: core.valueForOption(Bool.self, option.key) ?? defaultValue, action: { _ in
                         let value = self.core.valueForOption(Bool.self, option.key) ?? defaultValue
                         self.core.setValue(!value, forOption: option)
                     })


### PR DESCRIPTION
This pull request uses the `display.description` variable as the SwitchRow subtitle if available (like with the [.multi ](https://github.com/dnicolson/Provenance/blob/101022af9eca763583f0ca99196ef079dd4ccdb8/Provenance/Emulator/CoreOptionsViewController.swift#L68)option).

It is dependent on QuickTableViewController v1.2.2 which includes https://github.com/bcylin/QuickTableViewController/pull/45 so Carthage must be updated.

Before:
<img width="559" alt="Screen Shot 2020-05-22 at 19 15 20" src="https://user-images.githubusercontent.com/2276355/82710545-635e6180-9c83-11ea-9f97-1f7223105ddf.png">

After:
<img width="559" alt="Screen Shot 2020-05-22 at 19 14 16" src="https://user-images.githubusercontent.com/2276355/82710530-5f324400-9c83-11ea-9a54-5ee533b55b60.png">
