### PR TITLE
Fix corner badge after orientation change

### DIFF
--- a/Provenance/Game Library/UI/Game Library/Reusable Views/PVGameLibraryCollectionViewCell.swift
+++ b/Provenance/Game Library/UI/Game Library/Reusable Views/PVGameLibraryCollectionViewCell.swift
@@ -945,7 +945,9 @@ final class PVGameLibraryCollectionViewCell: UICollectionViewCell {
             }
         #endif
 
-        updateImageConstraints()
+        DispatchQueue.main.async {
+            self.updateImageConstraints()
+        }
 
         #if os(iOS)
             if !PVSettingsModel.shared.showGameTitles, let titleLabelHeightConstraint = titleLabelHeightConstraint {


### PR DESCRIPTION
### What does this PR do
This pull request fixes the alignment of the right corner badge after changing orientation.

The `topRightBadgeTrailingConstraint` and the `topRightBadgeTopConstraint` values can be set incorrectly in the [updateImageConstraints](https://github.com/Provenance-Emu/Provenance/blob/develop/Provenance/Game%20Library/UI/Game%20Library/Reusable%20Views/PVGameLibraryCollectionViewCell.swift#L959) method due to incorrect `bounds` values in the [contentClippingRect](https://github.com/Provenance-Emu/Provenance/blob/develop/Provenance/Game%20Library/UI/Game%20Library/Reusable%20Views/PVGameLibraryCollectionViewCell.swift#L178) method while the UI is busy. Unlike the previous pull request (https://github.com/Provenance-Emu/Provenance/pull/1384) the whole data is not reloaded.

### How should this be manually tested
Change orientation from landscape to portrait.

### Screenshots (important for UI changes)
Before:
<img width="280" alt="Screen Shot 2020-07-06 at 18 10 46" src="https://user-images.githubusercontent.com/2276355/86615059-3ad0c380-bfb4-11ea-8bf0-27a155d443dc.png">

After:
<img width="280" alt="Screen Shot 2020-07-06 at 18 11 06" src="https://user-images.githubusercontent.com/2276355/86615073-3f957780-bfb4-11ea-9a66-1e675fd489d3.png">
