### PR TITLE
Add missing iOS 13.0 to #availability check

### DIFF
--- a/Provenance/Emulator/PVEmulatorViewController.swift
+++ b/Provenance/Emulator/PVEmulatorViewController.swift
@@ -888,7 +888,7 @@ extension GCController {
     }
 
     private var buttonMenu: GCControllerButtonInput? {
-        if #available(tvOS 13.0, *) {
+        if #available(iOS 13.0, tvOS 13.0, *) {
             if let microGamepad = microGamepad {
                 return microGamepad.buttonMenu
             } else if let extendedGamepad = extendedGamepad {


### PR DESCRIPTION
So, I messed up in #1570 and didn't add a proper check for iOS 13.0 availability, here it is.

Also going to look into just getting a GitHub-action that builds for iOS and tvOS, as a bare-minimum check :) 

Fixes #1574