### PR TITLE
Sort cores displayed when starting a game

### DIFF
--- a/Provenance/Game Library/UI/GameLaunchingViewController.swift
+++ b/Provenance/Game Library/UI/GameLaunchingViewController.swift
@@ -395,7 +395,7 @@ extension GameLaunchingViewController where Self: UIViewController {
             return
         }
 
-        let cores = system.cores
+        let cores = system.cores.sorted(byKeyPath: "projectName")
 
         let coreChoiceAlert = UIAlertController(title: "Multiple cores found", message: "Select which core to use with this game.", preferredStyle: .actionSheet)
         if traitCollection.userInterfaceIdiom == .pad, let senderView = sender as? UIView ?? self.view {

--- a/Provenance/Settings/PVSettingsViewController.swift
+++ b/Provenance/Settings/PVSettingsViewController.swift
@@ -98,7 +98,7 @@ final class PVSettingsViewController: PVQuickTableViewController {
 
         // -- Core Options
         let realm = try! Realm()
-        let cores: [NavigationRow<SystemSettingsCell>] = realm.objects(PVCore.self).sorted(byKeyPath: "identifier").compactMap { pvcore in
+        let cores: [NavigationRow<SystemSettingsCell>] = realm.objects(PVCore.self).sorted(byKeyPath: "projectName").compactMap { pvcore in
             guard let coreClass = NSClassFromString(pvcore.principleClass) as? CoreOptional.Type else {
                 DLOG("Class <\(pvcore.principleClass)> does not implement CoreOptional")
                 return nil


### PR DESCRIPTION
### What does this PR do
This pull request sorts of the order of the cores so that they display in the same order on tvOS and iOS. At the moment for NES games the order of the "Mednafen" and "FCEUX" cores is different.

Additionally, the sorting that was applied in #1397 has been changed to make it consistent with [original sorting](https://github.com/dnicolson/Provenance/blob/sort-cores-before-game/Provenance/Settings/PVCoresTableViewContorller.swift#L17) by using the `projectName` key.

### How should this be manually tested
Check that the order of the cores when starting a NES game are consistent on tvOS and iOS.