### PR TITLE
Update TVL in crt_fragment.glsl to reduce moirée effects at UHD

### DIFF
--- a/Provenance/Utilities/shaders/crt/crt_fragment.glsl
+++ b/Provenance/Utilities/shaders/crt/crt_fragment.glsl
@@ -59,7 +59,7 @@ uniform vec2 FinalRes;
 #define SCANLINE_MIN_BRIGHTNESS vec3( 0.25, 0.25, 0.25 )
 #define SHADOW_MASK_HARDNESS 16.0
 
-#define TVL 350.0
+#define TVL 800.0
 
 #define WARP_EDGE_HARDNESS 256.0
 #define WARP_X ( 1.0 / 96.0 )


### PR DESCRIPTION
Update the TVL(ines) parameter in the CRT shader from 350.0 to 800.0 to match a Sony BVM and to also help reduce the moirée artifacts that we see on the AppleTV at UHD / 4K.