### PR TITLE
Handle updates to game-library outside of PVGameLibraryViewController

### DIFF
--- a/Provenance.xcodeproj/project.pbxproj
+++ b/Provenance.xcodeproj/project.pbxproj
@@ -54,6 +54,8 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		1180B3242492AFC900636C8A /* PVGameLibraryUpdatesController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1180B3232492AFC900636C8A /* PVGameLibraryUpdatesController.swift */; };
+		11A8A9E72496A3E500C1C6B4 /* PVGameLibraryUpdatesController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1180B3232492AFC900636C8A /* PVGameLibraryUpdatesController.swift */; };
 		11ADB31F2471A34E001C7B27 /* PVTVTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11ADB31E2471A34E001C7B27 /* PVTVTabBarController.swift */; };
 		14C4C19F21EBADC90055C6DC /* PVTGBDual.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14C4C19E21EBADC90055C6DC /* PVTGBDual.framework */; };
 		14C4C1A021EBADC90055C6DC /* PVTGBDual.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 14C4C19E21EBADC90055C6DC /* PVTGBDual.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -690,6 +692,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1180B3232492AFC900636C8A /* PVGameLibraryUpdatesController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PVGameLibraryUpdatesController.swift; sourceTree = "<group>"; };
 		11ADB31E2471A34E001C7B27 /* PVTVTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PVTVTabBarController.swift; sourceTree = "<group>"; };
 		14C4C19E21EBADC90055C6DC /* PVTGBDual.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PVTGBDual.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		14C8EF2121D9443E001B7E37 /* PVTGBDual.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PVTGBDual.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1892,6 +1895,7 @@
 		B3DBF13A2094669A005935A8 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				1180B3232492AFC900636C8A /* PVGameLibraryUpdatesController.swift */,
 				B3D5E2A9218EC1970015C690 /* RxRealmDataSources */,
 				B3E6DADA20B7AD1500454DD4 /* PVLogViewController.h */,
 				B3E6DADB20B7AD1500454DD4 /* PVLogViewController.m */,
@@ -2741,6 +2745,7 @@
 				B3B923B0202D2EAE00580FFC /* Theme.swift in Sources */,
 				B3AB37342187F569009D9244 /* PVGBControllerViewController.swift in Sources */,
 				B3532C3C21A9AC93006CDA0F /* Services.swift in Sources */,
+				1180B3242492AFC900636C8A /* PVGameLibraryUpdatesController.swift in Sources */,
 				B3AB37382187F569009D9244 /* PVGBAControllerViewController.swift in Sources */,
 				1A5665091D96A18A006EAE01 /* UIDevice+Hardware.m in Sources */,
 				B36D9DF8203562E000D583C4 /* PVControllerViewController.swift in Sources */,
@@ -2824,6 +2829,7 @@
 				B31117B0218EB3A900C495A2 /* PVEmulatorViewController.swift in Sources */,
 				1AD481E51BA3546600FDA50A /* PVGLViewController.m in Sources */,
 				B369B0DD21A3BF7C0064EDCA /* PVSettingsViewController.swift in Sources */,
+				11A8A9E72496A3E500C1C6B4 /* PVGameLibraryUpdatesController.swift in Sources */,
 				B354E7C3219A7D630041F971 /* SystemSettingsHeaderCell.swift in Sources */,
 				B349AF641E9ABCFA00ACD416 /* (null) in Sources */,
 				B349AE8C1E9ABCF900ACD416 /* (null) in Sources */,

--- a/Provenance/Game Library/UI/PVConflictViewController.swift
+++ b/Provenance/Game Library/UI/PVConflictViewController.swift
@@ -10,19 +10,25 @@
 import PVLibrary
 import PVSupport
 import UIKit
+import RxSwift
+import RxDataSources
 
 final class PVConflictViewController: UITableViewController {
-    var gameImporter: GameImporter?
-    var conflictedFiles: [URL] = [URL]()
+    let conflictsController: ConflictsController
+    private let disposeBag = DisposeBag()
 
-    init(gameImporter: GameImporter) {
+    init(conflictsController: ConflictsController) {
+        self.conflictsController = conflictsController
         super.init(style: .plain)
-
-        self.gameImporter = gameImporter
     }
 
     required init?(coder _: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    enum Row {
+        case conflict(ConflictsController.Conflict)
+        case empty(title: String)
     }
 
     override func viewDidLoad() {
@@ -34,11 +40,63 @@ final class PVConflictViewController: UITableViewController {
             tableView = SettingsTableView(frame: currentTableview.frame, style: currentTableview.style)
 
             title = "Solve Conflicts"
-            if !conflictedFiles.isEmpty {
-                tableView.separatorColor = UIColor.clear
-            }
+            tableView.separatorColor = UIColor.clear
         #endif
-        updateConflictedFiles()
+
+        let cellIdentifier = "Cell"
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: cellIdentifier)
+
+        let rows = conflictsController.conflicts
+            .map({ conflicts -> [Row] in
+                if conflicts.isEmpty {
+                    return [.empty(title: ""), .empty(title: ""), .empty(title: "No Conflicts...")]
+                } else {
+                    return conflicts.map { .conflict($0) }
+                }
+            })
+
+        rows.bind(to: tableView.rx.items(cellIdentifier: cellIdentifier, cellType: UITableViewCell.self)) { _, row, cell in
+            switch row {
+            case .conflict(let conflict):
+                cell.textLabel?.text = conflict.path.deletingPathExtension().lastPathComponent
+                cell.accessoryType = .disclosureIndicator
+            case .empty(let title):
+                cell.textLabel?.text = title
+                cell.textLabel?.textAlignment = .center
+                cell.accessoryType = .none
+            }
+
+            #if os(iOS)
+                cell.textLabel?.textColor = Theme.currentTheme.settingsCellText
+            #endif
+        }
+        .disposed(by: disposeBag)
+
+        tableView.rx.itemSelected
+            .do(onNext: { self.tableView.deselectRow(at: $0, animated: true) })
+            .compactMap({ indexPath -> (ConflictsController.Conflict, IndexPath)? in
+                let row: Row = try self.tableView.rx.model(at: indexPath)
+                switch row {
+                case .conflict(let conflict):
+                    return (conflict, indexPath)
+                case .empty:
+                    return nil
+                }
+            })
+            .bind(onNext: { conflict, indexPath in
+                let alertController = UIAlertController(title: "Choose a System", message: nil, preferredStyle: .actionSheet)
+                alertController.popoverPresentationController?.sourceView = self.view
+                alertController.popoverPresentationController?.sourceRect = self.tableView.rectForRow(at: indexPath)
+                conflict.candidates.forEach { system in
+                    alertController.addAction(.init(title: system.name, style: .default, handler: { _ in
+                        self.conflictsController.resolveConflicts(withSolutions: [conflict.path: system])
+                    }))
+                }
+
+                alertController.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+                self.present(alertController, animated: true) { () -> Void in }
+            })
+            .disposed(by: disposeBag)
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -52,132 +110,15 @@ final class PVConflictViewController: UITableViewController {
         dismiss(animated: true) { () -> Void in }
     }
 
-    func updateConflictedFiles() {
-        guard let filesInConflictsFolder = gameImporter?.conflictedFiles else {
-            conflictedFiles = [URL]()
-            return
-        }
-
-        var tempConflictedFiles = [URL]()
-        for file: URL in filesInConflictsFolder {
-            let ext: String = file.pathExtension.lowercased()
-            if let systems = PVEmulatorConfiguration.systemIdentifiers(forFileExtension: ext), systems.count > 1 {
-                tempConflictedFiles.append(file)
-            }
-        }
-
-        conflictedFiles = tempConflictedFiles
-    }
-
-    lazy var documentsPath: URL = PVEmulatorConfiguration.documentsPath
-    lazy var conflictsPath: URL = PVEmulatorConfiguration.documentsPath.appendingPathComponent("conflicts", isDirectory: true)
-
-    #if TARGET_OS_TV
-        override func tableView(_: UITableView, canFocusRowAt indexPath: IndexPath) -> Bool {
-            if conflictedFiles.isEmpty {
-                if indexPath.row == 2 {
-                    return true
-                }
+    #if os(tvOS)
+        override func tableView(_ tableView: UITableView, canFocusRowAt indexPath: IndexPath) -> Bool {
+            let row: Row = try! tableView.rx.model(at: indexPath)
+            switch row {
+            case .conflict:
+                return true
+            case .empty:
                 return false
             }
-            return true
         }
-
     #endif
-    override func numberOfSections(in _: UITableView) -> Int {
-        return 1
-    }
-
-    override func tableView(_: UITableView, numberOfRowsInSection _: Int) -> Int {
-        if !conflictedFiles.isEmpty {
-            return conflictedFiles.count
-        }
-        return 3
-    }
-
-    override func tableView(_: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell: UITableViewCell
-
-        if conflictedFiles.isEmpty {
-            cell = tableView.dequeueReusableCell(withIdentifier: "EmptyCell") ?? UITableViewCell(style: .default, reuseIdentifier: "EmptyCell")
-            cell.textLabel?.textAlignment = .center
-            if indexPath.row == 0 || indexPath.row == 1 {
-                cell.textLabel?.text = ""
-            } else {
-                cell.textLabel?.text = "No Conflicts..."
-            }
-        } else {
-            cell = tableView.dequeueReusableCell(withIdentifier: "Cell") ?? UITableViewCell(style: .default, reuseIdentifier: "Cell")
-
-            let file = conflictedFiles[indexPath.row]
-            let name: String = file.deletingPathExtension().lastPathComponent
-            cell.textLabel?.text = name
-            cell.accessoryType = .disclosureIndicator
-        }
-
-        #if os(iOS)
-            cell.textLabel?.textColor = Theme.currentTheme.settingsCellText
-        #endif
-        return cell
-    }
-
-    override func tableView(_: UITableView, didSelectRowAt indexPath: IndexPath) {
-        if let aRow = self.tableView.indexPathForSelectedRow {
-            tableView.deselectRow(at: aRow, animated: true)
-        }
-
-        if conflictedFiles.isEmpty {
-            return
-        }
-
-        let path = conflictedFiles[indexPath.row]
-        let alertController = UIAlertController(title: "Choose a System", message: nil, preferredStyle: .actionSheet)
-        alertController.popoverPresentationController?.sourceView = view
-        alertController.popoverPresentationController?.sourceRect = tableView.rectForRow(at: indexPath)
-
-        // This should be a better query, testing - jm
-        //		PVSystem.all.filter("supportedExtensions CONTAINS[cd] %@",  path.pathExtension ).forEach { system in
-        //			let name: String = system.name
-        //			alertController.addAction(UIAlertAction(title: name, style: .default, handler: {(_ action: UIAlertAction) -> Void in
-        //				self.gameImporter?.resolveConflicts(withSolutions: [path: system])
-        //				// This update crashes since we remove for me on aTV.
-        //				//                [self.tableView beginUpdates];
-        //				//                [self.tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationTop];
-        //				self.updateConflictedFiles()
-        //				self.tableView.reloadData()
-        //				//                [self.tableView endUpdates];
-        //			}))
-        //		}
-
-        PVSystem.all.filter({ $0.supportedExtensions.contains(path.pathExtension) }).forEach { system in
-            let name: String = system.name
-            alertController.addAction(UIAlertAction(title: name, style: .default, handler: { (_: UIAlertAction) -> Void in
-                self.gameImporter?.resolveConflicts(withSolutions: [path: system.asDomain()])
-                // This update crashes since we remove for me on aTV.
-                //                [self.tableView beginUpdates];
-                //                [self.tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationTop];
-                self.updateConflictedFiles()
-                self.tableView.reloadData()
-                //                [self.tableView endUpdates];
-            }))
-        }
-
-//        PVSystem.all.forEach { system in
-//            if system.supportedExtensions.contains(path.pathExtension) {
-//                let name: String = system.name
-//                alertController.addAction(UIAlertAction(title: name, style: .default, handler: {(_ action: UIAlertAction) -> Void in
-//                    self.gameImporter?.resolveConflicts(withSolutions: [path: system])
-//                    // This update crashes since we remove for me on aTV.
-//                    //                [self.tableView beginUpdates];
-//                    //                [self.tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationTop];
-//                    self.updateConflictedFiles()
-//                    self.tableView.reloadData()
-//                    //                [self.tableView endUpdates];
-//                }))
-//            }
-//        }
-
-        alertController.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
-        present(alertController, animated: true) { () -> Void in }
-    }
 }

--- a/Provenance/Utilities/PVGameLibraryUpdatesController.swift
+++ b/Provenance/Utilities/PVGameLibraryUpdatesController.swift
@@ -1,0 +1,277 @@
+//
+//  PVGameLibraryUpdatesController.swift
+//  Provenance
+//
+//  Created by Dan Berglund on 2020-06-11.
+//  Copyright © 2020 Provenance Emu. All rights reserved.
+//
+
+import Foundation
+import PVSupport
+import PVLibrary
+import RxSwift
+import RxCocoa
+import CoreSpotlight
+
+protocol ConflictsController {
+    typealias Conflict = (path: URL, candidates: [System])
+    var conflicts: Observable<[Conflict]> { get }
+    func resolveConflicts(withSolutions: [URL: System])
+}
+
+// Responsible for handling updates to game library, finding conflicts and resolving them
+struct PVGameLibraryUpdatesController {
+    public let hudState: Observable<HudState>
+    public let conflicts: Observable<[Conflict]>
+
+    private let gameImporter: GameImporter
+    private let gameImporterEvents: Observable<GameImporter.Event>
+    private let updateConflicts = PublishSubject<Void>()
+
+    enum HudState {
+        case hidden
+        case title(String)
+        case titleAndProgress(title: String, progress: Float)
+    }
+
+    // TODO: Would be nice to inject the DirectoryWatcher as well
+    init(gameImporter: GameImporter, importPath: URL = PVEmulatorConfiguration.Paths.romsImportPath, scheduler: SchedulerType = MainScheduler.asyncInstance) {
+        self.gameImporter = gameImporter
+        #warning("FIXME: Why do we need Reactive here?")
+        self.gameImporterEvents = Reactive(gameImporter).events.share()
+
+        let directoryWatcher = RxDirectoryWatcher(directory: importPath)
+        let directoryWatcherExtractedFiles = directoryWatcher.events.debug("🚨 directoryWatcher2").finishedExtracting(at: importPath)
+
+        let initialScan: Observable<[URL]> = gameImporterEvents
+            .filter { $0 == .initialized }
+            .map { _ in try FileManager.default.contentsOfDirectory(at: PVEmulatorConfiguration.Paths.romsImportPath, includingPropertiesForKeys: nil, options: [.skipsPackageDescendants, .skipsSubdirectoryDescendants])}
+            .filter { !$0.isEmpty }
+
+        let filesToImport = Observable.merge(initialScan, directoryWatcherExtractedFiles)
+
+        // We use a hacky combineLatest here since we need to do the bind to `gameImporter.startImport` somewhere, so we hack it into the hudState definition
+        hudState = Observable.combineLatest(
+            Self.hudState(from: directoryWatcher, gameImporterEvents: gameImporterEvents, scheduler: scheduler),
+            filesToImport.do(onNext: gameImporter.startImport)
+        ) { hudState, _ in hudState }
+
+        let gameImporterConflicts = gameImporterEvents
+            .compactMap({ event -> Void? in
+                if case .completed = event {
+                    return ()
+                }
+                return nil
+            })
+
+        let systemDirsConflicts = Observable.just(PVSystem.all.map { $0 })
+            .map({ systems -> [(System, [URL])] in
+                systems
+                    .map { $0.asDomain() }
+                    .compactMap { system in
+                        guard let candidates = FileManager.default.candidateROMs(for: system) else { return nil }
+                        return (system, candidates)
+                }
+            })
+            .flatMap({ systems -> Observable<Void> in
+                Observable.concat(systems.map { system, paths in
+                    Observable.create { observer in
+                        gameImporter.getRomInfoForFiles(atPaths: paths, userChosenSystem: system)
+                        observer.onCompleted()
+                        return Disposables.create()
+                    }
+                })
+            })
+
+        let potentialConflicts = Observable.merge(gameImporterConflicts, systemDirsConflicts, updateConflicts).startWith(())
+
+        conflicts = potentialConflicts
+            .map { gameImporter.conflictedFiles ?? [] }
+            .map({ filesInConflictsFolder -> [Conflict] in
+                filesInConflictsFolder.map { file in
+                    (
+                        path: file,
+                        candidates: PVSystem.all.filter { $0.supportedExtensions.contains(file.pathExtension.lowercased() )}.map { $0.asDomain() }
+                    )
+                }
+            })
+            .map { conflicts in conflicts.filter { !$0.candidates.isEmpty }}
+            .share(replay: 1, scope: .forever)
+    }
+
+    #if os(iOS)
+    func addImportedGames(to spotlightIndex: CSSearchableIndex, database: RomDatabase) -> Disposable {
+        gameImporterEvents
+            .compactMap({ event -> String? in
+                if case .finished(let md5, _) = event {
+                    return md5
+                }
+                return nil
+            })
+            .compactMap { database.realm.object(ofType: PVGame.self, forPrimaryKey: $0) }
+            .map { game in CSSearchableItem(uniqueIdentifier: game.spotlightUniqueIdentifier, domainIdentifier: "com.provenance-emu.game", attributeSet: game.spotlightContentSet) }
+            .observeOn(SerialDispatchQueueScheduler(qos: .background))
+            .subscribe(onNext: { item in
+                spotlightIndex.indexSearchableItems([item]) { error in
+                    if let error = error {
+                        ELOG("indexing error: \(error)")
+                    }
+                }
+            })
+    }
+    #endif
+
+    private static func hudState(from directoryWatcher: RxDirectoryWatcher, gameImporterEvents: Observable<GameImporter.Event>, scheduler: SchedulerType) -> Observable<HudState> {
+        let stateFromGameImporter = gameImporterEvents
+            .compactMap({ event -> HudState? in
+                switch event {
+                case .initialized, .finishedArtwork, .completed:
+                    return nil
+                case .started(let path):
+                    return .title("Importing: \(path.lastPathComponent)")
+                case .finished:
+                    return .hidden
+                }
+            })
+
+        func labelMaker(_ path: URL) -> String {
+            #if os(tvOS)
+            return "Extracting Archive: \(path.lastPathComponent)"
+            #else
+            return "Extracting Archive..."
+            #endif
+        }
+
+        let stateFromDirectoryWatcher = directoryWatcher.events
+            .flatMap({ event -> Observable<HudState> in
+                switch event {
+                case .started(let path):
+                    return .just(.titleAndProgress(title: labelMaker(path), progress: 0))
+                case .updated(let path, let progress):
+                    return .just(.titleAndProgress(title: labelMaker(path), progress: progress))
+                case .completed(let paths):
+                    return Observable.merge(
+                        .just(.titleAndProgress(title: paths != nil ? "Extraction Complete!" : "Extraction Failed.", progress: 1)),
+                        Observable.just(.hidden).delay(.milliseconds(500), scheduler: scheduler)
+                    )
+                }
+            })
+
+        return Observable.merge(stateFromGameImporter, stateFromDirectoryWatcher)
+    }
+}
+
+extension PVGameLibraryUpdatesController: ConflictsController {
+    func resolveConflicts(withSolutions solutions: [URL : System]) {
+        gameImporter.resolveConflicts(withSolutions: solutions)
+        updateConflicts.onNext(())
+    }
+}
+
+private extension Observable where Element == RxDirectoryWatcher.Event {
+    // Emits the url:s once all archives has been extracted
+    func finishedExtracting(at path: URL) -> Observable<[URL]> {
+        return compactMap({ event -> [URL]? in
+            if case .completed(let paths) = event {
+                return paths
+            }
+            return nil
+        })
+        .scan((extracted: [], extractionComplete: false), accumulator: { acc, extracted -> (extracted: [URL], extractionComplete: Bool) in
+            let allExtracted = acc.extracted + extracted
+            do {
+                let remainingFiles = try FileManager.default.contentsOfDirectory(at: path, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])
+                return (
+                    extracted: allExtracted,
+                    extractionComplete: remainingFiles.filter { $0.isArchive }.isEmpty
+                )
+            } catch {
+                ELOG("\(error.localizedDescription)")
+                return (
+                    extracted: allExtracted,
+                    extractionComplete: false
+                )
+            }
+        })
+        .filter { $0.extractionComplete }
+        .map { $0.extracted }
+    }
+}
+
+private extension FileManager {
+    /// Returns a list of all the files in a systems directory that are potential ROMs (AKA has the correct extension)
+    func candidateROMs(for system: System) -> [URL]? {
+        let systemDir = system.romsDirectory
+
+        // Check if a folder actually exists, nothing to do if it doesn't
+        guard fileExists(atPath: systemDir.path) else {
+            VLOG("Nothing found at \(systemDir.path)")
+            return nil
+        }
+        guard let contents = try? contentsOfDirectory(at: systemDir, includingPropertiesForKeys: nil, options: [.skipsSubdirectoryDescendants, .skipsHiddenFiles]),
+            !contents.isEmpty else {
+                return nil
+        }
+
+        return contents.filter { system.extensions.contains($0.pathExtension) }
+    }
+}
+
+private extension GameImporter {
+    enum Event: Equatable {
+        case initialized
+        case started(path: URL)
+        case finished(md5: String, modified: Bool)
+        case finishedArtwork(url: URL)
+        case completed(encounteredConflicts: Bool)
+    }
+}
+
+private extension Reactive where Base: GameImporter {
+    var events: Observable<Base.Event> {
+        return Observable.create { observer in
+            self.base.initialized.notify(queue: DispatchQueue.global(qos: .background)) {
+                observer.onNext(.initialized)
+            }
+
+            self.base.importStartedHandler = { observer.onNext(.started(path: URL(fileURLWithPath: $0))) }
+            self.base.finishedImportHandler = { observer.onNext(.finished(md5: $0, modified: $1)) }
+            self.base.finishedArtworkHandler = { observer.onNext(.finishedArtwork(url: URL(fileURLWithPath: $0))) }
+            self.base.completionHandler = { observer.onNext(.completed(encounteredConflicts: $0)) }
+
+            return Disposables.create {
+                self.base.importStartedHandler = nil
+                self.base.finishedImportHandler = nil
+                self.base.finishedArtworkHandler = nil
+                self.base.completionHandler = nil
+            }
+        }
+    }
+}
+
+private struct RxDirectoryWatcher {
+    enum Event {
+        case started(path: URL)
+        case updated(path: URL, progress: Float)
+        case completed(paths: [URL]?)
+    }
+    let events: Observable<Event>
+    init(directory: URL) {
+        events = Observable.create { observer in
+            let internalWatcher = DirectoryWatcher(directory: directory,
+                                                   extractionStartedHandler: { observer.onNext(.started(path: $0)) },
+                                                   extractionUpdatedHandler: { observer.onNext(.updated(path: $0, progress: $3)) },
+                                                   extractionCompleteHandler: { observer.onNext(.completed(paths: $0)) })
+            internalWatcher.startMonitoring()
+            return Disposables.create {
+                internalWatcher.stopMonitoring()
+            }
+        }.share()
+    }
+}
+
+private extension URL {
+    var isArchive: Bool {
+        PVEmulatorConfiguration.archiveExtensions.contains(pathExtension.lowercased())
+    }
+}


### PR DESCRIPTION
### What does this PR do
This PR moves most of the handling of scanning directories, importing files and handling conflicts out of PVGameLibraryViewController, making that VC a bit less bloated and also fixes some synchronisation issues between views.

### Where should the reviewer start
The new PVGameLibraryUpdatesController is now responsible for everything above, so that's a good way to start. Then it emits some events when UI needs to be shown to the user, so the UI-parts are still handled in the GameLibraryVC.

### How should this be manually tested
Make sure that imports still work as expected, including resolving conflicts.

### Any background context you want to provide
The base motivation for this is to make the PVGameLibraryViewController more manageable, and move stuff out of it, so this is a small step in that direction.

### What are the relevant tickets
Probably fixes #833 (due to better synchronization)
Fixes #1339 (due to different logic)