### PR TITLE
Set preferredFPS to 60 - Resolves a lot of frame stuttering. 

### DIFF
--- a/Provenance/Emulator/PVGLViewController.m
+++ b/Provenance/Emulator/PVGLViewController.m
@@ -231,12 +231,7 @@ struct RenderSettings {
 }
 
 - (void) updatePreferredFPS {
-    float preferredFPS = self.emulatorCore.frameInterval;
-    if (preferredFPS  < 10) {
-        WLOG(@"Cores frame interval (%f) too low. Setting to 60", preferredFPS);
-        preferredFPS = 60;
-    }
-
+    int preferredFPS = 60;
     [self setPreferredFramesPerSecond:preferredFPS];
 }
 


### PR DESCRIPTION
Per the Apple Developer docs, PreferredFPS takes an int, and generally only allows for "clean" frame rates of 60, 30, 15, etc. 

Setting this to a hardcoded 60 seems to resolve a lot of the frame skipping issues we've seen on modern devices, especially on Displays that can refresh >60. No point in setting it to the native Display refresh (i.e. >120) because the ProMotion engine will just auto-throttle accordingly anyways and this results in more frame drops and non-smooth playback. 

The other workaround that really helps reduce visual frame drops is to play the cores using a controller which in turn will remove the Controller UI being rendered on top of the Core render buffer.