### PR TITLE
Update blit_ps.metal to use Halfs

### DIFF
--- a/Provenance/Emulator/Shaders/blit_ps.metal
+++ b/Provenance/Emulator/Shaders/blit_ps.metal
@@ -6,10 +6,10 @@ struct Inputs
     float2 fTexCoord [[user(TEXCOORD0)]];
 };
 
-fragment float4 blit_ps(Inputs I [[stage_in]], texture2d<float> EmulatedImage [[texture(0)]], sampler Sampler [[sampler(0)]])
+fragment half4 blit_ps(Inputs I [[stage_in]], texture2d<half> EmulatedImage [[texture(0)]], sampler Sampler [[sampler(0)]])
 {
-    float4 output;
-    output.rgb = EmulatedImage.sample(Sampler, I.fTexCoord, level(0.0)).rgb;
+    half4 output;
+    output.rgb = EmulatedImage.sample(Sampler, I.fTexCoord).rgb;
     output.a = 1.0;
     return output;
 }


### PR DESCRIPTION
MTL refactor to use half as opposed to floats in the fragment shaders

Ongoing PR to refactor the Provenance MTL fragment shaders to default to using halfs as opposed to floats for better power efficiency and a performance increase on mobile devices.
