### PR TITLE
Fix pause-button on tvOS

### DIFF
--- a/Provenance/Emulator/PVEmulatorViewController.swift
+++ b/Provenance/Emulator/PVEmulatorViewController.swift
@@ -340,23 +340,16 @@ final class PVEmulatorViewController: PVEmulatorViewControllerRootClass, PVAudio
         gameAudio.volume = PVSettingsModel.shared.volume
         gameAudio.outputDeviceID = 0
         gameAudio.start()
-
         #if os(tvOS)
-            // Adding a tap gesture recognizer for the menu type will override the default 'back' functionality of tvOS
-            if menuGestureRecognizer == nil {
-                menuGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(PVEmulatorViewController.controllerPauseButtonPressed(_:)))
-                menuGestureRecognizer?.allowedPressTypes = [.menu]
-            }
-            if let aRecognizer = menuGestureRecognizer {
-                view.addGestureRecognizer(aRecognizer)
-            }
-        #else
-            GCController.controllers().filter({ $0.vendorName != "Remote" }).forEach { [unowned self] in
-                $0.controllerPausedHandler = { controller in
-                    self.controllerPauseButtonPressed(controller)
-                }
-            }
+        // On tvOS the siri-remotes menu-button will default to go back in the hierachy (thus dismissing the emulator), we don't want that behaviour
+        // (we'd rather pause the game), so we just install a tap-recognizer here (that doesn't do anything), and add our own logic in `setupPauseHandler`
+        if menuGestureRecognizer == nil {
+            menuGestureRecognizer = UITapGestureRecognizer()
+            menuGestureRecognizer?.allowedPressTypes = [.menu]
+            view.addGestureRecognizer(menuGestureRecognizer!)
+        }
         #endif
+        GCController.controllers().forEach { $0.setupPauseHandler(onPause: self.controllerPauseButtonPressed) }
     }
 
     public override func viewDidAppear(_: Bool) {
@@ -680,7 +673,7 @@ extension PVEmulatorViewController {
     }
 
     // #endif
-    @objc func controllerPauseButtonPressed(_: Any?) {
+    func controllerPauseButtonPressed() {
         DispatchQueue.main.async(execute: { () -> Void in
             if !self.isShowingMenu {
                 self.showMenu(self)
@@ -696,12 +689,7 @@ extension PVEmulatorViewController {
         if !(controller is PViCade8BitdoController || controller is PViCade8BitdoZeroController) {
             menuButton?.isHidden = true
             // In instances where the controller is connected *after* the VC has been shown, we need to set the pause handler
-            // Except for the Apple Remote, where it's handled in the menuGestureRecognizer
-//             if controller?.vendorName != "Remote" {
-//                 controller?.controllerPausedHandler = { [unowned self] controller in
-//                     self.controllerPauseButtonPressed(controller)
-//                 }
-//             }
+            controller?.setupPauseHandler(onPause: controllerPauseButtonPressed)
             #if os(iOS)
                 if #available(iOS 11.0, *) {
                     setNeedsUpdateOfHomeIndicatorAutoHidden()
@@ -892,5 +880,32 @@ extension NSNumber {
 
     private convenience init(touchType: UITouch.TouchType) {
         self.init(integerLiteral: touchType.rawValue)
+    }
+}
+
+extension GCController {
+    func setupPauseHandler(onPause: @escaping () -> Void) {
+        // Using buttonMenu is the recommended way for iOS/tvOS13 and later
+        if let buttonMenu = buttonMenu {
+            buttonMenu.pressedChangedHandler = { _, _, isPressed in
+                if isPressed {
+                    onPause()
+                }
+            }
+        } else {
+            // Fallback to the old method
+            controllerPausedHandler = { _ in onPause() }
+        }
+    }
+
+    private var buttonMenu: GCControllerButtonInput? {
+        if #available(tvOS 13.0, *) {
+            if let microGamepad = microGamepad {
+                return microGamepad.buttonMenu
+            } else if let extendedGamepad = extendedGamepad {
+                return extendedGamepad.buttonMenu
+            }
+        }
+        return nil
     }
 }

--- a/Provenance/Emulator/PVEmulatorViewController.swift
+++ b/Provenance/Emulator/PVEmulatorViewController.swift
@@ -662,17 +662,6 @@ extension PVEmulatorViewController {
 // MARK: - Controllers
 
 extension PVEmulatorViewController {
-    // #if os(tvOS)
-    // Ensure that override of menu gesture is caught and handled properly for tvOS
-    override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
-        if let press = presses.first, press.type == .menu, !isShowingMenu {
-            //         [self controllerPauseButtonPressed];
-        } else {
-            super.pressesBegan(presses, with: event)
-        }
-    }
-
-    // #endif
     func controllerPauseButtonPressed() {
         DispatchQueue.main.async(execute: { () -> Void in
             if !self.isShowingMenu {


### PR DESCRIPTION
### What does this PR do
This partially reverts #1473 since that broke the pause-button behaviour (for me at least).
This PR also refactors the code related to pause/menu-button handling a bit, and uses the new `buttonMenu` API:s (if available).

### How should this be manually tested
I've tested on ATV 4K (tvOS 14.7) with a DS4 and the Siri remote, would be nice with some testing with other combos as well. Just verify that the pause/menu/start button brings up the provenance menu and pauses the game as expected.

It would be extra nice if @dnicolson could verify that this does indeed work, so that we're not breaking things for each other 😄 