### PR TITLE
Fix core options crash on iPad

### DIFF
--- a/Provenance/Emulator/CoreOptionsViewController.swift
+++ b/Provenance/Emulator/CoreOptionsViewController.swift
@@ -57,7 +57,7 @@ final class CoreOptionsViewController: QuickTableViewController {
         typealias TableRow = Row & RowStyle
 
         let sections: [Section] = groups.map {
-            let rows: [TableRow] = $0.options.map { option in
+            let rows: [TableRow] = $0.options.enumerated().map { (rowIndex, option) in
                 switch option {
                 case let .bool(display, defaultValue):
                     let detailText: DetailText = display.description != nil ? DetailText.subtitle(display.description!) : .none
@@ -75,6 +75,13 @@ final class CoreOptionsViewController: QuickTableViewController {
                                                              action: { _ in
                                                                  let currentSelection: String? = self.core.valueForOption(String.self, option.key) ?? option.defaultValue as? String
                                                                  let actionController = UIAlertController(title: display.title, message: nil, preferredStyle: .actionSheet)
+
+                                                                 if let popoverPresentationController = actionController.popoverPresentationController {
+                                                                    let cellRect = self.tableView.rectForRow(at: IndexPath(row: rowIndex, section: 0))
+                                                                    popoverPresentationController.sourceView = self.tableView
+                                                                    popoverPresentationController.sourceRect = cellRect
+                                                                 }
+
                                                                  values.forEach { value in
                                                                      var title = value.title
                                                                      if currentSelection == value.title {

--- a/Provenance/User Interface/Themes/UIAlertController+Theming.swift
+++ b/Provenance/User Interface/Themes/UIAlertController+Theming.swift
@@ -34,16 +34,6 @@ import UIKit
             }
         }
 
-        // view{load,willAppear,didAppear} had GFX glitches. This seems to render accuratly before animation and after
-        // Remove this method if you don't want ALL your UIAlertController's to look the same
-        open override func viewDidLayoutSubviews() {
-            super.viewDidLayoutSubviews()
-            setDefaultOverrides()
-            if let popoverPresentationController = popoverPresentationController {
-                popoverPresentationController.backgroundColor = .clear
-            }
-        }
-
         open override func viewWillAppear(_ animated: Bool) {
             super.viewWillAppear(animated)
             setDefaultOverrides()


### PR DESCRIPTION
### What does this PR do
This pull request fixes a crash on iPad when a UIAlert was invoked in core options. Alerts are now placed near the relevant table cell. Some theme code was removed to fix a height issue.

### Where should the reviewer start
Open a UIAlert in core options with an iPad device.

### Screenshots (important for UI changes)
After the crash fix:
![PixelSnap 2020-06-25 at 20 55 12@2x](https://user-images.githubusercontent.com/2276355/85784436-91264280-b728-11ea-9ab6-f71a47e7059a.png)

After the theme fix:
![PixelSnap 2020-06-25 at 20 54 36@2x](https://user-images.githubusercontent.com/2276355/85784428-908dac00-b728-11ea-9da9-4599d0edd0ec.png)


### Questions
Does the removal of the `viewDidLayoutSubviews` override cause any issues?