### PR TITLE
Enable VALIDATE_WORKSPACE for PVLibrary

### DIFF
--- a/PVLibrary/PVLibrary.xcodeproj/project.pbxproj
+++ b/PVLibrary/PVLibrary.xcodeproj/project.pbxproj
@@ -2363,6 +2363,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_WORKSPACE = YES;
 			};
 			name = Archive;
 		};
@@ -2600,6 +2601,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_WORKSPACE = YES;
 			};
 			name = Debug;
 		};
@@ -2643,6 +2645,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_WORKSPACE = YES;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Happy new year, everyone! 🎈 

Compiling on an M1 machine wasn’t possible for both iOS device and simulator: "Building for iOS, but the linked and embedded framework 'RxRealm.framework' was built for iOS + iOS Simulator".

Enabling workspace validation makes it work.