### PR TITLE
Make collapse buttons focusable on tvOS

### DIFF
--- a/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController+CollectionView.swift
+++ b/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController+CollectionView.swift
@@ -82,8 +82,10 @@ extension PVGameLibraryViewController: UICollectionViewDelegateFlowLayout {
 
     #if os(tvOS)
         func collectionView(_ collectionView: UICollectionView, layout _: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
-            let item: Section.Item = try! collectionView.rx.model(at: IndexPath(item: 0, section: section))
+            let item: Section.Item? = firstModel(in: collectionView, at: section)
             switch item {
+            case .none:
+                return .zero
             case .game:
                 return 40
             case .saves, .favorites, .recents:

--- a/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
+++ b/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
@@ -326,6 +326,22 @@ final class PVGameLibraryViewController: UIViewController, UITextFieldDelegate, 
                     .bind(to: self.collapsedSystems)
                     .disposed(by: header.disposeBag)
                 #endif
+                #if os(tvOS)
+                header.collapseButton.rx.primaryAction
+                    .withLatestFrom(self.collapsedSystems)
+                    .map({ (collapsedSystems: Set<String>) in
+                        switch section.collapsable {
+                        case .collapsed(let token):
+                            return collapsedSystems.subtracting([token])
+                        case .notCollapsed(let token):
+                            return collapsedSystems.union([token])
+                        case nil:
+                            return collapsedSystems
+                        }
+                    })
+                    .bind(to: self.collapsedSystems)
+                    .disposed(by: header.disposeBag)
+                #endif
                 return header
             case UICollectionView.elementKindSectionFooter:
                 return collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: PVGameLibraryFooterViewIdentifier, for: indexPath)

--- a/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
+++ b/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
@@ -341,6 +341,7 @@ final class PVGameLibraryViewController: UIViewController, UITextFieldDelegate, 
                     })
                     .bind(to: self.collapsedSystems)
                     .disposed(by: header.disposeBag)
+                    header.updateFocusIfNeeded()
                 #endif
                 return header
             case UICollectionView.elementKindSectionFooter:

--- a/Provenance/Game Library/UI/Game Library/Reusable Views/PVGameLibrarySectionHeaderView.swift
+++ b/Provenance/Game Library/UI/Game Library/Reusable Views/PVGameLibrarySectionHeaderView.swift
@@ -25,9 +25,15 @@ class CollapseButton: UIButton {
 
     override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
         if isFocused {
-            backgroundColor = .lightGray
+            UIView.animate(withDuration: 0.1, animations: {
+                self.transform = CGAffineTransform(scaleX: 1.5, y: 1.5)
+                self.tintColor = .white
+            })
         } else {
-            backgroundColor = .none
+            UIView.animate(withDuration: 0.1, animations: {
+                self.transform = CGAffineTransform(scaleX: 1, y: 1)
+                self.tintColor = .darkGray
+            })
         }
     }
 }
@@ -156,12 +162,17 @@ final class PVGameLibrarySectionHeaderView: UICollectionReusableView {
         }
 
         override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
+            UIView.transition(with: titleLabel, duration: 0.1, options: .transitionCrossDissolve, animations: {
+              self.titleLabel.textColor = .white
+            }, completion: nil)
+
             if isFocused {
                 myPreferredFocusedView = collapseButton
                 setNeedsFocusUpdate()
-                updateFocusIfNeeded()
             } else {
-                backgroundColor = .none
+                if !collapseButton.isFocused {
+                    titleLabel.textColor = colorForText
+                }
             }
         }
     #endif

--- a/Provenance/Game Library/UI/Game Library/Reusable Views/PVGameLibrarySectionHeaderView.swift
+++ b/Provenance/Game Library/UI/Game Library/Reusable Views/PVGameLibrarySectionHeaderView.swift
@@ -18,30 +18,10 @@ internal struct GameLibrarySectionViewModel {
 //    }
 }
 
-class CollapseButton: UIButton {
-    override var canBecomeFocused: Bool {
-        return true
-    }
-
-    override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
-        if isFocused {
-            UIView.animate(withDuration: 0.1, animations: {
-                self.transform = CGAffineTransform(scaleX: 1.5, y: 1.5)
-                self.tintColor = .white
-            })
-        } else {
-            UIView.animate(withDuration: 0.1, animations: {
-                self.transform = CGAffineTransform(scaleX: 1, y: 1)
-                self.tintColor = .darkGray
-            })
-        }
-    }
-}
-
 final class PVGameLibrarySectionHeaderView: UICollectionReusableView {
     private(set) var titleLabel: UILabel = UILabel()
-    let collapseButton: CollapseButton = {
-        let button = CollapseButton()
+    let collapseButton: UIButton = {
+        let button = UIButton()
 
         button.setImage(UIImage(named: "chevron_down"), for: .normal)
         button.clipsToBounds = true
@@ -69,12 +49,6 @@ final class PVGameLibrarySectionHeaderView: UICollectionReusableView {
             collapseButton.imageView?.transform = viewModel.collapsed ? CGAffineTransform(rotationAngle: CGFloat.pi / 2.0) : .identity
             setNeedsDisplay()
         }
-    }
-
-    var myPreferredFocusedView: UIView?
-
-    override var preferredFocusedView: UIView? {
-         return myPreferredFocusedView
     }
 
     override init(frame: CGRect) {
@@ -164,28 +138,30 @@ final class PVGameLibrarySectionHeaderView: UICollectionReusableView {
             return false
         }
 
-        override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
-            guard let button = presses.first?.type else { return }
-
-            switch button {
-            case .rightArrow:
-                myPreferredFocusedView = collapseButton
-                setNeedsFocusUpdate()
-            case .leftArrow:
-                myPreferredFocusedView = self
-                setNeedsFocusUpdate()
-            default:
-                super.pressesEnded(presses, with: event)
+        override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
+            if isFocused {
+                UIView.transition(with: titleLabel, duration: 0.1, options: .transitionCrossDissolve, animations: {
+                  self.titleLabel.textColor = .white
+                }, completion: nil)
+                UIView.animate(withDuration: 0.1, animations: {
+                    self.collapseButton.transform = CGAffineTransform(scaleX: 1.5, y: 1.5)
+                    self.collapseButton.tintColor = .white
+                })
+            } else {
+                titleLabel.textColor = colorForText
+                UIView.animate(withDuration: 0.1, animations: {
+                    self.collapseButton.transform = CGAffineTransform(scaleX: 1, y: 1)
+                    self.collapseButton.tintColor = .darkGray
+                })
             }
         }
 
-        override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
-            UIView.transition(with: titleLabel, duration: 0.1, options: .transitionCrossDissolve, animations: {
-              self.titleLabel.textColor = .white
-            }, completion: nil)
-
-            if !isFocused && !collapseButton.isFocused {
-                titleLabel.textColor = colorForText
+        override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+            super.pressesBegan(presses, with: event)
+            if presses.contains(where: { (press) -> Bool in
+                press.type == .select
+            }) {
+                collapseButton.sendActions(for: .touchUpInside)
             }
         }
     #endif

--- a/Provenance/Game Library/UI/Game Library/Reusable Views/PVGameLibrarySectionHeaderView.swift
+++ b/Provenance/Game Library/UI/Game Library/Reusable Views/PVGameLibrarySectionHeaderView.swift
@@ -164,18 +164,28 @@ final class PVGameLibrarySectionHeaderView: UICollectionReusableView {
             return false
         }
 
+        override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+            guard let button = presses.first?.type else { return }
+
+            switch button {
+            case .rightArrow:
+                myPreferredFocusedView = collapseButton
+                setNeedsFocusUpdate()
+            case .leftArrow:
+                myPreferredFocusedView = self
+                setNeedsFocusUpdate()
+            default:
+                super.pressesEnded(presses, with: event)
+            }
+        }
+
         override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
             UIView.transition(with: titleLabel, duration: 0.1, options: .transitionCrossDissolve, animations: {
               self.titleLabel.textColor = .white
             }, completion: nil)
 
-            if isFocused {
-                myPreferredFocusedView = collapseButton
-                setNeedsFocusUpdate()
-            } else {
-                if !collapseButton.isFocused {
-                    titleLabel.textColor = colorForText
-                }
+            if !isFocused && !collapseButton.isFocused {
+                titleLabel.textColor = colorForText
             }
         }
     #endif

--- a/Provenance/Game Library/UI/Game Library/Reusable Views/PVGameLibrarySectionHeaderView.swift
+++ b/Provenance/Game Library/UI/Game Library/Reusable Views/PVGameLibrarySectionHeaderView.swift
@@ -158,7 +158,10 @@ final class PVGameLibrarySectionHeaderView: UICollectionReusableView {
         }
 
         override var canBecomeFocused: Bool {
-            return true
+            if !collapseButton.isHidden {
+                return true
+            }
+            return false
         }
 
         override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {

--- a/Provenance/Game Library/UI/Game Library/Reusable Views/PVGameLibrarySectionHeaderView.swift
+++ b/Provenance/Game Library/UI/Game Library/Reusable Views/PVGameLibrarySectionHeaderView.swift
@@ -18,10 +18,25 @@ internal struct GameLibrarySectionViewModel {
 //    }
 }
 
+class CollapseButton: UIButton {
+    override var canBecomeFocused: Bool {
+        return true
+    }
+
+    override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
+        if isFocused {
+            backgroundColor = .lightGray
+        } else {
+            backgroundColor = .none
+        }
+    }
+}
+
 final class PVGameLibrarySectionHeaderView: UICollectionReusableView {
     private(set) var titleLabel: UILabel = UILabel()
-    let collapseButton: UIButton = {
-        let button = UIButton()
+    let collapseButton: CollapseButton = {
+        let button = CollapseButton()
+
         button.setImage(UIImage(named: "chevron_down"), for: .normal)
         button.clipsToBounds = true
         #if os(iOS)
@@ -48,6 +63,12 @@ final class PVGameLibrarySectionHeaderView: UICollectionReusableView {
             collapseButton.imageView?.transform = viewModel.collapsed ? CGAffineTransform(rotationAngle: CGFloat.pi / 2.0) : .identity
             setNeedsDisplay()
         }
+    }
+
+    var myPreferredFocusedView: UIView?
+
+    override var preferredFocusedView: UIView? {
+         return myPreferredFocusedView
     }
 
     override init(frame: CGRect) {
@@ -128,6 +149,20 @@ final class PVGameLibrarySectionHeaderView: UICollectionReusableView {
             }
 
             return UIColor.darkGray
+        }
+
+        override var canBecomeFocused: Bool {
+            return true
+        }
+
+        override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
+            if isFocused {
+                myPreferredFocusedView = collapseButton
+                setNeedsFocusUpdate()
+                updateFocusIfNeeded()
+            } else {
+                backgroundColor = .none
+            }
         }
     #endif
     override func prepareForReuse() {


### PR DESCRIPTION
### What does this PR do
This pull request enables the collapse buttons on tvOS, similar to how they function on iOS. It was originally planned to remove the non-functional buttons in https://github.com/Provenance-Emu/Provenance/pull/1460, after some discussion adding focus functionality was decided instead.

### Where should the reviewer start
Look at how the focus state is changed.

### How should this be manually tested
Test with at least a few consoles that have ROMS with less than 7, 7, and more than 7 items.

### Any background context you want to provide
Different focus approaches were considered:
- Originally the focus was automatically shifted from the header to the button. This unfortunately rendered some section items inaccessible as the focus would only go down from the button which required at least 7 items below for a focus hit.
- Letting the user focus on the collapse button by using the right key (not a swipe), this only worked in the Simulator and also required additional input.
- Show a focused style for the collapse button when the header is focused and trigger a tap/primaryAction event on select.

The latter focus option is used in 41668a0, it seems to be a good UX tradeoff but triggering the event perhaps is not the best solution.

### Screenshots (important for UI changes)
![gifme](https://user-images.githubusercontent.com/2276355/102704173-335a5980-4278-11eb-9c56-562b393cdc6c.gif)