### PR TITLE
Update PVGenesisEmulatorCore.m

### DIFF
--- a/Cores/Genesis-Plus-GX/PVGenesis/Genesis/PVGenesisEmulatorCore.m
+++ b/Cores/Genesis-Plus-GX/PVGenesis/Genesis/PVGenesisEmulatorCore.m
@@ -409,7 +409,7 @@ static bool environment_callback(unsigned cmd, void *data)
     {
         return CGSizeMake(256 * (8.0/7.0), 192);
     }else {
-        return CGSizeMake(4, 3);
+        return CGSizeMake(_videoWidth, _videoHeight);;
     }
 }
 


### PR DESCRIPTION
Fixes the displayed Aspect Ratio to match the Genesis' VDP output for an accurate square pixel display rendering of the games.

Fixed aspect ratio (circle should be round)
![dragons_fury_ok_aspect](https://user-images.githubusercontent.com/30782821/93415446-5c71e500-f858-11ea-8bf4-d1e8f76414ee.png)

Original aspect ratio (circle is not round)
![dragons_fury_wrong_aspect](https://user-images.githubusercontent.com/30782821/93415449-5ed43f00-f858-11ea-9758-c140863b54b8.png)
