### PR TITLE
Fix core option SwitchRow colours

### DIFF
--- a/Provenance/Emulator/CoreOptionsViewController.swift
+++ b/Provenance/Emulator/CoreOptionsViewController.swift
@@ -61,7 +61,7 @@ final class CoreOptionsViewController: QuickTableViewController {
                 switch option {
                 case let .bool(display, defaultValue):
                     let detailText: DetailText = display.description != nil ? DetailText.subtitle(display.description!) : .none
-                    return SwitchRow(text: display.title, detailText: detailText, switchValue: core.valueForOption(Bool.self, option.key) ?? defaultValue, action: { _ in
+                    return SwitchRow<PVSwitchCell>(text: display.title, detailText: detailText, switchValue: core.valueForOption(Bool.self, option.key) ?? defaultValue, action: { _ in
                         let value = self.core.valueForOption(Bool.self, option.key) ?? defaultValue
                         self.core.setValue(!value, forOption: option)
                     })


### PR DESCRIPTION
### What does this PR do
This pull request specifies the same cell class as used in the top-level settings to use the same styles.

### Where should the reviewer start
Check core options and the PVSwitchCell class. The HW Lighting and GFX Plugin cells have matching colours.

### How should this be manually tested
Check Mupen64Plus core options.

### What are the relevant tickets
https://github.com/Provenance-Emu/Provenance/issues/1342

### Screenshots (important for UI changes)
Before and after:
<img width="280" alt="Screen Shot 2020-07-23 at 18 43 35" src="https://user-images.githubusercontent.com/2276355/88314384-23643b00-cd15-11ea-8f37-a559319f5b9d.png"><img width="280" alt="Screen Shot 2020-07-23 at 18 43 52" src="https://user-images.githubusercontent.com/2276355/88314386-252dfe80-cd15-11ea-9776-3f337f2eacd8.png">

