### PR TITLE
Update ProvenanceTV-Release.xcscheme

### DIFF
--- a/Provenance.xcworkspace/xcshareddata/xcschemes/ProvenanceTV-Release.xcscheme
+++ b/Provenance.xcworkspace/xcshareddata/xcschemes/ProvenanceTV-Release.xcscheme
@@ -3,8 +3,8 @@
    LastUpgradeVersion = "1300"
    version = "2.0">
    <BuildAction
-      parallelizeBuildables = "NO"
-      buildImplicitDependencies = "NO">
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"


### PR DESCRIPTION
Add back in "Parallelized Build" support and "Implicit dependency" tracking for the tvOS Release Scheme.
