### PR TITLE
Fix core option sub-options

### DIFF
--- a/PVSupport/CoreOptions/CoreOptions.swift
+++ b/PVSupport/CoreOptions/CoreOptions.swift
@@ -27,27 +27,9 @@ public extension CoreOptional { // where Self:PVEmulatorCore {
         if let savedOption = UserDefaults.standard.object(forKey: key) as? T {
             return savedOption
         } else {
-            let levels = option.split(separator: ".")
-
-            var currentOptions: [CoreOption] = options
-            var foundOption: CoreOption?
-            for (i, level) in levels.enumerated() {
-                if i == levels.count - 1 {
-                    foundOption = findOption(forKey: String(level), options: currentOptions)
-                } else {
-                    if let nextSubOption = findOption(forKey: String(level), options: currentOptions) {
-                        switch nextSubOption {
-                        case let .group(_, subOptions):
-                            currentOptions = subOptions
-                        default:
-                            break
-                        }
-                    } else {
-                        break
-                    }
-                }
-            }
-            return foundOption?.defaultValue as? T
+            let currentOptions: [CoreOption] = options
+            let foundOption = findOption(forKey: option, options: currentOptions)
+            return UserDefaults.standard.object(forKey: "\(className).\(foundOption!)") as? T
         }
     }
 
@@ -93,9 +75,14 @@ public extension CoreOptional { // where Self:PVEmulatorCore {
     }
 
     static func findOption(forKey key: String, options: [CoreOption]) -> CoreOption? {
-        return options.first {
-            $0.key == key
+        var foundOption: CoreOption?
+        for option in options {
+            let subOption = option.subOptionForKey(key)
+            if subOption != nil {
+                foundOption = subOption
+            }
         }
+        return foundOption
     }
 }
 


### PR DESCRIPTION
### What does this PR do
This pull request fixes core option settings not being saved. Traversing sub-options did not work correctly and also `UserDefaults` was not called when getting sub-options.

### Where should the reviewer start
Look at how the sub-options are stored.

### How should this be manually tested
Toggle the Core Options > Mupen64Plus > HW Lighting switch.

### What are the relevant tickets
https://github.com/Provenance-Emu/Provenance/issues/1337
