### PR TITLE
Fix action sheet crash on iPad

### DIFF
--- a/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
+++ b/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
@@ -869,12 +869,8 @@ final class PVGameLibraryViewController: UIViewController, UITextFieldDelegate, 
         let cell = collectionView!.cellForItem(at: indexPath)!
         let actionSheet = contextMenu(for: item, cell: cell, point: point)
 
-        if traitCollection.userInterfaceIdiom == .pad {
-            actionSheet.popoverPresentationController?.sourceView = cell
-            actionSheet.popoverPresentationController?.sourceRect = (collectionView?.layoutAttributesForItem(at: indexPath)?.bounds ?? CGRect.zero)
-        }
-
-        present(actionSheet, animated: true)
+        presentActionSheetViewControllerForPopoverPresentation(contextMenu(for: item, cell: cell, point: point),
+                                                               sourceView: cell)
     }
 
     private func contextMenu(for item: Section.Item, cell: UICollectionViewCell, point: CGPoint) -> UIAlertController {
@@ -893,7 +889,7 @@ final class PVGameLibraryViewController: UIViewController, UITextFieldDelegate, 
         }
     }
 
-    private func contextMenu(for game: PVGame, sender: Any?) -> UIAlertController {
+    private func contextMenu(for game: PVGame, sender: UIView) -> UIAlertController {
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         #if os(tvOS)
         actionSheet.message = "Options for \(game.title)"
@@ -952,9 +948,9 @@ final class PVGameLibraryViewController: UIViewController, UITextFieldDelegate, 
             })
         }))
 
-        actionSheet.addAction(UIAlertAction(title: "Choose Cover", style: .default, handler: { (_: UIAlertAction) -> Void in
-            self.chooseCustomArtwork(for: game)
-        }))
+        actionSheet.addAction(UIAlertAction(title: "Choose Cover", style: .default) { [self] _ in
+            self.chooseCustomArtwork(for: game, sourceView: sender)
+        })
 
         actionSheet.addAction(UIAlertAction(title: "Paste Cover", style: .default, handler: { (_: UIAlertAction) -> Void in
             self.pasteCustomArtwork(for: game)
@@ -1090,7 +1086,7 @@ final class PVGameLibraryViewController: UIViewController, UITextFieldDelegate, 
     }
 
     #if os(iOS)
-        func chooseCustomArtwork(for game: PVGame) {
+    private func chooseCustomArtwork(for game: PVGame, sourceView: UIView) {
             weak var weakSelf: PVGameLibraryViewController? = self
             let imagePickerActionSheet = UIAlertController(title: "Choose Artwork", message: "Choose the location of the artwork.\n\nUse Latest Photo: Use the last image in the camera roll.\nTake Photo: Use the camera to take a photo.\nChoose Photo: Use the camera roll to choose an image.", preferredStyle: .actionSheet)
             
@@ -1151,10 +1147,20 @@ final class PVGameLibraryViewController: UIViewController, UITextFieldDelegate, 
             imagePickerActionSheet.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: { (action) in
                 imagePickerActionSheet.dismiss(animated: true, completion: nil)
             }))
-            present(imagePickerActionSheet, animated: true, completion: nil)
+        
+            presentActionSheetViewControllerForPopoverPresentation(imagePickerActionSheet, sourceView: sourceView)
+        }
+    
+        private func presentActionSheetViewControllerForPopoverPresentation(_ alertController: UIAlertController, sourceView: UIView) {
+            if traitCollection.userInterfaceIdiom == .pad {
+                alertController.popoverPresentationController?.sourceView = sourceView
+                alertController.popoverPresentationController?.sourceRect = sourceView.bounds
+            }
+            
+            present(alertController, animated: true)
         }
 
-        func pasteCustomArtwork(for game: PVGame) {
+        private func pasteCustomArtwork(for game: PVGame) {
             let pb = UIPasteboard.general
             var pastedImageMaybe: UIImage? = pb.image
 


### PR DESCRIPTION
Hello, it's a me again. 👋 

I saw #1436 where the app crashes on iPads when showing an action sheet.

This is a funny tidbit everybody has run into before once at least when using UIImagePicker on iPads (and how action sheets are being presented on iPad). Unlike on iPhones, on iPads it is being presented within a popover and popovers need certain information about the environment they're being presented in (where should the arrow point to, which view is the source of the interaction...). 

For a better explanation, check out my comment [here](https://github.com/Provenance-Emu/Provenance/issues/1436#issuecomment-753530659).