### PR TITLE
Fix game titles if Show Game Titles is enabled

### DIFF
--- a/Provenance/Game Library/UI/Game Library/Reusable Views/PVGameLibraryCollectionViewCell.swift
+++ b/Provenance/Game Library/UI/Game Library/Reusable Views/PVGameLibraryCollectionViewCell.swift
@@ -464,7 +464,7 @@ final class PVGameLibraryCollectionViewCell: UICollectionViewCell {
         let originalArtworkURL: String = game.originalArtworkURL
         if PVSettingsModel.shared.showGameTitles {
             titleLabel.text = game.title
-        }
+        } else { titleLabel.text = nil }
 
         // TODO: May be renabled later
         let placeholderImageText: String = game.title


### PR DESCRIPTION
Update Provenance/Game Library/UI/Game Library/Reusable Views/PVGameLibraryCollectionViewCell.swift

Adding a proper else case to remove default string

Fix search field on iOS 11 and later

### What does this PR do

### Where should the reviewer start

### How should this be manually tested

### Any background context you want to provide

### What are the relevant tickets

### Screenshots (important for UI changes)

### Questions
