### PR TITLE
Don't call view.isHidden on unloaded view, fixes #1066.

### DIFF
--- a/Provenance/Game Library/UI/GameLaunchingViewController.swift
+++ b/Provenance/Game Library/UI/GameLaunchingViewController.swift
@@ -573,7 +573,6 @@ extension GameLaunchingViewController where Self: UIViewController {
         // Present the emulator VC
         emulatorViewController.modalTransitionStyle = .crossDissolve
         emulatorViewController.modalPresentationStyle = .fullScreen
-        emulatorViewController.glViewController.view.isHidden = saveState != nil
 
         present(emulatorViewController, animated: true) { () -> Void in
             // Open the save state after a bootup delay if the user selected one


### PR DESCRIPTION
I'm not really sure why this call is here, but removing it seems to fix
the rather strange issue #1066. Anyway, since the codePath where
`saveState == nil` doesn't ever run `view.isHidden = false` it seems
like this is an error, and I couldn't see any reason why it should be
there in the first place.

### How should this be manually tested
I've only tested this locally myself, so it would be nice to have some more testing, with different cores/games etc
### What are the relevant tickets
Fixes #1066 