### PR TITLE
Use a separate PVGameLibrary for logic stuff (part 1)

### DIFF
--- a/PVLibrary/PVLibrary.xcodeproj/project.pbxproj
+++ b/PVLibrary/PVLibrary.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		11D381FF247D9B78005594A2 /* ZipArchive.framework in Copy Framework */ = {isa = PBXBuildFile; fileRef = B3AF700721916979000FA7F9 /* ZipArchive.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		11D38200247D9BBE005594A2 /* CocoaLumberjackSwift.framework in Copy Framework */ = {isa = PBXBuildFile; fileRef = B3AF700121916978000FA7F9 /* CocoaLumberjackSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		11D38201247D9BF5005594A2 /* NSLogger.framework in Copy Framework */ = {isa = PBXBuildFile; fileRef = B3AF6FFB21916978000FA7F9 /* NSLogger.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		112E7E2F247EF3840050431C /* PVGameLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112E7E2E247EF3840050431C /* PVGameLibrary.swift */; };
+		112E7E30247EF3840050431C /* PVGameLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112E7E2E247EF3840050431C /* PVGameLibrary.swift */; };
 		B3067F4B2106B5A30091437F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3067F4A2106B5A20091437F /* Foundation.framework */; };
 		B3067F5D2106B8590091437F /* OESQLiteDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = B3579D1E2106B4D600DDEBD6 /* OESQLiteDatabase.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B3067F5E2106B8590091437F /* OESQLiteDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = B3579D202106B4D600DDEBD6 /* OESQLiteDatabase.m */; settings = {COMPILER_FLAGS = "-Wno-everything"; }; };
@@ -446,6 +448,7 @@
 
 /* Begin PBXFileReference section */
 		11D381FB247D9A82005594A2 /* RxRealm.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxRealm.framework; path = iOS/RxRealm.framework; sourceTree = "<group>"; };
+		112E7E2E247EF3840050431C /* PVGameLibrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PVGameLibrary.swift; sourceTree = "<group>"; };
 		B3067F4A2106B5A20091437F /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		B3067F732106B9130091437F /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		B3067F752106B9180091437F /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
@@ -1068,6 +1071,7 @@
 				B3579D232106B4D600DDEBD6 /* Util */,
 				B3AF460A21071CA5002211EE /* LzmaSDKObjC */,
 				B3AF47DB21072AD3002211EE /* Resources */,
+				112E7E2E247EF3840050431C /* PVGameLibrary.swift */,
 				B3579D122106B11D00DDEBD6 /* PVLibrary.h */,
 				B3579D132106B11D00DDEBD6 /* Info.plist */,
 			);
@@ -1980,6 +1984,7 @@
 				B3AF47B221071F43002211EE /* StreamUtils.cpp in Sources */,
 				B3AF47D521071FC0002211EE /* XzCrc64Reg.cpp in Sources */,
 				B3AF47B321071F43002211EE /* VirtThread.cpp in Sources */,
+				112E7E2F247EF3840050431C /* PVGameLibrary.swift in Sources */,
 				B3AF47A721071F43002211EE /* CWrappers.cpp in Sources */,
 				B3AF47A121071EE9002211EE /* HandlerOut.cpp in Sources */,
 				B3AF47CD21071FC0002211EE /* CrcReg.cpp in Sources */,
@@ -2161,6 +2166,7 @@
 				B3C04AEB21077B3100E7AF79 /* StreamUtils.cpp in Sources */,
 				B3C04AEC21077B3100E7AF79 /* XzCrc64Reg.cpp in Sources */,
 				B3C04AED21077B3100E7AF79 /* VirtThread.cpp in Sources */,
+				112E7E30247EF3840050431C /* PVGameLibrary.swift in Sources */,
 				B3C04AEE21077B3100E7AF79 /* CWrappers.cpp in Sources */,
 				B3C04AEF21077B3100E7AF79 /* HandlerOut.cpp in Sources */,
 				B3C04AF021077B3100E7AF79 /* CrcReg.cpp in Sources */,

--- a/PVLibrary/PVLibrary.xcodeproj/project.pbxproj
+++ b/PVLibrary/PVLibrary.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		112E7E2F247EF3840050431C /* PVGameLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112E7E2E247EF3840050431C /* PVGameLibrary.swift */; };
+		112E7E30247EF3840050431C /* PVGameLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112E7E2E247EF3840050431C /* PVGameLibrary.swift */; };
+		11AFB2B324867482000A3922 /* PVGameLibrary+Migration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AFB2B224867482000A3922 /* PVGameLibrary+Migration.swift */; };
+		11AFB2B424867482000A3922 /* PVGameLibrary+Migration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AFB2B224867482000A3922 /* PVGameLibrary+Migration.swift */; };
 		11D381F7247D9980005594A2 /* RxSwift.framework in Copy Framework */ = {isa = PBXBuildFile; fileRef = B3AF700621916979000FA7F9 /* RxSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		11D381F8247D9996005594A2 /* CocoaLumberjack.framework in Copy Framework */ = {isa = PBXBuildFile; fileRef = B3AF700421916979000FA7F9 /* CocoaLumberjack.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		11D381F9247D9A47005594A2 /* Realm.framework in Copy Framework */ = {isa = PBXBuildFile; fileRef = B3AF700221916978000FA7F9 /* Realm.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -16,8 +20,6 @@
 		11D381FF247D9B78005594A2 /* ZipArchive.framework in Copy Framework */ = {isa = PBXBuildFile; fileRef = B3AF700721916979000FA7F9 /* ZipArchive.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		11D38200247D9BBE005594A2 /* CocoaLumberjackSwift.framework in Copy Framework */ = {isa = PBXBuildFile; fileRef = B3AF700121916978000FA7F9 /* CocoaLumberjackSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		11D38201247D9BF5005594A2 /* NSLogger.framework in Copy Framework */ = {isa = PBXBuildFile; fileRef = B3AF6FFB21916978000FA7F9 /* NSLogger.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		112E7E2F247EF3840050431C /* PVGameLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112E7E2E247EF3840050431C /* PVGameLibrary.swift */; };
-		112E7E30247EF3840050431C /* PVGameLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112E7E2E247EF3840050431C /* PVGameLibrary.swift */; };
 		B3067F4B2106B5A30091437F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3067F4A2106B5A20091437F /* Foundation.framework */; };
 		B3067F5D2106B8590091437F /* OESQLiteDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = B3579D1E2106B4D600DDEBD6 /* OESQLiteDatabase.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B3067F5E2106B8590091437F /* OESQLiteDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = B3579D202106B4D600DDEBD6 /* OESQLiteDatabase.m */; settings = {COMPILER_FLAGS = "-Wno-everything"; }; };
@@ -447,8 +449,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		11D381FB247D9A82005594A2 /* RxRealm.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxRealm.framework; path = iOS/RxRealm.framework; sourceTree = "<group>"; };
 		112E7E2E247EF3840050431C /* PVGameLibrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PVGameLibrary.swift; sourceTree = "<group>"; };
+		11AFB2B224867482000A3922 /* PVGameLibrary+Migration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PVGameLibrary+Migration.swift"; sourceTree = "<group>"; };
+		11D381FB247D9A82005594A2 /* RxRealm.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxRealm.framework; path = iOS/RxRealm.framework; sourceTree = "<group>"; };
 		B3067F4A2106B5A20091437F /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		B3067F732106B9130091437F /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		B3067F752106B9180091437F /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
@@ -1072,6 +1075,7 @@
 				B3AF460A21071CA5002211EE /* LzmaSDKObjC */,
 				B3AF47DB21072AD3002211EE /* Resources */,
 				112E7E2E247EF3840050431C /* PVGameLibrary.swift */,
+				11AFB2B224867482000A3922 /* PVGameLibrary+Migration.swift */,
 				B3579D122106B11D00DDEBD6 /* PVLibrary.h */,
 				B3579D132106B11D00DDEBD6 /* Info.plist */,
 			);
@@ -1954,6 +1958,7 @@
 				B354E7C9219A7E470041F971 /* System.swift in Sources */,
 				B3AF478B21071E85002211EE /* Xz.c in Sources */,
 				B3AF47CF21071FC0002211EE /* MyString.cpp in Sources */,
+				11AFB2B324867482000A3922 /* PVGameLibrary+Migration.swift in Sources */,
 				B3AF47A221071EE9002211EE /* ItemNameUtils.cpp in Sources */,
 				B354E79C219A76C80041F971 /* LocalFile.swift in Sources */,
 				B3AF478121071E85002211EE /* Lzma2DecMt.c in Sources */,
@@ -2136,6 +2141,7 @@
 				B354E7CA219A7E470041F971 /* System.swift in Sources */,
 				B3C04AD521077B3100E7AF79 /* Xz.c in Sources */,
 				B3C04AD621077B3100E7AF79 /* MyString.cpp in Sources */,
+				11AFB2B424867482000A3922 /* PVGameLibrary+Migration.swift in Sources */,
 				B3C04AD721077B3100E7AF79 /* ItemNameUtils.cpp in Sources */,
 				B354E79D219A76C80041F971 /* LocalFile.swift in Sources */,
 				B3C04AD821077B3100E7AF79 /* Lzma2DecMt.c in Sources */,

--- a/PVLibrary/PVLibrary/PVGameLibrary+Migration.swift
+++ b/PVLibrary/PVLibrary/PVGameLibrary+Migration.swift
@@ -1,0 +1,156 @@
+//
+//  PVGameLibrary+Migration.swift
+//  PVLibrary
+//
+//  Created by Dan Berglund on 2020-06-02.
+//  Copyright © 2020 Provenance Emu. All rights reserved.
+//
+
+import Foundation
+import RxSwift
+import PVSupport
+
+extension PVGameLibrary {
+    public enum MigrationEvent {
+        case starting
+        case pathsToImport(paths: [URL])
+    }
+
+    public enum MigrationError: Error {
+        case unableToCreateRomsDirectory(error: Error)
+        case unableToGetContentsOfDocuments(error: Error)
+        case unableToGetRomPaths(error: Error)
+    }
+    // This method is probably outdated
+    public func migrate(fileManager: FileManager = .default) -> Observable<MigrationEvent> {
+
+        let libraryPath: String = NSSearchPathForDirectoriesInDomains(.libraryDirectory, .userDomainMask, true).first!
+        let libraryURL = URL(fileURLWithPath: libraryPath)
+        let toDelete = ["PVGame.sqlite", "PVGame.sqlite-shm", "PVGame.sqlite-wal"].map { libraryURL.appendingPathComponent($0) }
+
+        let deleteDatabase = Completable.concat(toDelete
+            .map({ path in
+                fileManager.rx
+                    .removeItem(at: path)
+                    .catchError({ error in
+                        ILOG("Unable to delete \(path) because \(error.localizedDescription)")
+                        return .empty()
+                    })
+            }))
+
+        let createDirectory = fileManager.rx
+            .createDirectory(at: PVEmulatorConfiguration.Paths.romsImportPath, withIntermediateDirectories: true, attributes: nil)
+            .catchError { .error(MigrationError.unableToCreateRomsDirectory(error: $0)) }
+
+
+        // Move everything that isn't a realm file, into the the import folder so it wil be re-imported
+        let moveFiles: Completable = fileManager.rx
+            .contentsOfDirectory(at: PVEmulatorConfiguration.documentsPath, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])
+            .catchError { Single<[URL]>.error(MigrationError.unableToGetContentsOfDocuments(error: $0)) }
+            .map({ contents -> [URL] in
+                let ignoredExtensions = ["jpg", "png", "gif", "jpeg"]
+                return contents.filter { (url) -> Bool in
+                    let dbFile = url.path.lowercased().contains("realm")
+                    let ignoredExtension = ignoredExtensions.contains(url.pathExtension)
+                    var isDir: ObjCBool = false
+                    let exists: Bool = fileManager.fileExists(atPath: url.path, isDirectory: &isDir)
+                    return exists && !dbFile && !ignoredExtension && !isDir.boolValue
+                }
+            })
+            .flatMapCompletable({ filesToMove -> Completable in
+                let moves = filesToMove
+                    .map { ($0, PVEmulatorConfiguration.Paths.romsImportPath.appendingPathComponent($0.lastPathComponent))}
+                    .map { path, toPath in
+                        fileManager.rx.moveItem(at: path, to: toPath)
+                            .catchError({ error in
+                                ELOG("Unable to move \(path.path) to \(toPath.path) because \(error.localizedDescription)")
+                                return .empty()
+                            })
+                }
+                return Completable.concat(moves)
+            })
+
+        let getRomPaths: Observable<MigrationEvent> = fileManager.rx
+            .contentsOfDirectory(at: PVEmulatorConfiguration.Paths.romsImportPath, includingPropertiesForKeys: nil, options: [.skipsSubdirectoryDescendants, .skipsHiddenFiles])
+            .catchError { Single<[URL]>.error(MigrationError.unableToGetRomPaths(error: $0)) }
+            .flatMapMaybe({ paths in
+                if paths.isEmpty {
+                    return .empty()
+                } else {
+                    return .just(.pathsToImport(paths: paths))
+                }
+            })
+            .asObservable()
+
+
+
+        return deleteDatabase
+            .andThen(createDirectory)
+            .andThen(moveFiles)
+            .andThen(getRomPaths)
+            .startWith(.starting)
+    }
+}
+
+extension PVGameLibrary.MigrationError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .unableToCreateRomsDirectory(let error):
+            return "Unable to create roms directory, error: \(error.localizedDescription)"
+        case .unableToGetContentsOfDocuments(let error):
+            return "Unable to get contents of directory, error: \(error.localizedDescription)"
+        case .unableToGetRomPaths(let error):
+            return "Unable to get rom paths, error: \(error.localizedDescription)"
+        }
+    }
+}
+
+private extension Reactive where Base: FileManager {
+    func removeItem(at path: URL) -> Completable {
+        Completable.create { observer in
+            do {
+                try self.base.removeItem(at: path)
+                observer(.completed)
+            } catch {
+                observer(.error(error))
+            }
+            return Disposables.create()
+        }
+    }
+
+    func createDirectory(at path: URL, withIntermediateDirectories: Bool, attributes: [FileAttributeKey: Any]?) -> Completable {
+        Completable.create { observer in
+            do {
+                try self.base.createDirectory(at: path, withIntermediateDirectories: withIntermediateDirectories, attributes: attributes)
+                observer(.completed)
+            } catch {
+                observer(.error(error))
+            }
+            return Disposables.create()
+        }
+    }
+
+    func contentsOfDirectory(at path: URL, includingPropertiesForKeys: [URLResourceKey]?, options: Base.DirectoryEnumerationOptions) -> Single<[URL]> {
+        Single.create { observer in
+            do {
+                let urls = try self.base.contentsOfDirectory(at: path, includingPropertiesForKeys: includingPropertiesForKeys, options: options)
+                observer(.success(urls))
+            } catch {
+                observer(.error(error))
+            }
+            return Disposables.create()
+        }
+    }
+
+    func moveItem(at path: URL, to destination: URL) -> Completable {
+        Completable.create { observer in
+            do {
+                try self.base.moveItem(at: path, to: destination)
+                observer(.completed)
+            } catch {
+                observer(.error(error))
+            }
+            return Disposables.create()
+        }
+    }
+}

--- a/PVLibrary/PVLibrary/PVGameLibrary+Migration.swift
+++ b/PVLibrary/PVLibrary/PVGameLibrary+Migration.swift
@@ -82,8 +82,6 @@ extension PVGameLibrary {
             })
             .asObservable()
 
-
-
         return deleteDatabase
             .andThen(createDirectory)
             .andThen(moveFiles)

--- a/PVLibrary/PVLibrary/PVGameLibrary.swift
+++ b/PVLibrary/PVLibrary/PVGameLibrary.swift
@@ -1,0 +1,17 @@
+//
+//  PVGameLibrary.swift
+//  PVLibrary
+//
+//  Created by Dan Berglund on 2020-05-27.
+//  Copyright © 2020 Provenance Emu. All rights reserved.
+//
+
+import Foundation
+
+public struct PVGameLibrary {
+    private let database: RomDatabase
+
+    public init(database: RomDatabase) {
+        self.database = database
+    }
+}

--- a/PVLibrary/PVLibrary/PVGameLibrary.swift
+++ b/PVLibrary/PVLibrary/PVGameLibrary.swift
@@ -27,6 +27,13 @@ public struct PVGameLibrary {
             .mapMany { $0.game }
     }
 
+    public func search(for searchText: String) -> Observable<[PVGame]> {
+        let results = self.database
+            .all(PVGame.self, filter: NSPredicate(format: "title CONTAINS[c] %@", argumentArray: [searchText]))
+            .sorted(byKeyPath: #keyPath(PVGame.title), ascending: true)
+        return Observable.collection(from: results).mapMany { $0 }
+    }
+
     public func toggleFavorite(for game: PVGame) -> Completable {
         Completable.create { observer in
             do {

--- a/PVLibrary/PVLibrary/PVGameLibrary.swift
+++ b/PVLibrary/PVLibrary/PVGameLibrary.swift
@@ -7,11 +7,26 @@
 //
 
 import Foundation
+import RxSwift
 
 public struct PVGameLibrary {
     private let database: RomDatabase
 
     public init(database: RomDatabase) {
         self.database = database
+    }
+
+    public func toggleFavorite(for game: PVGame) -> Completable {
+        Completable.create { observer in
+            do {
+                try self.database.writeTransaction {
+                    game.isFavorite = !game.isFavorite
+                    observer(.completed)
+                }
+            } catch {
+                observer(.error(error))
+            }
+            return Disposables.create()
+        }
     }
 }

--- a/Provenance.xcodeproj/project.pbxproj
+++ b/Provenance.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		1180B305248EB8C300636C8A /* UISearchController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AFB2B62487C120000A3922 /* UISearchController+Rx.swift */; };
 		11ADB31F2471A34E001C7B27 /* PVTVTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11ADB31E2471A34E001C7B27 /* PVTVTabBarController.swift */; };
 		11AFB2B72487C120000A3922 /* UISearchController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AFB2B62487C120000A3922 /* UISearchController+Rx.swift */; };
 		14C4C19F21EBADC90055C6DC /* PVTGBDual.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14C4C19E21EBADC90055C6DC /* PVTGBDual.framework */; };
@@ -1244,13 +1245,6 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		11AFB2B52487C10F000A3922 /* Categories */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Categories;
-			sourceTree = "<group>";
-		};
 		1A1237F217CA279900CEC788 /* User Interface */ = {
 			isa = PBXGroup;
 			children = (
@@ -1584,7 +1578,6 @@
 		1AD481B51BA350A400FDA50A /* ProvenanceTV */ = {
 			isa = PBXGroup;
 			children = (
-				11AFB2B52487C10F000A3922 /* Categories */,
 				B35D667D21814EAB0005A992 /* Story Boards */,
 				BE9FDCCC1C21109B0046DF0E /* Provenance.entitlements */,
 				11ADB31E2471A34E001C7B27 /* PVTVTabBarController.swift */,
@@ -2810,6 +2803,7 @@
 				B385542E20336D02006CA50B /* PVGameMoreInfoViewController.swift in Sources */,
 				B36D9DFD203605BC00D583C4 /* PVCoreFactory.swift in Sources */,
 				378F4A0C1B63D7CD0065FA39 /* GCDWebServerStreamedResponse.m in Sources */,
+				1180B305248EB8C300636C8A /* UISearchController+Rx.swift in Sources */,
 				B3890BF420B995A9005BB001 /* PVGameLibraryViewController+CollectionView.swift in Sources */,
 				B302F31421713AFD000322B9 /* CenterFlowLayout.swift in Sources */,
 			);

--- a/Provenance.xcodeproj/project.pbxproj
+++ b/Provenance.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 
 /* Begin PBXBuildFile section */
 		11ADB31F2471A34E001C7B27 /* PVTVTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11ADB31E2471A34E001C7B27 /* PVTVTabBarController.swift */; };
+		11AFB2B72487C120000A3922 /* UISearchController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AFB2B62487C120000A3922 /* UISearchController+Rx.swift */; };
 		14C4C19F21EBADC90055C6DC /* PVTGBDual.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14C4C19E21EBADC90055C6DC /* PVTGBDual.framework */; };
 		14C4C1A021EBADC90055C6DC /* PVTGBDual.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 14C4C19E21EBADC90055C6DC /* PVTGBDual.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		14C4C1A121EBB0040055C6DC /* PVTGBDual.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14C8EF2121D9443E001B7E37 /* PVTGBDual.framework */; };
@@ -691,6 +692,7 @@
 
 /* Begin PBXFileReference section */
 		11ADB31E2471A34E001C7B27 /* PVTVTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PVTVTabBarController.swift; sourceTree = "<group>"; };
+		11AFB2B62487C120000A3922 /* UISearchController+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UISearchController+Rx.swift"; sourceTree = "<group>"; };
 		14C4C19E21EBADC90055C6DC /* PVTGBDual.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PVTGBDual.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		14C8EF2121D9443E001B7E37 /* PVTGBDual.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PVTGBDual.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1A0938B917CD45D400029021 /* README.mdown */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README.mdown; sourceTree = SOURCE_ROOT; };
@@ -1242,6 +1244,13 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		11AFB2B52487C10F000A3922 /* Categories */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Categories;
+			sourceTree = "<group>";
+		};
 		1A1237F217CA279900CEC788 /* User Interface */ = {
 			isa = PBXGroup;
 			children = (
@@ -1553,6 +1562,7 @@
 		1AADCDB117BD997500F53CFE /* Categories */ = {
 			isa = PBXGroup;
 			children = (
+				11AFB2B62487C120000A3922 /* UISearchController+Rx.swift */,
 				1A3FD78C1AC7744100F8C23C /* MBProgressHUD.h */,
 				1A3FD78D1AC7744100F8C23C /* MBProgressHUD.m */,
 				1AADCDB217BD998A00F53CFE /* UIActionSheet+BlockAdditions.h */,
@@ -1574,6 +1584,7 @@
 		1AD481B51BA350A400FDA50A /* ProvenanceTV */ = {
 			isa = PBXGroup;
 			children = (
+				11AFB2B52487C10F000A3922 /* Categories */,
 				B35D667D21814EAB0005A992 /* Story Boards */,
 				BE9FDCCC1C21109B0046DF0E /* Provenance.entitlements */,
 				11ADB31E2471A34E001C7B27 /* PVTVTabBarController.swift */,
@@ -2900,6 +2911,7 @@
 				B3589E32219E8C5B001C5E12 /* LogViewable.swift in Sources */,
 				B3D5E2B1218EC1AE0015C690 /* Reactive+RxRealmDataSources.swift in Sources */,
 				11ADB31F2471A34E001C7B27 /* PVTVTabBarController.swift in Sources */,
+				11AFB2B72487C120000A3922 /* UISearchController+Rx.swift in Sources */,
 				B3B104C5218F2EF400210C39 /* PVDreamcastControllerViewController.swift in Sources */,
 				B3B104CE218F2EF400210C39 /* PVPCFXControllerViewController.swift in Sources */,
 				B3D5E2B3218EC1AE0015C690 /* RxTableViewRealmDataSource.swift in Sources */,

--- a/Provenance/Categories/UISearchController+Rx.swift
+++ b/Provenance/Categories/UISearchController+Rx.swift
@@ -1,0 +1,40 @@
+//
+//  UISearchController+Rx.swift
+//  ProvenanceTV
+//
+//  Created by Dan Berglund on 2020-06-03.
+//  Copyright © 2020 Provenance Emu. All rights reserved.
+//
+
+import Foundation
+import RxSwift
+import RxCocoa
+
+private class RxUISearchResultsUpdating: DelegateProxy<UISearchController, UISearchResultsUpdating>, DelegateProxyType, UISearchResultsUpdating {
+    static func registerKnownImplementations() {
+        self.register(make: { RxUISearchResultsUpdating.init(parentObject: $0, delegateProxy: RxUISearchResultsUpdating.self) })
+    }
+
+    static func currentDelegate(for object: UISearchController) -> UISearchResultsUpdating? {
+        return object.searchResultsUpdater
+    }
+
+    static func setCurrentDelegate(_ delegate: UISearchResultsUpdating?, to object: UISearchController) {
+        object.searchResultsUpdater = delegate
+    }
+
+    fileprivate var updates = PublishSubject<UISearchController>()
+    func updateSearchResults(for searchController: UISearchController) {
+        updates.onNext(searchController)
+    }
+}
+
+extension Reactive where Base: UISearchController {
+    private var searchResultsUpdating: RxUISearchResultsUpdating {
+        RxUISearchResultsUpdating.proxy(for: base)
+    }
+    var searchText: Observable<String> {
+        searchResultsUpdating.updates
+            .compactMap { $0.searchBar.text }
+    }
+}

--- a/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
+++ b/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
@@ -62,6 +62,7 @@ final class PVGameLibraryViewController: UIViewController, UITextFieldDelegate, 
     lazy var collectionViewZoom: CGFloat = CGFloat(PVSettingsModel.shared.gameLibraryScale)
 
     let disposeBag = DisposeBag()
+    var gameLibrary: PVGameLibrary!
     var watcher: DirectoryWatcher?
     var gameImporter: GameImporter!
     var filePathsToImport = [URL]()
@@ -1890,19 +1891,13 @@ final class PVGameLibraryViewController: UIViewController, UITextFieldDelegate, 
     }
 
     func toggleFavorite(for game: PVGame) {
-        do {
-            try RomDatabase.sharedInstance.writeTransaction {
-                game.isFavorite = !game.isFavorite
-            }
-
-            register3DTouchShortcuts()
-
-            DispatchQueue.main.async {
+        gameLibrary.toggleFavorite(for: game)
+            .subscribe(onCompleted: {
                 self.collectionView?.reloadData()
-            }
-        } catch {
-            ELOG("Failed to toggle Favourite for game \(game.title)")
-        }
+            }, onError: { error in
+                ELOG("Failed to toggle Favourite for game \(game.title)")
+            })
+            .disposed(by: disposeBag)
     }
 
     func moreInfo(for game: PVGame) {

--- a/Provenance/Game Library/UI/GameLaunchingViewController.swift
+++ b/Provenance/Game Library/UI/GameLaunchingViewController.swift
@@ -37,7 +37,6 @@ public protocol GameLaunchingViewController: class {
     func load(_ game: PVGame, sender: Any?, core: PVCore?, saveState: PVSaveState?)
     func openSaveState(_ saveState: PVSaveState)
     func updateRecentGames(_ game: PVGame)
-    func register3DTouchShortcuts()
     func presentCoreSelection(forGame game: PVGame, sender: Any?)
 }
 
@@ -755,8 +754,6 @@ extension GameLaunchingViewController where Self: UIViewController {
                 ELOG("Failed to create Recent Game entry. \(error.localizedDescription)")
             }
         }
-
-        register3DTouchShortcuts()
     }
 
     func openSaveState(_ saveState: PVSaveState) {
@@ -782,46 +779,6 @@ extension GameLaunchingViewController where Self: UIViewController {
             }
         } else {
             presentWarning("No core loaded")
-        }
-    }
-
-    func register3DTouchShortcuts() {
-        if #available(iOS 9.0, *) {
-            #if os(iOS)
-                // Add 3D touch shortcuts to recent games
-                var shortcuts = [UIApplicationShortcutItem]()
-
-                let database = RomDatabase.sharedInstance
-
-                let favorites = database.all(PVGame.self, where: #keyPath(PVGame.isFavorite), value: true)
-                for game in favorites {
-                    let icon: UIApplicationShortcutIcon?
-                    if #available(iOS 9.1, *) {
-                        icon = UIApplicationShortcutIcon(type: .favorite)
-                    } else {
-                        icon = UIApplicationShortcutIcon(type: .play)
-                    }
-
-                    let shortcut = UIApplicationShortcutItem(type: "kRecentGameShortcut", localizedTitle: game.title, localizedSubtitle: PVEmulatorConfiguration.name(forSystemIdentifier: game.systemIdentifier), icon: icon, userInfo: ["PVGameHash": game.md5Hash as NSSecureCoding])
-                    shortcuts.append(shortcut)
-                }
-
-                let sortedRecents: Results<PVRecentGame> = database.all(PVRecentGame.self).sorted(byKeyPath: #keyPath(PVRecentGame.lastPlayedDate), ascending: false)
-
-                for recentGame in sortedRecents {
-                    if let game = recentGame.game {
-                        let icon: UIApplicationShortcutIcon?
-                        icon = UIApplicationShortcutIcon(type: .play)
-
-                        let shortcut = UIApplicationShortcutItem(type: "kRecentGameShortcut", localizedTitle: game.title, localizedSubtitle: PVEmulatorConfiguration.name(forSystemIdentifier: game.systemIdentifier), icon: icon, userInfo: ["PVGameHash": game.md5Hash as NSSecureCoding])
-                        shortcuts.append(shortcut)
-                    }
-                }
-
-                UIApplication.shared.shortcutItems = shortcuts
-            #endif
-        } else {
-            // Fallback on earlier versions
         }
     }
 }

--- a/Provenance/PVAppDelegate.swift
+++ b/Provenance/PVAppDelegate.swift
@@ -88,16 +88,10 @@ final class PVAppDelegate: UIResponder, UIApplicationDelegate {
 
         #if os(tvOS)
             if let tabBarController = window?.rootViewController as? UITabBarController {
-                let flowLayout = UICollectionViewFlowLayout()
-                flowLayout.sectionInset = UIEdgeInsets(top: 20, left: 0, bottom: 20, right: 0)
-                let searchViewController = PVSearchViewController(collectionViewLayout: flowLayout, gameLibrary: gameLibrary)
-                let searchController = UISearchController(searchResultsController: searchViewController)
-                searchController.searchResultsUpdater = searchViewController
-                let searchContainerController = UISearchContainerViewController(searchController: searchController)
-                searchContainerController.title = "Search"
-                let navController = UINavigationController(rootViewController: searchContainerController)
+                let searchNavigationController = PVSearchViewController.createEmbeddedInNavigationController(gameLibrary: gameLibrary)
+
                 var viewControllers = tabBarController.viewControllers!
-                viewControllers.insert(navController, at: 1)
+                viewControllers.insert(searchNavigationController, at: 1)
                 tabBarController.viewControllers = viewControllers
             }
         #else

--- a/Provenance/PVAppDelegate.swift
+++ b/Provenance/PVAppDelegate.swift
@@ -63,6 +63,8 @@ final class PVAppDelegate: UIResponder, UIApplicationDelegate {
             return true
         }
 
+        let gameLibrary = PVGameLibrary(database: RomDatabase.sharedInstance)
+
         #if os(iOS)
             if #available(iOS 9.0, *) {
                 if let shortcut = launchOptions?[.shortcutItem] as? UIApplicationShortcutItem, shortcut.type == "kRecentGameShortcut", let md5Value = shortcut.userInfo?["PVGameHash"] as? String, let matchedGame = ((try? Realm().object(ofType: PVGame.self, forPrimaryKey: md5Value)) as PVGame??) {
@@ -75,7 +77,7 @@ final class PVAppDelegate: UIResponder, UIApplicationDelegate {
             if let tabBarController = window?.rootViewController as? UITabBarController {
                 let flowLayout = UICollectionViewFlowLayout()
                 flowLayout.sectionInset = UIEdgeInsets(top: 20, left: 0, bottom: 20, right: 0)
-                let searchViewController = PVSearchViewController(collectionViewLayout: flowLayout)
+                let searchViewController = PVSearchViewController(collectionViewLayout: flowLayout, gameLibrary: gameLibrary)
                 let searchController = UISearchController(searchResultsController: searchViewController)
                 searchController.searchResultsUpdater = searchViewController
                 let searchContainerController = UISearchContainerViewController(searchController: searchController)
@@ -90,6 +92,17 @@ final class PVAppDelegate: UIResponder, UIApplicationDelegate {
 //        Theme.currentTheme = currentTheme.theme
             Theme.currentTheme = Theme.darkTheme
         #endif
+
+
+        #if os(iOS)
+        let rootNavigation = window!.rootViewController as! UINavigationController
+        #else
+        let rootNavigation = (window!.rootViewController as! UITabBarController).viewControllers![0] as! UINavigationController
+        #endif
+        let gameLibraryViewController = rootNavigation.viewControllers[0] as! PVGameLibraryViewController
+
+        // Would be nice to inject this in a better way, so that we can be certain that it's present at viewDidLoad for PVGameLibraryViewController, but this works for now
+        gameLibraryViewController.gameLibrary = gameLibrary
 
         startOptionalWebDavServer()
 

--- a/ProvenanceTV/PVSearchViewController.swift
+++ b/ProvenanceTV/PVSearchViewController.swift
@@ -55,6 +55,7 @@ final class PVSearchViewController: UICollectionViewController, GameLaunchingVie
 
         let sections: Observable<[Section]> = searchController
             .rx.searchText
+            .compactMap { $0 }
             .flatMap { self.gameLibrary.search(for: $0) }
             .map { games in [Section(items: games)] }
 


### PR DESCRIPTION
### What does this PR do
This PR moves some stuff from VC:s (GameLibraryVC and SearchVC) into a GameLibrary struct, refactoring it to reuse code and make the VC:s more manageable.

The idea is to move even more stuff to `PVGameLibrary` so that the VC:s can focus on presenting stuff, instead of having a lot of logic inside them.

This also uses `RxRealm` and `RxDataSources` in `PVSearchVC`, to avoid having to deal with tokens etc.

### How should this be manually tested
Functionality should be intact, so it should work as before.

### Any background context you want to provide
We should probably discuss if this is the correct way to go, I think so, and think going this way will help us solve a bunch of synchronization-issues, while making the code easier to reason about.
Expanding this for the whole `PVGameLibraryVC` would probably solve #1068 for instance.