### PR TITLE
Speedup Mednafen compile, and LIKELY compiler hints

### DIFF
--- a/Cores/Mednafen/PVMednafen.xcodeproj/project.pbxproj
+++ b/Cores/Mednafen/PVMednafen.xcodeproj/project.pbxproj
@@ -607,7 +607,6 @@
 		B32CF1D1219240770058E2E7 /* libneogeopocket-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B32CF17821923F520058E2E7 /* libneogeopocket-tvOS.a */; };
 		B32CF1D2219240770058E2E7 /* libpce-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B32CF19F21923F790058E2E7 /* libpce-tvOS.a */; };
 		B32CF1D3219240770058E2E7 /* libpcefast-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B32CF1B121923F7F0058E2E7 /* libpcefast-tvOS.a */; };
-		B32CF1D4219240770058E2E7 /* libsegamastersystem-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B32CF1C421923F850058E2E7 /* libsegamastersystem-tvOS.a */; };
 		B32CF1D5219240770058E2E7 /* libvirtualboy-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B32CF15521923F330058E2E7 /* libvirtualboy-tvOS.a */; };
 		B32CF1D6219241EE0058E2E7 /* libhwvideo-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B324C34C21919C1C009F4EDC /* libhwvideo-tvOS.a */; };
 		B32CF1D7219241EE0058E2E7 /* libmednafen-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B324C42A21919D73009F4EDC /* libmednafen-tvOS.a */; };
@@ -913,7 +912,6 @@
 		B3335282207B02EB0036A448 /* libpce-iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B33351CB207B01860036A448 /* libpce-iOS.a */; };
 		B3335283207B02EB0036A448 /* libpcefast-iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B33351D8207B01970036A448 /* libpcefast-iOS.a */; };
 		B3335284207B02EB0036A448 /* libpcfx-iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B33351FC207B020C0036A448 /* libpcfx-iOS.a */; };
-		B3335285207B02EB0036A448 /* libsegamastersystem-iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B33351E5207B01C60036A448 /* libsegamastersystem-iOS.a */; };
 		B3335286207B02F70036A448 /* c65c02.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B3AAAC0020736EE80097D86F /* c65c02.cpp */; };
 		B3335287207B02F70036A448 /* cart.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B3AAAC0120736EE80097D86F /* cart.cpp */; };
 		B3335288207B02F70036A448 /* memmap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B3AAABEA20736EE80097D86F /* memmap.cpp */; };
@@ -1063,6 +1061,10 @@
 		B35D6689218185710005A992 /* v810_fp_ops.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B3AAAE0020736EE90097D86F /* v810_fp_ops.cpp */; };
 		B35D6691218185A60005A992 /* libhwcpu-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B35D6690218185710005A992 /* libhwcpu-tvOS.a */; };
 		B36CBFED2039819100728482 /* PVMednafen.h in Headers */ = {isa = PBXBuildFile; fileRef = B340E4641E08887700AD0E8B /* PVMednafen.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B393F252277C0C1C0097F71C /* m68k.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B3AAADEB20736EE90097D86F /* m68k.cpp */; };
+		B393F260277C0C4E0097F71C /* m68k.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B3AAADEB20736EE90097D86F /* m68k.cpp */; };
+		B393F261277C109C0097F71C /* libhwcpu-m68k-iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B393F251277C0BF70097F71C /* libhwcpu-m68k-iOS.a */; };
+		B393F262277C10A40097F71C /* libhwcpu-m68k-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B393F25F277C0C340097F71C /* libhwcpu-m68k-tvOS.a */; };
 		B3AAB425207379230097D86F /* stubs.mm in Sources */ = {isa = PBXBuildFile; fileRef = 94454E3B17852E61006C057B /* stubs.mm */; };
 		B3AAB43D2073820C0097D86F /* MednafenGameCore.mm in Sources */ = {isa = PBXBuildFile; fileRef = 824088350FFDDCF400F0FE7D /* MednafenGameCore.mm */; };
 		B3AAB43F2073820C0097D86F /* MednafenMultiDisc.m in Sources */ = {isa = PBXBuildFile; fileRef = B3CF44B72039B64A005BEB14 /* MednafenMultiDisc.m */; };
@@ -1241,7 +1243,6 @@
 		C6E1B64C25AAA042007C3CF1 /* rom.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B3AAB1E720736EEA0097D86F /* rom.cpp */; };
 		C6E1B64F25AAA24A007C3CF1 /* DSPUtility.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 11AFB2CC24880BF3000A3922 /* DSPUtility.cpp */; };
 		C6E1B65125AAA24A007C3CF1 /* SwiftResampler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 11AFB2CD24880BF3000A3922 /* SwiftResampler.cpp */; };
-		C6E1B65225AAA3EA007C3CF1 /* m68k.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B3AAADEB20736EE90097D86F /* m68k.cpp */; };
 		C6E1B66F25AAC1B1007C3CF1 /* scu_dsp_misc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B3AAB17B20736EEA0097D86F /* scu_dsp_misc.cpp */; };
 		C6E1B67025AAC1B1007C3CF1 /* scu_dsp_jmp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B3AAB18020736EEA0097D86F /* scu_dsp_jmp.cpp */; };
 		C6E1B67125AAC1B1007C3CF1 /* 3dpad.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B3AAB18920736EEA0097D86F /* 3dpad.cpp */; };
@@ -1275,7 +1276,6 @@
 		C6E1B68D25AAC1B2007C3CF1 /* cart.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B3AAB21520736EEB0097D86F /* cart.cpp */; };
 		C6E1B68E25AAC1B2007C3CF1 /* vdp1.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B3AAB21620736EEB0097D86F /* vdp1.cpp */; };
 		C6E1B68F25AAC1B2007C3CF1 /* scu_dsp_gen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B3AAB21820736EEB0097D86F /* scu_dsp_gen.cpp */; };
-		C6E1B69225AAC1FC007C3CF1 /* m68k.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B3AAADEB20736EE90097D86F /* m68k.cpp */; };
 		C6E1B69325AAC243007C3CF1 /* DSPUtility.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 11AFB2CC24880BF3000A3922 /* DSPUtility.cpp */; };
 		C6E1B69425AAC243007C3CF1 /* SwiftResampler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 11AFB2CD24880BF3000A3922 /* SwiftResampler.cpp */; };
 		C6E1B69525AAC5A3007C3CF1 /* libsaturn-iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C6E1B66E25AAC123007C3CF1 /* libsaturn-iOS.a */; };
@@ -2138,6 +2138,24 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		B393F24C277C0BF70097F71C /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B393F25A277C0C340097F71C /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B3FBDEF6207FF0E300E661D1 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2314,6 +2332,8 @@
 		B34CB0EC2274BA81009134B4 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		B3547B5F205858EF00CFF7D8 /* Core.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Core.plist; sourceTree = "<group>"; };
 		B35D6690218185710005A992 /* libhwcpu-tvOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libhwcpu-tvOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B393F251277C0BF70097F71C /* libhwcpu-m68k-iOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libhwcpu-m68k-iOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B393F25F277C0C340097F71C /* libhwcpu-m68k-tvOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libhwcpu-m68k-tvOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B3A74C8C20522B86001D3D2E /* MednafenGameCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MednafenGameCore.swift; sourceTree = "<group>"; };
 		B3AA9D6A20736B030097D86F /* README.PORTING */ = {isa = PBXFileReference; lastKnownFileType = text; path = README.PORTING; sourceTree = "<group>"; };
 		B3AA9D6B20736B030097D86F /* acinclude.m4 */ = {isa = PBXFileReference; lastKnownFileType = text; path = acinclude.m4; sourceTree = "<group>"; };
@@ -4297,6 +4317,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B393F261277C109C0097F71C /* libhwcpu-m68k-iOS.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4391,7 +4412,6 @@
 				B3335282207B02EB0036A448 /* libpce-iOS.a in Frameworks */,
 				B3335283207B02EB0036A448 /* libpcefast-iOS.a in Frameworks */,
 				B3335284207B02EB0036A448 /* libpcfx-iOS.a in Frameworks */,
-				B3335285207B02EB0036A448 /* libsegamastersystem-iOS.a in Frameworks */,
 				B333519F207B01230036A448 /* libgb-iOS.a in Frameworks */,
 				B33350AE207B00080036A448 /* libnes-iOS.a in Frameworks */,
 				B333509C207AFF3F0036A448 /* libvirtualboy-iOS.a in Frameworks */,
@@ -4417,7 +4437,6 @@
 				B32CF1D1219240770058E2E7 /* libneogeopocket-tvOS.a in Frameworks */,
 				B32CF1D2219240770058E2E7 /* libpce-tvOS.a in Frameworks */,
 				B32CF1D3219240770058E2E7 /* libpcefast-tvOS.a in Frameworks */,
-				B32CF1D4219240770058E2E7 /* libsegamastersystem-tvOS.a in Frameworks */,
 				B32CF1D5219240770058E2E7 /* libvirtualboy-tvOS.a in Frameworks */,
 				B32CF14721923F030058E2E7 /* libhwaudio-tvOS.a in Frameworks */,
 				B324C62521920724009F4EDC /* libgba-tvOS.a in Frameworks */,
@@ -4442,6 +4461,21 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		B35D668B218185710005A992 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B393F262277C10A40097F71C /* libhwcpu-m68k-tvOS.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B393F24B277C0BF70097F71C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B393F259277C0C340097F71C /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -4613,6 +4647,8 @@
 				B32CF1CE219240270058E2E7 /* libhwmisc-tvOS.a */,
 				C6E1B62825AA9C15007C3CF1 /* libsaturn-tvOS.a */,
 				C6E1B66E25AAC123007C3CF1 /* libsaturn-iOS.a */,
+				B393F251277C0BF70097F71C /* libhwcpu-m68k-iOS.a */,
+				B393F25F277C0C340097F71C /* libhwcpu-m68k-tvOS.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -8599,6 +8635,40 @@
 			productReference = B35D6690218185710005A992 /* libhwcpu-tvOS.a */;
 			productType = "com.apple.product-type.library.static";
 		};
+		B393F245277C0BF70097F71C /* hwcpu-m68k-iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B393F24D277C0BF70097F71C /* Build configuration list for PBXNativeTarget "hwcpu-m68k-iOS" */;
+			buildPhases = (
+				B393F246277C0BF70097F71C /* Sources */,
+				B393F24B277C0BF70097F71C /* Frameworks */,
+				B393F24C277C0BF70097F71C /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "hwcpu-m68k-iOS";
+			productName = hwcpu;
+			productReference = B393F251277C0BF70097F71C /* libhwcpu-m68k-iOS.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		B393F253277C0C340097F71C /* hwcpu-m68k-tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B393F25B277C0C340097F71C /* Build configuration list for PBXNativeTarget "hwcpu-m68k-tvOS" */;
+			buildPhases = (
+				B393F254277C0C340097F71C /* Sources */,
+				B393F259277C0C340097F71C /* Frameworks */,
+				B393F25A277C0C340097F71C /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "hwcpu-m68k-tvOS";
+			productName = hwcpu;
+			productReference = B393F25F277C0C340097F71C /* libhwcpu-m68k-tvOS.a */;
+			productType = "com.apple.product-type.library.static";
+		};
 		B3FBDEF7207FF0E300E661D1 /* snes-iOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = B3FBDF00207FF0E400E661D1 /* Build configuration list for PBXNativeTarget "snes-iOS" */;
@@ -8843,6 +8913,8 @@
 				B324C34421919C1C009F4EDC /* hwvideo-tvOS */,
 				B33352C0207B06730036A448 /* hwcpu-iOS */,
 				B35D6684218185710005A992 /* hwcpu-tvOS */,
+				B393F245277C0BF70097F71C /* hwcpu-m68k-iOS */,
+				B393F253277C0C340097F71C /* hwcpu-m68k-tvOS */,
 				B33352CD207B067F0036A448 /* hwmisc-iOS */,
 				B32CF1C5219240270058E2E7 /* hwmisc-tvOS */,
 				B333546E207B1B500036A448 /* cdrom-iOS */,
@@ -10044,7 +10116,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C6E1B69225AAC1FC007C3CF1 /* m68k.cpp in Sources */,
 				B33352E8207B07C20036A448 /* z80_ops.cpp in Sources */,
 				B33352E0207B06D70036A448 /* v810_cpu.cpp in Sources */,
 				B33352E9207B07FD0036A448 /* z80.cpp in Sources */,
@@ -10259,11 +10330,26 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C6E1B65225AAA3EA007C3CF1 /* m68k.cpp in Sources */,
 				B35D6686218185710005A992 /* z80_ops.cpp in Sources */,
 				B35D6687218185710005A992 /* v810_cpu.cpp in Sources */,
 				B35D6688218185710005A992 /* z80.cpp in Sources */,
 				B35D6689218185710005A992 /* v810_fp_ops.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B393F246277C0BF70097F71C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B393F252277C0C1C0097F71C /* m68k.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B393F254277C0C340097F71C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B393F260277C0C4E0097F71C /* m68k.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -10948,7 +11034,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_INCREASE_PRECOMPILED_HEADER_SHARING = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_OPTIMIZATION_LEVEL = 2;
+				GCC_OPTIMIZATION_LEVEL = s;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					WANT_GB_EMU,
 					WANT_GBA_EMU,
@@ -11597,7 +11683,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_INCREASE_PRECOMPILED_HEADER_SHARING = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_OPTIMIZATION_LEVEL = 2;
+				GCC_OPTIMIZATION_LEVEL = s;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					WANT_GB_EMU,
 					WANT_GBA_EMU,
@@ -16321,6 +16407,185 @@
 			};
 			name = Release;
 		};
+		B393F24E277C0BF70097F71C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRIP_INSTALLED_PRODUCT = NO;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+				TARGETED_DEVICE_FAMILY = "1,2,6";
+			};
+			name = Debug;
+		};
+		B393F24F277C0BF70097F71C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_OPTIMIZATION_LEVEL = 1;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRIP_INSTALLED_PRODUCT = NO;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+				TARGETED_DEVICE_FAMILY = "1,2,6";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		B393F250277C0BF70097F71C /* Archive */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_OPTIMIZATION_LEVEL = 1;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRIP_INSTALLED_PRODUCT = NO;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+				TARGETED_DEVICE_FAMILY = "1,2,6";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Archive;
+		};
+		B393F25C277C0C340097F71C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				STRIP_INSTALLED_PRODUCT = NO;
+				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
+				TARGETED_DEVICE_FAMILY = 3;
+			};
+			name = Debug;
+		};
+		B393F25D277C0C340097F71C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_OPTIMIZATION_LEVEL = s;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				STRIP_INSTALLED_PRODUCT = NO;
+				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
+				TARGETED_DEVICE_FAMILY = 3;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		B393F25E277C0C340097F71C /* Archive */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_OPTIMIZATION_LEVEL = s;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				STRIP_INSTALLED_PRODUCT = NO;
+				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
+				TARGETED_DEVICE_FAMILY = 3;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Archive;
+		};
 		B3FBDEFE207FF0E300E661D1 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -17232,6 +17497,26 @@
 				B35D668E218185710005A992 /* Debug */,
 				B35D668F218185710005A992 /* Release */,
 				B324C4F02191A22A009F4EDC /* Archive */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B393F24D277C0BF70097F71C /* Build configuration list for PBXNativeTarget "hwcpu-m68k-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B393F24E277C0BF70097F71C /* Debug */,
+				B393F24F277C0BF70097F71C /* Release */,
+				B393F250277C0BF70097F71C /* Archive */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B393F25B277C0C340097F71C /* Build configuration list for PBXNativeTarget "hwcpu-m68k-tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B393F25C277C0C340097F71C /* Debug */,
+				B393F25D277C0C340097F71C /* Release */,
+				B393F25E277C0C340097F71C /* Archive */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Cores/Mupen64Plus/MupenGameCore.m
+++ b/Cores/Mupen64Plus/MupenGameCore.m
@@ -120,7 +120,8 @@ static void MupenStateCallback(void *context, m64p_core_param paramType, int new
 @implementation MupenGameCore
 {
     NSData *romData;
-    
+    NSOperationQueue *_inputQueue;
+
     dispatch_semaphore_t mupenWaitToBeginFrameSemaphore;
     dispatch_semaphore_t coreWaitToEndFrameSemaphore;
 
@@ -161,6 +162,11 @@ static void MupenStateCallback(void *context, m64p_core_param paramType, int new
 
         _callbackQueue = dispatch_queue_create("org.openemu.MupenGameCore.CallbackHandlerQueue", DISPATCH_QUEUE_SERIAL);
         _callbackHandlers = [[NSMutableDictionary alloc] init];
+        
+        _inputQueue = [[NSOperationQueue alloc] init];
+        _inputQueue.name = @"mupen.input";
+        _inputQueue.qualityOfService = NSOperationQueuePriorityHigh;
+        _inputQueue.maxConcurrentOperationCount = 4;
     }
     _current = self;
     return self;
@@ -170,6 +176,8 @@ static void MupenStateCallback(void *context, m64p_core_param paramType, int new
 {
     SetStateCallback(NULL, NULL);
     SetDebugCallback(NULL, NULL);
+    
+    [_inputQueue cancelAllOperations];
     
     [self pluginsUnload];
     [self detachCoreLib];
@@ -499,23 +507,39 @@ static void MupenControllerCommand(int Control, unsigned char *Command)
 }
 
 - (void)pollControllers {
+#define con(num) [self.controller##num capture]
+//#define con(num) self.controller##num
+
+#if 0
+    [self pollController:con(1) forIndedx:0];
+    [self pollController:con(2) forIndedx:1];
+    [self pollController:con(3) forIndedx:2];
+    [self pollController:con(4) forIndedx:3];
+#else
 //    const NSOperationQueue *queue = [NSOperationQueue currentQueue];
-//
-//    NSArray<NSBlockOperation*>* ops = @[
-//    [NSBlockOperation blockOperationWithBlock:^{
-        [self pollController:self.controller1 forIndedx:0];
-//    }],
-//    [NSBlockOperation blockOperationWithBlock:^{
-        [self pollController:self.controller2 forIndedx:1];
-//    }],
-//    [NSBlockOperation blockOperationWithBlock:^{
-        [self pollController:self.controller3 forIndedx:2];
-//    }],
-//    [NSBlockOperation blockOperationWithBlock:^{
-        [self pollController:self.controller4 forIndedx:3];
-//    }]
-//    ];
-//    [queue addOperations:ops waitUntilFinished:false];
+    [_inputQueue cancelAllOperations];
+    NSArray<NSBlockOperation*>* ops = @[
+    [NSBlockOperation blockOperationWithBlock:^{
+        if(!self.controller1) { return; }
+        [self pollController:con(1)  forIndedx:0];
+    }],
+    [NSBlockOperation blockOperationWithBlock:^{
+        if(!self.controller2) { return; }
+        [self pollController:con(2) forIndedx:1];
+    }],
+    [NSBlockOperation blockOperationWithBlock:^{
+        if(!self.controller3) { return; }
+        [self pollController:con(3) forIndedx:2];
+    }],
+    [NSBlockOperation blockOperationWithBlock:^{
+        if(!self.controller4) { return; }
+        [self pollController:con(4) forIndedx:3];
+    }]
+    ];
+//    [[NSOperationQueue currentQueue] addOperations:ops waitUntilFinished:NO];
+    [_inputQueue addOperations:ops waitUntilFinished:NO];
+#endif
+#undef con
 }
 
 static AUDIO_INFO AudioInfo;
@@ -1278,8 +1302,9 @@ static void ConfigureRICE() {
     }
 }
 
-- (void)stopEmulation
-{
+- (void)stopEmulation {
+    [_inputQueue cancelAllOperations];
+
     CoreDoCommand(M64CMD_STOP, 0, NULL);
     
     dispatch_semaphore_signal(mupenWaitToBeginFrameSemaphore);
@@ -1290,8 +1315,7 @@ static void ConfigureRICE() {
     [super stopEmulation];
 }
 
-- (void)resetEmulation
-{
+- (void)resetEmulation {
     // FIXME: do we want/need soft reset? It doesn’t seem to work well with sending M64CMD_RESET alone
     // FIXME: (astrange) should this method worry about this instance’s dispatch semaphores?
     CoreDoCommand(M64CMD_RESET, 1 /* hard reset */, NULL);
@@ -1363,6 +1387,8 @@ static void ConfigureRICE() {
 
          return !scheduleSaveState();
      }];
+    
+    [super saveStateToFileAtPath:fileName completionHandler:block];
 }
 
 

--- a/PVLibrary/PVLibrary/Database/OESQLiteDatabase.m
+++ b/PVLibrary/PVLibrary/Database/OESQLiteDatabase.m
@@ -88,7 +88,7 @@ NSString * const OESQLiteErrorDomain = @"OESQLiteErrorDomain";
 
         result = [NSMutableArray array];
 
-        while(sqlite3_step(stmt) == SQLITE_ROW)
+        while(LIKELY(sqlite3_step(stmt) == SQLITE_ROW))
         {
             int columnCount = sqlite3_column_count(stmt);
             NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithCapacity:columnCount];

--- a/PVLibrary/PVLibrary/NSExtensions/NSFileManager+Hashing.m
+++ b/PVLibrary/PVLibrary/NSExtensions/NSFileManager+Hashing.m
@@ -8,6 +8,7 @@
 
 #import "NSFileManager+Hashing.h"
 #import <CommonCrypto/CommonDigest.h>
+#import <PVSupport/DebugUtils.h>
 
 #define HASH_READ_CHUNK_SIZE (1024 * 32)
 
@@ -48,7 +49,7 @@
                 break;
             }
         }
-    } while (YES);
+    } while (LIKELY(YES));
     
     [handle closeFile];
     

--- a/PVSupport/DebugUtils.h
+++ b/PVSupport/DebugUtils.h
@@ -9,22 +9,28 @@
 #ifndef PVSupport_DebugUtils_h
 #define PVSupport_DebugUtils_h
 
+//MARK: Strong/Weak
 #define MAKEWEAK(x)\
 __weak __typeof(x)weak##x = x
 
 #define MAKESTRONG(x)\
 __strong __typeof(weak##x) strong##x = weak##x;
 
+//MARK: System Version
 #define SYSTEM_VERSION_EQUAL_TO(v)                  ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedSame)
 #define SYSTEM_VERSION_GREATER_THAN(v)              ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedDescending)
 #define SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(v)  ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedAscending)
 #define SYSTEM_VERSION_LESS_THAN(v)                 ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedAscending)
 #define SYSTEM_VERSION_LESS_THAN_OR_EQUAL_TO(v)     ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedDescending)
 
+// MARK: BOOLs
 #define BOOL_TOGGLE(x) \
 x ^= true
 
+// MARK: X-Macros
 #define QUOTE(...) @#__VA_ARGS__
+
+//MARK: Threading
 
 #define FORCEMAIN(x)                      \
 if (![NSThread isMainThread]) {           \
@@ -33,10 +39,15 @@ if (![NSThread isMainThread]) {           \
 	waitUntilDone:YES]; \
 	return;                                 \
 }
+#define PVAssertMainThread \
+NSAssert([NSThread isMainThread], @"Not main thread");
+
+// MARK: String
 
 #define PVStringF( s, ... ) [NSString stringWithFormat:(s), ##__VA_ARGS__]
 
-#define PVAssertMainThread \
-NSAssert([NSThread isMainThread], @"Not main thread");
+//MARK: Likely
+#define UNLIKELY(n) __builtin_expect((n) != 0, 0)
+#define LIKELY(n) __builtin_expect((n) != 0, 1)
 
 #endif

--- a/PVSupport/EmulatorCore/PVEmulatorCore.m
+++ b/PVSupport/EmulatorCore/PVEmulatorCore.m
@@ -217,7 +217,7 @@ NSString *const PVEmulatorCoreErrorDomain = @"org.provenance-emu.EmulatorCore.Er
     MakeCurrentThreadRealTime();
 
     //Emulation loop
-    while (!shouldStop) {
+    while (UNLIKELY(!shouldStop)) {
 
         [self updateControllers];
         

--- a/PVSupport/EmulatorCore/PVEmulatorCore.m
+++ b/PVSupport/EmulatorCore/PVEmulatorCore.m
@@ -324,7 +324,7 @@ NSString *const PVEmulatorCoreErrorDomain = @"org.provenance-emu.EmulatorCore.Er
         return;
     }
 
-    if (self.controller1 && self.controller1.isAttachedToDevice == NO) {
+    if (self.controller1 && !self.controller1.isAttachedToDevice) {
         // Don't rumble if using a controller and it's not an attached type.
         return;
     }

--- a/PVSupport/PVSupport/Audio/CARingBuffer/CARingBuffer.cpp
+++ b/PVSupport/PVSupport/Audio/CARingBuffer/CARingBuffer.cpp
@@ -47,7 +47,7 @@
 #include "CARingBuffer.h"
 #include "CABitOperations.h"
 #include "CAAutoDisposer.h"
-#include "CAAtomic.h"
+//#include "CAAtomic.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -220,7 +220,7 @@ CARingBufferError	CARingBuffer::Store(const AudioBufferList *abl, UInt32 framesT
 	
 	return kCARingBufferError_OK;	// success
 }
-
+#include <atomic>
 void	CARingBuffer::SetTimeBounds(SampleTime startTime, SampleTime endTime)
 {
 	UInt32 nextPtr = mTimeBoundsQueuePtr + 1;
@@ -229,7 +229,9 @@ void	CARingBuffer::SetTimeBounds(SampleTime startTime, SampleTime endTime)
 	mTimeBoundsQueue[index].mStartTime = startTime;
 	mTimeBoundsQueue[index].mEndTime = endTime;
 	mTimeBoundsQueue[index].mUpdateCounter = nextPtr;
-	CAAtomicCompareAndSwap32Barrier(mTimeBoundsQueuePtr, mTimeBoundsQueuePtr + 1, (SInt32*)&mTimeBoundsQueuePtr);
+//    std::atomic_compare_exchange_strong((volatile int32_t *)&mTimeBoundsQueuePtr, mTimeBoundsQueuePtr, mTimeBoundsQueuePtr + 1);
+    OSAtomicCompareAndSwap32Barrier(mTimeBoundsQueuePtr, mTimeBoundsQueuePtr + 1, (volatile int32_t *)&mTimeBoundsQueuePtr);
+//	CAAtomicCompareAndSwap32Barrier(mTimeBoundsQueuePtr, mTimeBoundsQueuePtr + 1, (SInt32*)&mTimeBoundsQueuePtr);
 }
 
 CARingBufferError	CARingBuffer::GetTimeBounds(SampleTime &startTime, SampleTime &endTime)

--- a/PVSupport/PVSupport/Audio/CARingBuffer/CARingBuffer.h
+++ b/PVSupport/PVSupport/Audio/CARingBuffer/CARingBuffer.h
@@ -118,7 +118,7 @@ protected:
 	} TimeBounds;
 	
 	CARingBuffer::TimeBounds mTimeBoundsQueue[kGeneralRingTimeBoundsQueueSize];
-	UInt32 mTimeBoundsQueuePtr;
+    volatile UInt32 mTimeBoundsQueuePtr;
 };
 
 

--- a/PVSupport/PVSupport/Audio/TPCircularBuffer.c
+++ b/PVSupport/PVSupport/Audio/TPCircularBuffer.c
@@ -31,6 +31,7 @@
 #include <mach/mach.h>
 #include <stdio.h>
 #include <stdlib.h>
+#import <PVSupport/DebugUtils.h>
 
 #define reportResult(result,operation) (_reportResult((result),(operation),strrchr(__FILE__, '/')+1,__LINE__))
 static inline bool _reportResult(kern_return_t result, const char *operation, const char* file, int line) {
@@ -52,7 +53,7 @@ bool _TPCircularBufferInit(TPCircularBuffer *buffer, uint32_t length, size_t str
     
     // Keep trying until we get our buffer, needed to handle race conditions
     int retries = 3;
-    while ( true ) {
+    while ( LIKELY(true) ) {
 
         buffer->length = (uint32_t)round_page(length);    // We need whole page sizes
 

--- a/PVSupport/PVSupport/NSFileManager+OEHashingAdditions.m
+++ b/PVSupport/PVSupport/NSFileManager+OEHashingAdditions.m
@@ -26,7 +26,7 @@
 
 #import "NSFileManager+OEHashingAdditions.h"
 #import <CommonCrypto/CommonDigest.h>
-
+#import "DebugUtils.h"
 #define HASH_READ_CHUNK_SIZE (1024 * 32)
 
 @implementation NSFileManager (OEHashingAdditions)
@@ -63,7 +63,7 @@
             
             if(data == nil || length < HASH_READ_CHUNK_SIZE) break;
         }
-    } while(YES);
+    } while(LIKELY(YES));
     
     [handle closeFile];
     

--- a/Provenance/Categories/UIImage+ImageEffects.m
+++ b/Provenance/Categories/UIImage+ImageEffects.m
@@ -219,7 +219,7 @@
                                   0,                    0,                    0,  1,
             };
             const int32_t divisor = 256;
-            NSUInteger matrixSize = sizeof(floatingPointSaturationMatrix)/sizeof(floatingPointSaturationMatrix[0]);
+            const NSUInteger matrixSize = sizeof(floatingPointSaturationMatrix)/sizeof(floatingPointSaturationMatrix[0]);
             int16_t saturationMatrix[matrixSize];
             for (NSUInteger i = 0; i < matrixSize; ++i) {
                 saturationMatrix[i] = (int16_t)roundf(floatingPointSaturationMatrix[i] * divisor);

--- a/Provenance/Emulator/PVGLViewController.m
+++ b/Provenance/Emulator/PVGLViewController.m
@@ -563,8 +563,6 @@ struct RenderSettings {
     };
 
     MAKEWEAK(self);
-    const BOOL rendersToOpenGL = [self.emulatorCore rendersToOpenGL];
-    const BOOL crtEnabled = self->renderSettings.crtFilterEnabled;
 
     void (^renderBlock)(void) = ^()
     {
@@ -573,6 +571,9 @@ struct RenderSettings {
         glClearColor(1.0, 1.0, 1.0, 1.0);
         glClear(GL_COLOR_BUFFER_BIT);
 #endif
+        const BOOL rendersToOpenGL = strongself->_emulatorCore.rendersToOpenGL;
+        const BOOL crtEnabled = strongself->renderSettings.crtFilterEnabled;
+
         GLuint frontBufferTex;
         if (UNLIKELY(rendersToOpenGL))
         {
@@ -638,8 +639,7 @@ struct RenderSettings {
         }
     };
     
-    if (UNLIKELY(rendersToOpenGL))
-    {
+    if (UNLIKELY(self.emulatorCore.rendersToOpenGL)) {
         // TODO: should isEmulationPaused be the always &&, not before the | ? @JoeMatt
         // if (LIKELY(!self.emulatorCore.isSpeedModified) && LIKELY(!self.emulatorCore.isEmulationPaused) && LIKELY(self.emulatorCore.isFrontBufferReady))
         if ((LIKELY(!self.emulatorCore.isSpeedModified) && LIKELY(!self.emulatorCore.isEmulationPaused)) || LIKELY(self.emulatorCore.isFrontBufferReady))
@@ -662,8 +662,7 @@ struct RenderSettings {
             }
         }
     }
-    else
-    {
+    else {
         if (UNLIKELY(self.emulatorCore.isSpeedModified))
         {
             fetchVideoBuffer();
@@ -685,8 +684,7 @@ struct RenderSettings {
                 [_emulatorCore.frontBufferLock unlock];
                 [_emulatorCore.frontBufferCondition unlock];
             }
-            else
-            {
+            else {
                 @synchronized(self.emulatorCore)
                 {
                     fetchVideoBuffer();

--- a/Provenance/Emulator/PVGLViewController.m
+++ b/Provenance/Emulator/PVGLViewController.m
@@ -640,7 +640,9 @@ struct RenderSettings {
     
     if (UNLIKELY(rendersToOpenGL))
     {
-        if ((!self.emulatorCore.isSpeedModified && ![self.emulatorCore isEmulationPaused]) || self.emulatorCore.isFrontBufferReady)
+        // TODO: should isEmulationPaused be the always &&, not before the | ? @JoeMatt
+        // if (LIKELY(!self.emulatorCore.isSpeedModified) && LIKELY(!self.emulatorCore.isEmulationPaused) && LIKELY(self.emulatorCore.isFrontBufferReady))
+        if ((LIKELY(!self.emulatorCore.isSpeedModified) && LIKELY(!self.emulatorCore.isEmulationPaused)) || LIKELY(self.emulatorCore.isFrontBufferReady))
         {
             [self.emulatorCore.frontBufferCondition lock];
             while (UNLIKELY(!self.emulatorCore.isFrontBufferReady) && LIKELY(!self.emulatorCore.isEmulationPaused))

--- a/Provenance/Provenance-Info.plist
+++ b/Provenance/Provenance-Info.plist
@@ -91,11 +91,11 @@
 		</dict>
 		<dict>
 			<key>ProfileName</key>
-			<string>DirectionalGamepad</string>
+			<string>MicroGamepad</string>
 		</dict>
 		<dict>
 			<key>ProfileName</key>
-			<string>MicroGamepad</string>
+			<string>DirectionalGamepad</string>
 		</dict>
 	</array>
 	<key>GCSupportsControllerUserInteraction</key>

--- a/ProvenanceTV/zh-Hans.lproj/Info.plist
+++ b/ProvenanceTV/zh-Hans.lproj/Info.plist
@@ -50,6 +50,8 @@
 	</array>
 	<key>GCSupportsControllerUserInteraction</key>
 	<true/>
+	<key>GCSupportsMultipleMicroGamepads</key>
+	<true/>
 	<key>GitBranch</key>
 	<string></string>
 	<key>GitDate</key>


### PR DESCRIPTION
1. Remove m68k from hwcpu
2. Make a new libhwcpu-m68k
3. Don't compile that lib

Making a new lib in case I need to roll that back.
This should speed up release compiles a lot.

Bonus

Created LIKELY/UNLIKELY macros, similar to cores like mednafen use, to hint at how to optimize boolean logic operations and loops