### PR TITLE
PCE/TG16 Mednafen Audio tweaks

### DIFF
--- a/Cores/Mednafen/MednafenGameCore.mm
+++ b/Cores/Mednafen/MednafenGameCore.mm
@@ -240,6 +240,8 @@ static void mednafen_init(MednafenGameCore* current)
     Mednafen::MDFNI_SetSetting("pce.slend", "239"); // PCE: Last rendered scanline 235 default, 241 max
     Mednafen::MDFNI_SetSetting("pce.h_overscan", "1"); // PCE: Show horizontal overscan are, default 0. Needed for correctly displaying the system aspect ratio.
     Mednafen::MDFNI_SetSetting("pce.resamp_quality", "5"); // PCE: Audio resampler quality, default 3 Higher values correspond to better SNR and better preservation of higher frequencies("brightness"), at the cost of increased computational complexity and a negligible increase in latency. Higher values will also slightly increase the probability of sample clipping(relevant if Mednafen's volume control settings are set too high), due to increased (time-domain) ringing.
+    Mednafen::MDFNI_SetSetting("pce.resamp_rate_error", "0.0000001"); // PCE: Sound output rate tolerance. Lower values correspond to better matching of the output rate of the resampler to the actual desired output rate, at the expense of increased RAM usage and poorer CPU cache utilization. default 0.0000009
+    Mednafen::MDFNI_SetSetting("pce.cdpsgvolume", "62"); // PCE: PSG volume when playing a CD game. Setting this volume control too high may cause sample clipping. default 100
 
 	// PCE_Fast settings
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ _Provenance_ is our origin story. The word has a similar meaning to _Genesis_, w
   - PC Engine Super CD-ROM² System / TurboGrafx-CD
   - PC Engine SuperGrafx
   - PC-FX
-- Nintendo
+- Nintendo 
   - Nintendo Entertainment System / Famicom (NES/FC)
   - Famicom Disk System
   - Super Nintendo Entertainment System / Super Famicom (SNES/SFC)


### PR DESCRIPTION
A set of two PCE module audio related setting tweaks that enable Provenance's PCE Audio output to match much closer to the measured MDFourier output of a real system, as tested with [@artemio](https://github.com/ArtemioUrbina) from the MDFourier project.