### PR TITLE
(Possible) Mupen N64 Core fix for tvOS/iOS

### DIFF
--- a/Cores/Mupen64Plus/MupenGameCore.m
+++ b/Cores/Mupen64Plus/MupenGameCore.m
@@ -1021,7 +1021,7 @@ static void ConfigureRICE() {
 
 	BOOL success = NO;
 
-#if !TARGET_OS_MAC
+#if !TARGET_OS_MACCATALYST
 	EAGLContext* context = [self bestContext];
 #endif
 
@@ -1127,7 +1127,7 @@ static void ConfigureRICE() {
     return YES;
 }
 
-#if !TARGET_OS_MAC
+#if !TARGET_OS_MACCATALYST
 -(EAGLContext*)bestContext {
 	EAGLContext* context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES3];
 	self.glesVersion = GLESVersion3;


### PR DESCRIPTION
This changes the EAGLContext bestContext block #if ! statements that are currently (probably) not allowing the Mupen N64 core to render any video.

@JoeMatt will need to confirm that this is the right solution of course.