### PR TITLE
Revert search field fix

### DIFF
--- a/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
+++ b/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
@@ -208,14 +208,13 @@ final class PVGameLibraryViewController: UIViewController, UITextFieldDelegate, 
 
                 // Navigation bar large titles
                 navigationController?.navigationBar.prefersLargeTitles = false
-                navigationController?.navigationBar.translatesAutoresizingMaskIntoConstraints = false
                 navigationItem.title = nil
 
                 // Create a search controller
                 let searchController = UISearchController(searchResultsController: nil)
                 searchController.searchBar.placeholder = "Search"
                 searchController.obscuresBackgroundDuringPresentation = false
-                searchController.hidesNavigationBarDuringPresentation = false
+                searchController.hidesNavigationBarDuringPresentation = true
                 navigationItem.hidesSearchBarWhenScrolling = true
                 navigationItem.searchController = searchController
 


### PR DESCRIPTION
This pull request reverts https://github.com/Provenance-Emu/Provenance/pull/1383 due to issues with iOS 11 and 12.

It is not clear what causes the search field to collapse (https://github.com/Provenance-Emu/Provenance/issues/1379), the problem doesn't occur if the `collectionView` is not added to the subview or if a large height constraint is applied to the `searchBar`.