### PR TITLE
Remove slider cell animation

### DIFF
--- a/Provenance/Settings/Cells/SliderCell.swift
+++ b/Provenance/Settings/Cells/SliderCell.swift
@@ -105,7 +105,7 @@ extension QuickTableViewController: SliderCellDelegate {
                 slider.maximumValue = row.valueLimits.max
                 slider.minimumValueImage = row.valueImages.min?.image
                 slider.maximumValueImage = row.valueImages.max?.image
-                slider.setValue(row.value, animated: true)
+                slider.setValue(row.value, animated: false)
             }
         }
 


### PR DESCRIPTION
### What does this PR do
This pull request removes animation of slider cell values. Slider cells animate at the moment, when scrolling occurs it looks incorrect for a slider value to suddenly change.

### How should this be manually tested
Open settings and scroll down.

### What are the relevant tickets
https://github.com/Provenance-Emu/Provenance/issues/1341