### PR TITLE
Update Atari8bit bios sizes

### DIFF
--- a/PVLibrary/PVLibrary/Resources/systems.plist
+++ b/PVLibrary/PVLibrary/Resources/systems.plist
@@ -3376,9 +3376,9 @@
 				<key>MD5</key>
 				<string>0bac0c6a50104045d902df4503a4c30b</string>
 				<key>Name</key>
-				<string>ataribas.rom</string>
+				<string>ATARIBAS.ROM</string>
 				<key>Size</key>
-				<integer>0</integer>
+				<integer>8192</integer>
 			</dict>
 			<dict>
 				<key>Description</key>
@@ -3388,7 +3388,7 @@
 				<key>Name</key>
 				<string>ATARIXL.ROM</string>
 				<key>Size</key>
-				<integer>0</integer>
+				<integer>16384</integer>
 			</dict>
 			<dict>
 				<key>Description</key>
@@ -3398,7 +3398,7 @@
 				<key>Name</key>
 				<string>ATARIOSA.ROM</string>
 				<key>Size</key>
-				<integer>0</integer>
+				<integer>10240</integer>
 			</dict>
 			<dict>
 				<key>Description</key>
@@ -3408,7 +3408,7 @@
 				<key>Name</key>
 				<string>ATARIOSB.ROM</string>
 				<key>Size</key>
-				<integer>0</integer>
+				<integer>10240</integer>
 			</dict>
 		</array>
 		<key>PVSupportedExtensions</key>


### PR DESCRIPTION
### What does this PR do
Updates Atari8Bit bios sizes (and uppercases `ATARIBAS.ROM`)

### Where should the reviewer start
n/a

### How should this be manually tested
Import Atari8Bit bioses - sizes should match. 

### Any background context you want to provide
I built the latest ([3b77a7c0dffc3c388912fa6c42a132b9d8bcda81](https://github.com/Provenance-Emu/Provenance/commit/3b77a7c0dffc3c388912fa6c42a132b9d8bcda81)) commit and saw that importing Atari8Bit bioses result in size mismatch, even though checksums match. It wasn't a problem on iOS build, as I could just change it in `default.realm`, but the problem got bigger on tvOS, where I couldn't find the database. Now I'm stuck without Atari8Bit on tvOS, hence this PR.

### What are the relevant tickets
n/a

### Screenshots (important for UI changes)
n/a

### Questions
n/a
