### PR TITLE
Fix Mupen64Plus options

### DIFF
--- a/Cores/Mupen64Plus/MupenOptions.swift
+++ b/Cores/Mupen64Plus/MupenOptions.swift
@@ -18,14 +18,14 @@ extension MupenGameCore: CoreOptional {
         var options = [CoreOption]()
 
         let glidenOption = CoreOption.multi(display: CoreOptionValueDisplay(title: "GFX Plugin",
-                                                                            description: nil),
+                                                                            description: "GlideN64 is newer but slower. Try Rice Video for older devices"),
                                             values: [
                                                 CoreOptionMultiValue(title: "GlideN64", description: "Newer, GLES3 GFX Driver"),
                                                 CoreOptionMultiValue(title: "Rice Video", description: "Older, faster, less feature rich GFX Driver")
         ])
 
         let rspOptions = CoreOption.multi(display: CoreOptionValueDisplay(title: "RSP Plugin",
-                                                                          description: "GlideN64 is newer but slower. Try Rice Video for older devices"),
+                                                                          description: nil),
                                           values: [
                                               CoreOptionMultiValue(title: "RSPHLE", description: "Faster, default RSP"),
                                               CoreOptionMultiValue(title: "CXD4", description: "Slower. More features for some games, breaks others.")

--- a/Cores/Mupen64Plus/MupenOptions.swift
+++ b/Cores/Mupen64Plus/MupenOptions.swift
@@ -18,10 +18,10 @@ extension MupenGameCore: CoreOptional {
         var options = [CoreOption]()
 
         let glidenOption = CoreOption.multi(display: CoreOptionValueDisplay(title: "GFX Plugin",
-                                                                            description: "GlideN64 is newer but slower. Try Rice Video for older devices"),
+                                                                            description: "GlideN64 is newer but slower. Try Rice for older devices."),
                                             values: [
                                                 CoreOptionMultiValue(title: "GlideN64", description: "Newer, GLES3 GFX Driver"),
-                                                CoreOptionMultiValue(title: "Rice Video", description: "Older, faster, less feature rich GFX Driver")
+                                                CoreOptionMultiValue(title: "Rice Video", description: "Older, faster, less feature rich GFX Driver.")
         ])
 
         let rspOptions = CoreOption.multi(display: CoreOptionValueDisplay(title: "RSP Plugin",

--- a/Cores/Mupen64Plus/MupenOptions.swift
+++ b/Cores/Mupen64Plus/MupenOptions.swift
@@ -21,11 +21,11 @@ extension MupenGameCore: CoreOptional {
                                                                             description: nil),
                                             values: [
                                                 CoreOptionMultiValue(title: "GlideN64", description: "Newer, GLES3 GFX Driver"),
-                                                CoreOptionMultiValue(title: "RICE", description: "Older, faster, less feature rich GFX Driver")
+                                                CoreOptionMultiValue(title: "Rice Video", description: "Older, faster, less feature rich GFX Driver")
         ])
 
         let rspOptions = CoreOption.multi(display: CoreOptionValueDisplay(title: "RSP Plugin",
-                                                                          description: "GlideN64 is newer but slower. Try RICE for older devices"),
+                                                                          description: "GlideN64 is newer but slower. Try Rice Video for older devices"),
                                           values: [
                                               CoreOptionMultiValue(title: "RSPHLE", description: "Faster, default RSP"),
                                               CoreOptionMultiValue(title: "CXD4", description: "Slower. More features for some games, breaks others.")
@@ -42,7 +42,7 @@ extension MupenGameCore: CoreOptional {
 @objc
 extension MupenGameCore {
     public static var useRice: Bool {
-        return valueForOption(String.self, "GFX Plugin") == "RICE"
+        return valueForOption(String.self, "GFX Plugin") == "Rice Video"
     }
 
     public static var useCXD4: Bool {


### PR DESCRIPTION
### What does this PR do
This pull adjusts the request Mupen64Plus settings in the following ways:
- "RICE" is replaced with "Rice Video" as per the [documentation](https://github.com/mupen64plus/mupen64plus-video-rice).
- The display title description was moved from "RSP Plugin" to "GFX Plugin".

### How should this be manually tested
Look at the Mupen64Plus core options.

### Screenshots (important for UI changes)
<img width="280" alt="Screen Shot 2020-06-16 at 22 34 52" src="https://user-images.githubusercontent.com/2276355/84825574-e922c200-b021-11ea-8cf8-ed3411dfdd5d.png">

### Questions
The https://github.com/Provenance-Emu/Provenance/commit/accf48e8fd8784c9aae26ac394ac273748117740 move is assumed to be correct, feel free to revert.
