### PR TITLE
Adjust README heading to support Dark Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center" style="text-align: center; align: center">
-<h1 align="center"><a href="http://www.provenance-emu.com" style="color:black;text-decoration:none;visited-color:black">Provenance</a></h1>
+<h1 align="center"><a href="http://www.provenance-emu.com" style="text-decoration:none;color:inherit;">Provenance</a></h1>
 <h4 align="center" style="text-align: center; align: center">An iOS & tvOS Frontend for Multiple Emulators</h4>
 </p>
 


### PR DESCRIPTION
### What does this PR do
This pull request adjusts the `h1` style to appear as light or dark depending on how it is viewed. Editing the file in Typora now appears as white and in Gitfox appears as light or dark depending on if Dark Mode is enabled. Also, on GitHub the black styling appears to have no effect.