### PR TITLE
 Fix game titles if Show Game Titles is enabled

### DIFF
--- a/Provenance/Game Library/UI/Game Library/Reusable Views/PVGameLibraryCollectionViewCell.swift
+++ b/Provenance/Game Library/UI/Game Library/Reusable Views/PVGameLibraryCollectionViewCell.swift
@@ -462,7 +462,9 @@ final class PVGameLibraryCollectionViewCell: UICollectionViewCell {
     private func setup(with game: PVGame) {
         let artworkURL: String = game.customArtworkURL
         let originalArtworkURL: String = game.originalArtworkURL
-        titleLabel.text = game.title
+         if PVSettingsModel.shared.showGameTitles {
+             titleLabel.text = game.title
+         } else { titleLabel.text = nil }
 
         // TODO: May be renabled later
         let placeholderImageText: String = game.title

--- a/Provenance/Game Library/UI/Game Library/Reusable Views/PVGameLibraryCollectionViewCell.swift
+++ b/Provenance/Game Library/UI/Game Library/Reusable Views/PVGameLibraryCollectionViewCell.swift
@@ -462,9 +462,7 @@ final class PVGameLibraryCollectionViewCell: UICollectionViewCell {
     private func setup(with game: PVGame) {
         let artworkURL: String = game.customArtworkURL
         let originalArtworkURL: String = game.originalArtworkURL
-        if PVSettingsModel.shared.showGameTitles {
-            titleLabel.text = game.title
-        }
+        titleLabel.text = game.title
 
         // TODO: May be renabled later
         let placeholderImageText: String = game.title


### PR DESCRIPTION
### What does this PR do
This pull request sets the game title even if the Show Game Titles option is disabled. If the text is not set and Show Game Titles is enabled after adding a game the placeholder "Long Game Title: Extra Extra Long Exaggerated Long Game Subtitle" text is displayed instead. 