### PR TITLE
Fix BIOS status

### DIFF
--- a/PVLibrary/PVLibrary/Domain/BIOS.swift
+++ b/PVLibrary/PVLibrary/Domain/BIOS.swift
@@ -176,7 +176,7 @@ public struct BIOSStatus: Codable {
 
 public extension BIOSStatus {
     init<T: BIOSFileProvider>(withBios bios: T) {
-        available = !(bios.fileInfo?.online ?? false)
+        available = bios.fileInfo != nil
         if available {
             let md5Match = bios.fileInfo?.md5?.uppercased() == bios.expectedMD5.uppercased()
             let sizeMatch = bios.fileInfo?.size == UInt64(bios.expectedSize)


### PR DESCRIPTION
### What does this PR do
This pull request fixes the file check for the existence of a BIOS. Previously BIOSes that did not exist would have an MD5 error and BIOSes that existed had the wrong status.

### How should this be manually tested
Upload a BIOS and check Systems in Settings.

### Screenshots (important for UI changes)

Before and after:
<img width="280" alt="Screen Shot 2020-09-05 at 18 45 19" src="https://user-images.githubusercontent.com/2276355/92309853-48e99300-efa9-11ea-98c3-998f5d153eac.png"> <img width="280" alt="Screen Shot 2020-09-05 at 18 46 02" src="https://user-images.githubusercontent.com/2276355/92309857-4b4bed00-efa9-11ea-9836-aacef043ea90.png">
