### PR TITLE
Add iOS 14 to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -149,6 +149,7 @@ replaceWithNotesOrDelete
 - [ ] Apple TV
 
 #### iOS/tvOS VERSION
+- [ ] 14.x
 - [ ] 13.x
 - [ ] 12.x
 - [ ] 11.x


### PR DESCRIPTION
### What does this PR do
This pull request adds iOS 14 to the issue template.

-----
[View rendered .github/ISSUE_TEMPLATE/bug-report.md](https://github.com/dnicolson/Provenance/blob/patch-1/.github/ISSUE_TEMPLATE/bug-report.md)