### PR TITLE
Update systems.plist - Make SuperGrafx games unique with the .sgx extension.

### DIFF
--- a/PVLibrary/PVLibrary/Resources/systems.plist
+++ b/PVLibrary/PVLibrary/Resources/systems.plist
@@ -818,7 +818,7 @@
 		<string>17</string>
 		<key>PVSupportedExtensions</key>
 		<array>
-			<string>pce</string>
+			<string>sgx</string>
 		</array>
 		<key>PVControlLayout</key>
 		<array>


### PR DESCRIPTION
Make SuperGrafx games unique with the .sgx extension and no longer use the .pce as a catch-all.
 
This will result in less of a chance with the GameImporter throwing conflicts as there are only 5 games for the entire system.