### PR TITLE
Adjust slider length for label in SliderCell

### DIFF
--- a/Provenance/Settings/Cells/SliderCell.swift
+++ b/Provenance/Settings/Cells/SliderCell.swift
@@ -123,10 +123,23 @@ extension QuickTableViewController: SliderCellDelegate {
         }
 
         private func setUpAppearance() {
-            slider.autoresizingMask = [.flexibleHeight, .flexibleWidth]
-            let leftInset = (textLabel?.bounds.width ?? 0) + 16
-            slider.frame = contentView.bounds.inset(by: UIEdgeInsets(top: 0, left: leftInset, bottom: 0, right: 16))
             contentView.addSubview(slider)
+
+            guard let textLabel = textLabel else {
+                return
+            }
+
+            contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: 44).isActive = true
+
+            textLabel.translatesAutoresizingMaskIntoConstraints = false
+            textLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 15).isActive = true
+            textLabel.topAnchor.constraint(equalTo: self.topAnchor, constant: 0).isActive = true
+            textLabel.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: 0).isActive = true
+
+            slider.translatesAutoresizingMaskIntoConstraints = false
+            slider.leadingAnchor.constraint(equalTo: textLabel.trailingAnchor, constant: 20).isActive = true
+            slider.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -20).isActive = true
+            slider.centerYAnchor.constraint(equalTo: self.centerYAnchor, constant: 0).isActive = true
         }
     }
 #endif


### PR DESCRIPTION
### What does this PR do
This pull request adjusts the slider length so it does not overlap with the label.

### How should this be manually tested
Interact a the slider in the settings.

### Any background context you want to provide
Most of the credit is due to the work of @antiquebeta, only a few changes were made in this file from the original [pull request](https://github.com/Provenance-Emu/Provenance/pull/1265/files#diff-e0eedeff11a15cfb1d2fc017bda22b72R131):
- The leading constraint was changed from `20` to `15`.
- The async UI updates were removed.
- A `heightAnchor` constraint was added to suppress a warning that other top/bottom constraints failed to suppress.

### Screenshots (important for UI changes)
Before:
<img width="280" alt="Screen Shot 2020-07-07 at 21 18 43" src="https://user-images.githubusercontent.com/2276355/86832831-fcf99b00-c098-11ea-9bf5-b6f856d9d476.png">

After:
<img width="280" alt="Screen Shot 2020-07-07 at 21 22 54" src="https://user-images.githubusercontent.com/2276355/86832765-e81d0780-c098-11ea-927b-da6b16dfc15a.png">
