### PR TITLE
Adjust UISwitch size

### DIFF
--- a/Provenance/Game Library/UI/GameLaunchingViewController.swift
+++ b/Provenance/Game Library/UI/GameLaunchingViewController.swift
@@ -627,7 +627,7 @@ extension GameLaunchingViewController where Self: UIViewController {
                         textField.delegate = textEditBlocker // Weak ref
 
                         switchControl.translatesAutoresizingMaskIntoConstraints = false
-                        switchControl.transform = CGAffineTransform(scaleX: 0.75, y: 0.75)
+                        switchControl.transform = CGAffineTransform(scaleX: 0.55, y: 0.55)
                     }
                 #endif
 


### PR DESCRIPTION
### What does this PR do
This pull request reduces the size of the switch so that the vertical margins are more equal.

### How should this be manually tested

Start a game on iOS that has a saved state.

### Screenshots (important for UI changes)

Before:
<img src="https://user-images.githubusercontent.com/2276355/127569586-cf838888-7bc1-4680-8075-fb6b69cb4267.PNG" height="500">

After:
<img src="https://user-images.githubusercontent.com/2276355/127569594-f8bd61c8-715c-4857-a813-2f7319b5cb9d.PNG" height="500">
