### PR TITLE
Make core options order consistent across tvOS and iOS

### DIFF
--- a/Provenance/Settings/PVSettingsViewController.swift
+++ b/Provenance/Settings/PVSettingsViewController.swift
@@ -90,7 +90,7 @@ final class PVSettingsViewController: PVQuickTableViewController {
 
         // -- Core Options
         let realm = try! Realm()
-        let cores: [NavigationRow<SystemSettingsCell>] = realm.objects(PVCore.self).compactMap { pvcore in
+        let cores: [NavigationRow<SystemSettingsCell>] = realm.objects(PVCore.self).sorted(byKeyPath: "identifier").compactMap { pvcore in
             guard let coreClass = NSClassFromString(pvcore.principleClass) as? CoreOptional.Type else {
                 DLOG("Class <\(pvcore.principleClass)> does not impliment CoreOptional")
                 return nil


### PR DESCRIPTION
### What does this PR do
The order of items under core options differs between iOS and tvOS. This is because it is dependent on a class list being [generated](https://github.com/Provenance-Emu/Provenance/blob/develop/PVLibrary/PVLibrary/Configuration/PVEmulatorConfiguration+Frameworks.swift#L22) from arbitrary memory locations. The list of systems is also [sorted](https://github.com/dnicolson/Provenance/blob/develop/Provenance/Settings/SystemSettings/SystemsSettingsTableViewController.swift#L20) in a similar way.

### How should this be manually tested
Check the order of core options on iOS and tvOS.