### PR TITLE
Fix keyboard shortcuts in the Simulator

### DIFF
--- a/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
+++ b/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
@@ -2186,20 +2186,20 @@ extension PVGameLibraryViewController {
                 let toggleFavoriteCommand = UIKeyCommand(input: "=", modifierFlags: flags, action: #selector(PVGameLibraryViewController.toggleFavoriteCommand), discoverabilityTitle: "Toggle Favorite")
                 sectionCommands.append(toggleFavoriteCommand)
 
-                let showMoreInfo = UIKeyCommand(input: "i", modifierFlags: flags, action: #selector(PVGameLibraryViewController.showMoreInfoCommand), discoverabilityTitle: "More info ...")
+                let showMoreInfo = UIKeyCommand(input: "i", modifierFlags: flags, action: #selector(PVGameLibraryViewController.showMoreInfoCommand), discoverabilityTitle: "More info…")
                 sectionCommands.append(showMoreInfo)
 
-                let renameCommand = UIKeyCommand(input: "r", modifierFlags: flags, action: #selector(PVGameLibraryViewController.renameCommand), discoverabilityTitle: "Rename ...")
+                let renameCommand = UIKeyCommand(input: "r", modifierFlags: flags, action: #selector(PVGameLibraryViewController.renameCommand), discoverabilityTitle: "Rename…")
                 sectionCommands.append(renameCommand)
 
-                let deleteCommand = UIKeyCommand(input: "x", modifierFlags: flags, action: #selector(PVGameLibraryViewController.deleteCommand), discoverabilityTitle: "Delete ...")
+                let deleteCommand = UIKeyCommand(input: "x", modifierFlags: flags, action: #selector(PVGameLibraryViewController.deleteCommand), discoverabilityTitle: "Delete…")
                 sectionCommands.append(deleteCommand)
 
                 let sortCommand = UIKeyCommand(input: "s", modifierFlags: flags, action: #selector(PVGameLibraryViewController.sortButtonTapped(_:)), discoverabilityTitle: "Sorting")
                 sectionCommands.append(sortCommand)
             }
         #elseif os(iOS)
-            let findCommand = UIKeyCommand(input: "f", modifierFlags: flags, action: #selector(PVGameLibraryViewController.selectSearch(_:)), discoverabilityTitle: "Find …")
+            let findCommand = UIKeyCommand(input: "f", modifierFlags: flags, action: #selector(PVGameLibraryViewController.selectSearch(_:)), discoverabilityTitle: "Find…")
             sectionCommands.append(findCommand)
 
             let sortCommand = UIKeyCommand(input: "s", modifierFlags: flags, action: #selector(PVGameLibraryViewController.sortButtonTapped(_:)), discoverabilityTitle: "Sorting")

--- a/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
+++ b/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
@@ -2171,7 +2171,7 @@ extension PVGameLibraryViewController {
         for (i, title) in sectionTitles.enumerated() {
             let input = "\(i)"
             // Simulator Command + number has shorcuts already
-            #if TARGET_OS_SIMULATOR
+            #if arch(i386) || arch(x86_64)
                 let flags: UIKeyModifierFlags = [.control, .command]
             #else
                 let flags: UIKeyModifierFlags = .command

--- a/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
+++ b/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
@@ -2168,45 +2168,45 @@ extension PVGameLibraryViewController {
     public override var keyCommands: [UIKeyCommand]? {
         var sectionCommands = [UIKeyCommand]() /* TODO: .reserveCapacity(sectionInfo.count + 2) */
 
+        // Simulator Command + number has shorcuts already
+        #if arch(i386) || arch(x86_64)
+            let flags: UIKeyModifierFlags = [.control, .command]
+        #else
+            let flags: UIKeyModifierFlags = .command
+        #endif
+
         for (i, title) in sectionTitles.enumerated() {
             let input = "\(i)"
-            // Simulator Command + number has shorcuts already
-            #if arch(i386) || arch(x86_64)
-                let flags: UIKeyModifierFlags = [.control, .command]
-            #else
-                let flags: UIKeyModifierFlags = .command
-            #endif
             let command = UIKeyCommand(input: input, modifierFlags: flags, action: #selector(PVGameLibraryViewController.selectSection(_:)), discoverabilityTitle: title)
             sectionCommands.append(command)
         }
 
         #if os(tvOS)
             if focusedGame != nil {
-                let toggleFavoriteCommand = UIKeyCommand(input: "=", modifierFlags: [.command], action: #selector(PVGameLibraryViewController.toggleFavoriteCommand), discoverabilityTitle: "Toggle Favorite")
+                let toggleFavoriteCommand = UIKeyCommand(input: "=", modifierFlags: flags, action: #selector(PVGameLibraryViewController.toggleFavoriteCommand), discoverabilityTitle: "Toggle Favorite")
                 sectionCommands.append(toggleFavoriteCommand)
 
-                let showMoreInfo = UIKeyCommand(input: "i", modifierFlags: [.command], action: #selector(PVGameLibraryViewController.showMoreInfoCommand), discoverabilityTitle: "More info ...")
+                let showMoreInfo = UIKeyCommand(input: "i", modifierFlags: flags, action: #selector(PVGameLibraryViewController.showMoreInfoCommand), discoverabilityTitle: "More info ...")
                 sectionCommands.append(showMoreInfo)
 
-                let renameCommand = UIKeyCommand(input: "r", modifierFlags: [.command], action: #selector(PVGameLibraryViewController.renameCommand), discoverabilityTitle: "Rename ...")
+                let renameCommand = UIKeyCommand(input: "r", modifierFlags: flags, action: #selector(PVGameLibraryViewController.renameCommand), discoverabilityTitle: "Rename ...")
                 sectionCommands.append(renameCommand)
 
-                let deleteCommand = UIKeyCommand(input: "x", modifierFlags: [.command], action: #selector(PVGameLibraryViewController.deleteCommand), discoverabilityTitle: "Delete ...")
+                let deleteCommand = UIKeyCommand(input: "x", modifierFlags: flags, action: #selector(PVGameLibraryViewController.deleteCommand), discoverabilityTitle: "Delete ...")
                 sectionCommands.append(deleteCommand)
 
-                let sortCommand = UIKeyCommand(input: "s", modifierFlags: [.command], action: #selector(PVGameLibraryViewController.sortButtonTapped(_:)), discoverabilityTitle: "Sorting")
+                let sortCommand = UIKeyCommand(input: "s", modifierFlags: flags, action: #selector(PVGameLibraryViewController.sortButtonTapped(_:)), discoverabilityTitle: "Sorting")
                 sectionCommands.append(sortCommand)
             }
         #elseif os(iOS)
-            let findCommand = UIKeyCommand(input: "f", modifierFlags: [.command], action: #selector(PVGameLibraryViewController.selectSearch(_:)), discoverabilityTitle: "Find …")
+            let findCommand = UIKeyCommand(input: "f", modifierFlags: flags, action: #selector(PVGameLibraryViewController.selectSearch(_:)), discoverabilityTitle: "Find …")
             sectionCommands.append(findCommand)
 
-            let sortCommand = UIKeyCommand(input: "s", modifierFlags: [.command], action: #selector(PVGameLibraryViewController.sortButtonTapped(_:)), discoverabilityTitle: "Sorting")
+            let sortCommand = UIKeyCommand(input: "s", modifierFlags: flags, action: #selector(PVGameLibraryViewController.sortButtonTapped(_:)), discoverabilityTitle: "Sorting")
             sectionCommands.append(sortCommand)
 
-            let settingsCommand = UIKeyCommand(input: ",", modifierFlags: [.command], action: #selector(PVGameLibraryViewController.settingsCommand), discoverabilityTitle: "Settings")
+            let settingsCommand = UIKeyCommand(input: ",", modifierFlags: flags, action: #selector(PVGameLibraryViewController.settingsCommand), discoverabilityTitle: "Settings")
             sectionCommands.append(settingsCommand)
-
         #endif
 
         return sectionCommands

--- a/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
+++ b/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
@@ -2169,7 +2169,7 @@ extension PVGameLibraryViewController {
         var sectionCommands = [UIKeyCommand]() /* TODO: .reserveCapacity(sectionInfo.count + 2) */
 
         // Simulator Command + number has shorcuts already
-        #if arch(i386) || arch(x86_64)
+        #if targetEnvironment(simulator)
             let flags: UIKeyModifierFlags = [.control, .command]
         #else
             let flags: UIKeyModifierFlags = .command

--- a/ProvenanceTV/PVTVTabBarController.swift
+++ b/ProvenanceTV/PVTVTabBarController.swift
@@ -12,10 +12,16 @@ class PVTVTabBarController: UITabBarController {
     public override var keyCommands: [UIKeyCommand]? {
         var sectionCommands = [UIKeyCommand]() /* TODO: .reserveCapacity(sectionInfo.count + 2) */
 
-        let findCommand = UIKeyCommand(input: "f", modifierFlags: [.command], action: #selector(PVTVTabBarController.searchAction), discoverabilityTitle: "Find …")
+        #if targetEnvironment(simulator)
+            let flags: UIKeyModifierFlags = [.control, .command]
+        #else
+            let flags: UIKeyModifierFlags = .command
+        #endif
+        
+        let findCommand = UIKeyCommand(input: "f", modifierFlags: flags, action: #selector(PVTVTabBarController.searchAction), discoverabilityTitle: "Find…")
         sectionCommands.append(findCommand)
 
-        let settingsCommand = UIKeyCommand(input: ",", modifierFlags: [.command], action: #selector(PVTVTabBarController.settingsAction), discoverabilityTitle: "Settings")
+        let settingsCommand = UIKeyCommand(input: ",", modifierFlags: flags, action: #selector(PVTVTabBarController.settingsAction), discoverabilityTitle: "Settings")
         sectionCommands.append(settingsCommand)
 
         return sectionCommands


### PR DESCRIPTION
### What does this PR do
This pull request fixes the [Simulator conditional](https://stackoverflow.com/questions/36180702/whats-wrong-with-my-if-target-os-simulator-code-for-realm-path-definition) and applies it to all the keyboard shortcuts.

### How should this be manually tested
Check the keyboard shortcuts in the Simulator.