### PR TITLE
[WIP] Use XCConfig for build settings

### DIFF
--- a/Build.xcconfig
+++ b/Build.xcconfig
@@ -1,0 +1,38 @@
+//
+// Copyright © 2021 osy. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+MARKETING_VERSION = 2.2.4
+CURRENT_PROJECT_VERSION = 36
+
+// Codesigning settings defined optionally, see Documentation/iOSDevelopment.md
+#include? "CodeSigning.xcconfig"
+
+// Entitlements based off of CodeSigning settings
+IOS_CODE_SIGN_ENTITLEMENTS_YES = Platform/iOS/iOS.entitlements
+IOS_CODE_SIGN_ENTITLEMENTS_NO =
+IOS_CODE_SIGN_ENTITLEMENTS = $(IOS_CODE_SIGN_ENTITLEMENTS_$(DEVELOPER_ACCOUNT_PAID:default=NO))
+MAC_CODE_SIGN_ENTITLEMENTS_YES = Platform/macOS/macOS.entitlements
+MAC_CODE_SIGN_ENTITLEMENTS_NO = Platform/macOS/macOS-unsigned.entitlements
+MAC_CODE_SIGN_ENTITLEMENTS = $(MAC_CODE_SIGN_ENTITLEMENTS_$(DEVELOPER_ACCOUNT_VM_ACCESS:default=NO))
+HELPER_CODE_SIGN_ENTITLEMENTS_YES = QEMUHelper/QEMUHelper.entitlements
+HELPER_CODE_SIGN_ENTITLEMENTS_NO = QEMUHelper/QEMUHelper-unsigned.entitlements
+HELPER_CODE_SIGN_ENTITLEMENTS = $(HELPER_CODE_SIGN_ENTITLEMENTS_$(DEVELOPER_ACCOUNT_VM_ACCESS:default=NO))
+LAUNCHER_CODE_SIGN_ENTITLEMENTS_YES = QEMULauncher/QEMULauncher.entitlements
+LAUNCHER_CODE_SIGN_ENTITLEMENTS_NO = QEMULauncher/QEMULauncher-unsigned.entitlements
+LAUNCHER_CODE_SIGN_ENTITLEMENTS = $(LAUNCHER_CODE_SIGN_ENTITLEMENTS_$(DEVELOPER_ACCOUNT_VM_ACCESS:default=NO))

--- a/CodeSigning.xcconfig.sample
+++ b/CodeSigning.xcconfig.sample
@@ -1,0 +1,52 @@
+// Your Team ID. See `Documentation/iOSDevelopment.md` for help finding this.
+DEVELOPMENT_TEAM = XYZ0123456
+
+// Prefix of unique bundle IDs registered to you in Apple Developer Portal.
+// You need to register:
+//   - com.myuniquename.UTM
+//   - com.myuniquename.QEMUHelper
+//   - com.myuniquename.QEMULauncher
+PRODUCT_BUNDLE_PREFIX = com.myuniquename
+
+// Set to YES if you have a valid paid Apple Developer account
+DEVELOPER_ACCOUNT_PAID = NO
+
+// Set to YES if you have access to VM entitlements in your account
+DEVELOPER_ACCOUNT_VM_ACCESS = NO
+
+// Name of the iOS development signing certificate, you probably do not need
+// to change this.
+CODE_SIGN_IDENTITY_IOS = Apple Development
+
+// The values below are specific to macOS development. If you do not define
+// these keys, the build will default to ad-hoc signing. You will need to
+// follow `Documentation/MacDevelopment.md` to disable library verification and
+// remove unsupported entitlements.
+
+// Name of the macOS development signing certificate. Comment out this line to
+// use ad-hoc signing.
+CODE_SIGN_IDENTITY_MAC = Apple Development
+
+// Create a Mac provisioning profile for com.myuniquename.UTM with the
+// Hypervisor entitlements and get its UUID. If you do not have access to these
+// entitlements, comment out the line and delete the following entitlements
+//   - com.apple.vm.device-access
+// from the following file
+//   - Platform/macOS/macOS.entitlements
+PROVISIONING_PROFILE_SPECIFIER_MAC = 00000000-1111-2222-3333-444444444444
+
+// Create a Mac provisioning profile for com.myuniquename.QEMUHelper with the
+// Hypervisor entitlements and get its UUID. If you do not have access to these
+// entitlements, comment out the line and delete the following entitlements
+//   - com.apple.vm.networking
+// from the following file
+//   - QEMUHelper/QEMUHelper.entitlements
+PROVISIONING_PROFILE_SPECIFIER_HELPER = 00000000-1111-2222-3333-555555555555
+
+// Create a Mac provisioning profile for com.myuniquename.QEMULauncher with the
+// Hypervisor entitlements and get its UUID. If you do not have access to these
+// entitlements, comment out the line and delete the following entitlements
+//   - com.apple.vm.networking
+// from the following file
+//   - QEMULauncher/QEMULauncher.entitlements
+PROVISIONING_PROFILE_SPECIFIER_LAUNCHER = 00000000-1111-2222-3333-555555555555


### PR DESCRIPTION
Easier import of overriding the `com.provenance-emu` part of the build using something I just learned,

`import? ...` in .xconfig is a way to import a file if it exists.


Adding a demo example from UTM.app for now so I don't forget this