### PR TITLE
Increase settings tvOS row height

### DIFF
--- a/Provenance/Settings/PVSettingsViewController.swift
+++ b/Provenance/Settings/PVSettingsViewController.swift
@@ -45,7 +45,7 @@ final class PVSettingsViewController: PVQuickTableViewController {
 
         #if os(tvOS)
             tableView.backgroundColor = .black
-            tableView.rowHeight = 60
+            tableView.rowHeight = 80
             splitViewController?.view.backgroundColor = .black
             tableView.sectionHeaderHeight = 0
             tableView.sectionFooterHeight = 0


### PR DESCRIPTION
### What does this PR do
This pull request slightly increases the settings table row height. If a cell has a subtitle the vertical padding can look off.

### Screenshots (important for UI changes)
Before:
<img width="898" alt="60" src="https://user-images.githubusercontent.com/2276355/101836838-66953e00-3b3e-11eb-8fd9-e12890ef92ee.png">

After:
<img width="898" alt="80" src="https://user-images.githubusercontent.com/2276355/101836912-8298df80-3b3e-11eb-8910-999ac207fe56.png">
