### PR TITLE
Make sure we use the correct root when creating relative paths

### DIFF
--- a/PVLibrary/PVLibrary/RealmPlatform/Entities/Files/PVFile.swift
+++ b/PVLibrary/PVLibrary/RealmPlatform/Entities/Files/PVFile.swift
@@ -33,28 +33,13 @@ public enum RelativeRoot: Int {
         case .caches:
             return RelativeRoot.cachesDirectory
         case .iCloud:
-            return RelativeRoot.iCloudDocumentsDirectory ?? RelativeRoot.documentsDirectory
+            return RelativeRoot.iCloudDocumentsDirectory ?? Self.platformDefault.directoryURL
         }
     }
 
     func createRelativePath(fromURL url: URL) -> String {
-        let searchString: String
-        switch self {
-        case .documents:
-            searchString = "Documents/"
-        case .caches:
-            searchString = "Caches/"
-        case .iCloud:
-            searchString = "Documents/"
-        }
-
-        let path = url.path
-        guard let range = path.range(of: searchString) else {
-            return path
-        }
-
-        let suffixPath = String(path.suffix(from: range.upperBound))
-        return suffixPath
+        // We need the dropFirst to remove the leading /
+        return String(url.path.replacingOccurrences(of: directoryURL.path, with: "").dropFirst())
     }
 
     func appendingPath(_ path: String) -> URL {


### PR DESCRIPTION
### What does this PR do
This fixes an issue where there's a mismatch between location of save states and their images and what's recorded in Realm. In short we're trying to create a relative path to store in the database, but trying to resolve against the `iCloud` root (which isn't even available on tvOS.

### How should this be manually tested
Start any game, create a save state, close provenance and load the save again.
Would be nice to get this tested on both iOS and tvOS

### Any background context you want to provide
Originally discussed here: https://discord.com/channels/421819941835243520/426555484221341708/722498320794124349

### What are the relevant tickets
Couldn't find any, but I assume more people has seen this bug, since it basically breaks save states on tvOS