### PR TITLE
Fix search field after orientation change

### DIFF
--- a/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
+++ b/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
@@ -243,6 +243,7 @@ final class PVGameLibraryViewController: UIViewController, UITextFieldDelegate, 
 
                 // Navigation bar large titles
                 navigationController?.navigationBar.prefersLargeTitles = false
+                navigationController?.navigationBar.translatesAutoresizingMaskIntoConstraints = false
                 navigationItem.title = nil
 
                 // Create a search controller
@@ -250,7 +251,7 @@ final class PVGameLibraryViewController: UIViewController, UITextFieldDelegate, 
                 searchController.searchBar.placeholder = "Search"
                 searchController.searchResultsUpdater = self
                 searchController.obscuresBackgroundDuringPresentation = false
-                searchController.hidesNavigationBarDuringPresentation = true
+                searchController.hidesNavigationBarDuringPresentation = false
 
                 searchController.delegate = self
                 navigationItem.hidesSearchBarWhenScrolling = true


### PR DESCRIPTION
### What does this PR do
This pull request prevents the search text field from collapsing after changing orientation.

### How should this be manually tested
Change orientation from landscape to portrait.

### What are the relevant tickets
https://github.com/Provenance-Emu/Provenance/issues/1379

### Screenshots (important for UI changes)
The search field will no longer appear as this:
<img width="280" alt="Screen Shot 2020-06-15 at 20 34 20" src="https://user-images.githubusercontent.com/2276355/84798884-c382c200-affb-11ea-8d8a-22d2ea1587fa.png">
