### PR TITLE
Fix corner badge after orientation change

### DIFF
--- a/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
+++ b/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
@@ -1056,6 +1056,8 @@ final class PVGameLibraryViewController: UIViewController, UITextFieldDelegate, 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
 
+        collectionView?.reloadData()
+        
         transitioningToSize = size
         collectionView?.collectionViewLayout.invalidateLayout()
         if #available(iOS 10.0, *) {


### PR DESCRIPTION
### What does this PR do
This pull request fixes the alignment of the right corner badge after changing orientation.

### How should this be manually tested
Change orientation from landscape to portrait.

### Screenshots (important for UI changes)
Before:
<img width="270" alt="Screen Shot 2020-06-16 at 17 55 41" src="https://user-images.githubusercontent.com/2276355/84799458-9551b200-affc-11ea-8c7b-f99d7bfe2aa8.png">

After:
<img width="292" alt="Screen Shot 2020-06-16 at 17 56 13" src="https://user-images.githubusercontent.com/2276355/84799466-971b7580-affc-11ea-840e-d5c973113f78.png">
