### PR TITLE
[WIP] Add a workflow for building the app for both tvOS and iOS on github

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: Build app
+on:
+  pull_request:
+    branches:
+      - develop
+jobs:
+  ios:
+    name: iOS
+    runs-on: macOS-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+        with:
+          submodules: recursive
+      - name: Build app
+        uses: sersoft-gmbh/xcodebuild-action@v1.7
+        with:
+          workspace: Provenance.xcworkspace
+          scheme: Provenance
+          destination: "platform=iOS Simulator,name=iPhone 12"
+          action: build
+  tvos:
+    name: tvOS
+    runs-on: macOS-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+        with:
+          submodules: recursive
+      - name: Build app
+        uses: sersoft-gmbh/xcodebuild-action@v1.7
+        with:
+          workspace: Provenance.xcworkspace
+          scheme: ProvenanceTV
+          destination: "platform=tvOS Simulator,name=Apple TV 4K"
+          action: build


### PR DESCRIPTION
This builds both `iOS` and `tvOS` on PR:s, and the config is much cleaner than the azure stuff, so maybe we should consider just getting rid of azure?

NB. The iOS-check fails, due to the issue fixed in #1572 