### PR TITLE
Fix Metal input texture copy to account for cores using an offset origin

### DIFF
--- a/Provenance/Emulator/PVGLViewController/PVMetalViewController.m
+++ b/Provenance/Emulator/PVGLViewController/PVMetalViewController.m
@@ -543,7 +543,7 @@ PV_OBJC_DIRECT_MEMBERS
             
 
             uint outputBytesPerRow;
-            if (screenRect.origin.x == 0) // fast path if x is aligned to edge
+            if (screenRect.origin.x == 0 && (screenRect.size.width * 2 >= videoBufferSize.width)) // fast path if x is aligned to edge and excess width isn't too crazy
             {
                 outputBytesPerRow = inputBytesPerRow;
                 const uint8_t* inputAddress = &videoBuffer[(uint)screenRect.origin.y * inputBytesPerRow];

--- a/Provenance/Emulator/PVGLViewController/PVMetalViewController.m
+++ b/Provenance/Emulator/PVGLViewController/PVMetalViewController.m
@@ -325,6 +325,9 @@ PV_OBJC_DIRECT_MEMBERS
     CGRect screenRect = self.emulatorCore.screenRect;
     MTLPixelFormat pixelFormat = [self getMTLPixelFormatFromGLPixelFormat:self.emulatorCore.pixelFormat type:self.emulatorCore.pixelType];
     
+    if (self.emulatorCore.rendersToOpenGL)
+        pixelFormat = MTLPixelFormatRGBA8Unorm;
+    
     if (self.inputTexture == nil ||
         self.inputTexture.width != screenRect.size.width ||
         self.inputTexture.height != screenRect.size.height ||

--- a/Provenance/Emulator/PVGLViewController/PVMetalViewController.m
+++ b/Provenance/Emulator/PVGLViewController/PVMetalViewController.m
@@ -361,9 +361,9 @@ PV_OBJC_DIRECT_MEMBERS
         desc.minFilter = MTLSamplerMinMagFilterNearest;
         desc.magFilter = MTLSamplerMinMagFilterNearest;
         desc.mipFilter = MTLSamplerMipFilterNearest;
-        desc.sAddressMode = MTLSamplerAddressModeClampToEdge;
-        desc.tAddressMode = MTLSamplerAddressModeClampToEdge;
-        desc.rAddressMode = MTLSamplerAddressModeClampToEdge;
+        desc.sAddressMode = MTLSamplerAddressModeClampToZero;
+        desc.tAddressMode = MTLSamplerAddressModeClampToZero;
+        desc.rAddressMode = MTLSamplerAddressModeClampToZero;
         
         _pointSampler = [_device newSamplerStateWithDescriptor:desc];
     }
@@ -373,9 +373,9 @@ PV_OBJC_DIRECT_MEMBERS
         desc.minFilter = MTLSamplerMinMagFilterLinear;
         desc.magFilter = MTLSamplerMinMagFilterLinear;
         desc.mipFilter = MTLSamplerMipFilterNearest;
-        desc.sAddressMode = MTLSamplerAddressModeClampToEdge;
-        desc.tAddressMode = MTLSamplerAddressModeClampToEdge;
-        desc.rAddressMode = MTLSamplerAddressModeClampToEdge;
+        desc.sAddressMode = MTLSamplerAddressModeClampToZero;
+        desc.tAddressMode = MTLSamplerAddressModeClampToZero;
+        desc.rAddressMode = MTLSamplerAddressModeClampToZero;
         
         _linearSampler = [_device newSamplerStateWithDescriptor:desc];
     }

--- a/Provenance/Emulator/PVGLViewController/PVMetalViewController.m
+++ b/Provenance/Emulator/PVGLViewController/PVMetalViewController.m
@@ -325,9 +325,9 @@ PV_OBJC_DIRECT_MEMBERS
     CGRect screenRect = self.emulatorCore.screenRect;
     MTLPixelFormat pixelFormat = [self getMTLPixelFormatFromGLPixelFormat:self.emulatorCore.pixelFormat type:self.emulatorCore.pixelType];
     
-    if (self.emulatorCore.rendersToOpenGL)
+    if (self.emulatorCore.rendersToOpenGL) {
         pixelFormat = MTLPixelFormatRGBA8Unorm;
-    
+    }    
     if (self.inputTexture == nil ||
         self.inputTexture.width != screenRect.size.width ||
         self.inputTexture.height != screenRect.size.height ||

--- a/Provenance/Emulator/PVGLViewController/PVMetalViewController.m
+++ b/Provenance/Emulator/PVGLViewController/PVMetalViewController.m
@@ -590,8 +590,8 @@ PV_OBJC_DIRECT_MEMBERS
         if (strongself->renderSettings.crtFilterEnabled)
         {
             struct CRT_Data cbData;
-            cbData.DisplayRect.x = screenRect.origin.x;
-            cbData.DisplayRect.y = screenRect.origin.y;
+            cbData.DisplayRect.x = 0;
+            cbData.DisplayRect.y = 0;
             cbData.DisplayRect.z = screenRect.size.width;
             cbData.DisplayRect.w = screenRect.size.height;
             


### PR DESCRIPTION
Fixes CPU render and from OpenGL core paths to account for the `emulatorCore.screenRect.origin` when doing the copy into a MTLTexture.

This fixes the issue with the TurboGrafx-16 Core having the view shifted down incorrectly. 

I also briefly tested NES, N64 and Genesis cores to make sure there weren't any obvious regressions. 