### PR TITLE
Fix submodule errors

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -43,9 +43,6 @@
 [submodule "Cores/DuckStation/duckstation"]
 	path = Cores/DuckStation/duckstation
 	url = https://github.com/stenzek/duckstation.git
-[submodule "Cores/Flycast/flycast"]
-	path = Cores/Desmume2015/flycast
-	url = https://github.com/flyinghead/flycast.git
 [submodule "Cores/Desmume2015/desmume2015"]
 	path = Cores/Desmume2015/desmume2015
 	url = https://github.com/libretro/desmume2015.git


### PR DESCRIPTION
### What does this PR do
This pull request fixes the following Git errors when running `git submodule status`:

`fatal: no submodule mapping found in .gitmodules for path 'Cores/Flycast/flycast'`
`fatal: no submodule mapping found in .gitmodules for path 'Cores/PPSSPP/cmake/assets/debugger'`

The `Cores/Flycast/flycast` submodule was defined twice and the second error was resolved with the following command:
`git rm --cached Cores/PPSSPP/cmake/assets/debugger`
