### PR TITLE
Fix core option selectionStyle

### DIFF
--- a/Provenance/Emulator/CoreOptionsViewController.swift
+++ b/Provenance/Emulator/CoreOptionsViewController.swift
@@ -94,6 +94,10 @@ final class CoreOptionsViewController: QuickTableViewController {
                                                                  }
                                                                  actionController.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
                                                                  self.present(actionController, animated: true)
+
+                                                                 if let indexPath = self.tableView.indexPathForSelectedRow {
+                                                                     self.tableView.deselectRow(at: indexPath, animated: false)
+                                                                 }
                     })
                 case .range:
                     fatalError("Unfinished feature")


### PR DESCRIPTION
### What does this PR do
This pull request sets the `selectionStyle` to `none` after tapping a multi core option.

### How should this be manually tested
Tap a core option.

### Any background context you want to provide
This [issue](https://github.com/bcylin/QuickTableViewController/issues/39) was used as a reference.

### Screenshots (important for UI changes)
Before and after:
![Before](https://user-images.githubusercontent.com/2276355/88459768-12900280-ce98-11ea-8b33-5efec626c593.gif) ![After](https://user-images.githubusercontent.com/2276355/88459770-1459c600-ce98-11ea-88be-1239639012c4.gif)
