### PR TITLE
Update dependencies

### DIFF
--- a/Provenance.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Provenance.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/realm/realm-cocoa.git",
         "state": {
           "branch": null,
-          "revision": "328425bfc372ce77ec1f4f2701f61ececbb97d84",
-          "version": "10.19.0"
+          "revision": "e83cc9f28e8bccd477b6b81cee521c02239d2773",
+          "version": "10.20.2"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/realm/realm-core",
         "state": {
           "branch": null,
-          "revision": "b170db6a47789ff5f2fbc3eeed0220b4b0a3f6b7",
-          "version": "11.6.0"
+          "revision": "c3c11a841642ac93c27bd1edd61f989fc0bfb809",
+          "version": "11.6.1"
         }
       },
       {

--- a/Provenance.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Provenance.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/CocoaLumberjack/CocoaLumberjack.git",
         "state": {
           "branch": null,
-          "revision": "e518eb6e362df327574ba5e04269cd6d29f40aec",
-          "version": "3.7.2"
+          "revision": "80ada1f753b0d53d9b57c465936a7c4169375002",
+          "version": "3.7.4"
         }
       },
       {


### PR DESCRIPTION
### What does this PR do
This pull request updates dependencies to suppress the Realm update log message and also this CocoaLumberjack message:
`DDFileLogger: Failed to get offset (null)`
