### PR TITLE
Remove unused bar buttons

### DIFF
--- a/Provenance/User Interface/en.lproj/Default.xib
+++ b/Provenance/User Interface/en.lproj/Default.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" launchScreen="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -13,33 +11,27 @@
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <navigationController id="fEE-cw-wxX">
             <navigationBar key="navigationBar" contentMode="scaleToFill" barStyle="black" id="0cy-Jv-W3f">
-                <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                 <autoresizingMask key="autoresizingMask"/>
             </navigationBar>
             <viewControllers>
                 <viewController id="r0W-Lf-3pt">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Dkz-3l-D0Z"/>
+                        <viewControllerLayoutGuide type="bottom" id="X8t-KK-VZt"/>
+                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="CBZ-2S-KGQ">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
-                    <navigationItem key="navigationItem" title="Loading…" id="WtS-co-OJ5">
-                        <barButtonItem key="leftBarButtonItem" image="gear" id="zOf-qU-KPQ">
-                            <color key="tintColor" red="0.094117647060000004" green="0.66274509800000003" blue="0.96862745100000003" alpha="1" colorSpace="calibratedRGB"/>
-                        </barButtonItem>
-                        <barButtonItem key="rightBarButtonItem" systemItem="add" id="wrg-t4-ubM">
-                            <color key="tintColor" red="0.094117647060000004" green="0.66274509800000003" blue="0.96862745100000003" alpha="1" colorSpace="calibratedRGB"/>
-                        </barButtonItem>
-                    </navigationItem>
+                    <navigationItem key="navigationItem" title="Loading…" id="WtS-co-OJ5"/>
                 </viewController>
             </viewControllers>
             <toolbar key="toolbar" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="vUe-16-zc1">
                 <autoresizingMask key="autoresizingMask"/>
             </toolbar>
-            <point key="canvasLocation" x="843" y="390"/>
+            <point key="canvasLocation" x="1287.0229007633586" y="274.64788732394368"/>
         </navigationController>
     </objects>
-    <resources>
-        <image name="gear" width="20" height="20"/>
-    </resources>
 </document>

--- a/Provenance/User Interface/es.lproj/Default.xib
+++ b/Provenance/User Interface/es.lproj/Default.xib
@@ -25,7 +25,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
-                    <navigationItem key="navigationItem" title="Loading…" id="WtS-co-OJ5"/>
+                    <navigationItem key="navigationItem" title="Cargando…" id="WtS-co-OJ5"/>
                 </viewController>
             </viewControllers>
             <toolbar key="toolbar" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="vUe-16-zc1">

--- a/Provenance/User Interface/es.lproj/Default.xib
+++ b/Provenance/User Interface/es.lproj/Default.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" launchScreen="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -13,33 +11,27 @@
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <navigationController id="fEE-cw-wxX">
             <navigationBar key="navigationBar" contentMode="scaleToFill" barStyle="black" id="0cy-Jv-W3f">
-                <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                 <autoresizingMask key="autoresizingMask"/>
             </navigationBar>
             <viewControllers>
                 <viewController id="r0W-Lf-3pt">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="ilz-7W-iQQ"/>
+                        <viewControllerLayoutGuide type="bottom" id="5dC-zj-IXk"/>
+                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="CBZ-2S-KGQ">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
-                    <navigationItem key="navigationItem" title="Loading…" id="WtS-co-OJ5">
-                        <barButtonItem key="leftBarButtonItem" image="gear" id="zOf-qU-KPQ">
-                            <color key="tintColor" red="0.094117647060000004" green="0.66274509800000003" blue="0.96862745100000003" alpha="1" colorSpace="calibratedRGB"/>
-                        </barButtonItem>
-                        <barButtonItem key="rightBarButtonItem" systemItem="add" id="wrg-t4-ubM">
-                            <color key="tintColor" red="0.094117647060000004" green="0.66274509800000003" blue="0.96862745100000003" alpha="1" colorSpace="calibratedRGB"/>
-                        </barButtonItem>
-                    </navigationItem>
+                    <navigationItem key="navigationItem" title="Loading…" id="WtS-co-OJ5"/>
                 </viewController>
             </viewControllers>
             <toolbar key="toolbar" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="vUe-16-zc1">
                 <autoresizingMask key="autoresizingMask"/>
             </toolbar>
-            <point key="canvasLocation" x="843" y="390"/>
+            <point key="canvasLocation" x="1287.0229007633586" y="274.64788732394368"/>
         </navigationController>
     </objects>
-    <resources>
-        <image name="gear" width="20" height="20"/>
-    </resources>
 </document>

--- a/Provenance/User Interface/it.lproj/Default.xib
+++ b/Provenance/User Interface/it.lproj/Default.xib
@@ -25,7 +25,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
-                    <navigationItem key="navigationItem" title="Loading…" id="WtS-co-OJ5"/>
+                    <navigationItem key="navigationItem" title="Caricamento…" id="WtS-co-OJ5"/>
                 </viewController>
             </viewControllers>
             <toolbar key="toolbar" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="vUe-16-zc1">

--- a/Provenance/User Interface/it.lproj/Default.xib
+++ b/Provenance/User Interface/it.lproj/Default.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" launchScreen="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -13,33 +11,27 @@
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <navigationController id="fEE-cw-wxX">
             <navigationBar key="navigationBar" contentMode="scaleToFill" barStyle="black" id="0cy-Jv-W3f">
-                <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                 <autoresizingMask key="autoresizingMask"/>
             </navigationBar>
             <viewControllers>
                 <viewController id="r0W-Lf-3pt">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="rGf-pi-SrP"/>
+                        <viewControllerLayoutGuide type="bottom" id="6op-KY-uwe"/>
+                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="CBZ-2S-KGQ">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
-                    <navigationItem key="navigationItem" title="Loading…" id="WtS-co-OJ5">
-                        <barButtonItem key="leftBarButtonItem" image="gear" id="zOf-qU-KPQ">
-                            <color key="tintColor" red="0.094117647060000004" green="0.66274509800000003" blue="0.96862745100000003" alpha="1" colorSpace="calibratedRGB"/>
-                        </barButtonItem>
-                        <barButtonItem key="rightBarButtonItem" systemItem="add" id="wrg-t4-ubM">
-                            <color key="tintColor" red="0.094117647060000004" green="0.66274509800000003" blue="0.96862745100000003" alpha="1" colorSpace="calibratedRGB"/>
-                        </barButtonItem>
-                    </navigationItem>
+                    <navigationItem key="navigationItem" title="Loading…" id="WtS-co-OJ5"/>
                 </viewController>
             </viewControllers>
             <toolbar key="toolbar" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="vUe-16-zc1">
                 <autoresizingMask key="autoresizingMask"/>
             </toolbar>
-            <point key="canvasLocation" x="843" y="390"/>
+            <point key="canvasLocation" x="1287.0229007633586" y="274.64788732394368"/>
         </navigationController>
     </objects>
-    <resources>
-        <image name="gear" width="20" height="20"/>
-    </resources>
 </document>

--- a/Provenance/User Interface/ja.lproj/Default.xib
+++ b/Provenance/User Interface/ja.lproj/Default.xib
@@ -25,7 +25,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
-                    <navigationItem key="navigationItem" title="Loading…" id="WtS-co-OJ5"/>
+                    <navigationItem key="navigationItem" title="読み込んでいます…" id="WtS-co-OJ5"/>
                 </viewController>
             </viewControllers>
             <toolbar key="toolbar" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="vUe-16-zc1">

--- a/Provenance/User Interface/ja.lproj/Default.xib
+++ b/Provenance/User Interface/ja.lproj/Default.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" launchScreen="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -13,33 +11,27 @@
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <navigationController id="fEE-cw-wxX">
             <navigationBar key="navigationBar" contentMode="scaleToFill" barStyle="black" id="0cy-Jv-W3f">
-                <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                 <autoresizingMask key="autoresizingMask"/>
             </navigationBar>
             <viewControllers>
                 <viewController id="r0W-Lf-3pt">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="XmM-m1-NJs"/>
+                        <viewControllerLayoutGuide type="bottom" id="DN0-Yn-zjK"/>
+                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="CBZ-2S-KGQ">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
-                    <navigationItem key="navigationItem" title="Loading…" id="WtS-co-OJ5">
-                        <barButtonItem key="leftBarButtonItem" image="gear" id="zOf-qU-KPQ">
-                            <color key="tintColor" red="0.094117647060000004" green="0.66274509800000003" blue="0.96862745100000003" alpha="1" colorSpace="calibratedRGB"/>
-                        </barButtonItem>
-                        <barButtonItem key="rightBarButtonItem" systemItem="add" id="wrg-t4-ubM">
-                            <color key="tintColor" red="0.094117647060000004" green="0.66274509800000003" blue="0.96862745100000003" alpha="1" colorSpace="calibratedRGB"/>
-                        </barButtonItem>
-                    </navigationItem>
+                    <navigationItem key="navigationItem" title="Loading…" id="WtS-co-OJ5"/>
                 </viewController>
             </viewControllers>
             <toolbar key="toolbar" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="vUe-16-zc1">
                 <autoresizingMask key="autoresizingMask"/>
             </toolbar>
-            <point key="canvasLocation" x="843" y="390"/>
+            <point key="canvasLocation" x="1287.0229007633586" y="274.64788732394368"/>
         </navigationController>
     </objects>
-    <resources>
-        <image name="gear" width="20" height="20"/>
-    </resources>
 </document>

--- a/Provenance/User Interface/nl.lproj/Default.xib
+++ b/Provenance/User Interface/nl.lproj/Default.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" launchScreen="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -13,33 +11,27 @@
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <navigationController id="fEE-cw-wxX">
             <navigationBar key="navigationBar" contentMode="scaleToFill" barStyle="black" id="0cy-Jv-W3f">
-                <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                 <autoresizingMask key="autoresizingMask"/>
             </navigationBar>
             <viewControllers>
                 <viewController id="r0W-Lf-3pt">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="LWp-gf-2zT"/>
+                        <viewControllerLayoutGuide type="bottom" id="hIO-Yf-uWf"/>
+                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="CBZ-2S-KGQ">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
-                    <navigationItem key="navigationItem" title="Loading…" id="WtS-co-OJ5">
-                        <barButtonItem key="leftBarButtonItem" image="gear" id="zOf-qU-KPQ">
-                            <color key="tintColor" red="0.094117647060000004" green="0.66274509800000003" blue="0.96862745100000003" alpha="1" colorSpace="calibratedRGB"/>
-                        </barButtonItem>
-                        <barButtonItem key="rightBarButtonItem" systemItem="add" id="wrg-t4-ubM">
-                            <color key="tintColor" red="0.094117647060000004" green="0.66274509800000003" blue="0.96862745100000003" alpha="1" colorSpace="calibratedRGB"/>
-                        </barButtonItem>
-                    </navigationItem>
+                    <navigationItem key="navigationItem" title="Loading…" id="WtS-co-OJ5"/>
                 </viewController>
             </viewControllers>
             <toolbar key="toolbar" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="vUe-16-zc1">
                 <autoresizingMask key="autoresizingMask"/>
             </toolbar>
-            <point key="canvasLocation" x="843" y="390"/>
+            <point key="canvasLocation" x="1287.0229007633586" y="274.64788732394368"/>
         </navigationController>
     </objects>
-    <resources>
-        <image name="gear" width="20" height="20"/>
-    </resources>
 </document>

--- a/Provenance/User Interface/nl.lproj/Default.xib
+++ b/Provenance/User Interface/nl.lproj/Default.xib
@@ -25,7 +25,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
-                    <navigationItem key="navigationItem" title="Loading…" id="WtS-co-OJ5"/>
+                    <navigationItem key="navigationItem" title="Laden…" id="WtS-co-OJ5"/>
                 </viewController>
             </viewControllers>
             <toolbar key="toolbar" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="vUe-16-zc1">

--- a/Provenance/User Interface/ru.lproj/Default.xib
+++ b/Provenance/User Interface/ru.lproj/Default.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" launchScreen="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -13,33 +11,27 @@
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <navigationController id="fEE-cw-wxX">
             <navigationBar key="navigationBar" contentMode="scaleToFill" barStyle="black" id="0cy-Jv-W3f">
-                <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                 <autoresizingMask key="autoresizingMask"/>
             </navigationBar>
             <viewControllers>
                 <viewController id="r0W-Lf-3pt">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="TiX-OX-C7u"/>
+                        <viewControllerLayoutGuide type="bottom" id="dMO-72-qLn"/>
+                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="CBZ-2S-KGQ">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
-                    <navigationItem key="navigationItem" title="Loading…" id="WtS-co-OJ5">
-                        <barButtonItem key="leftBarButtonItem" image="gear" id="zOf-qU-KPQ">
-                            <color key="tintColor" red="0.094117647060000004" green="0.66274509800000003" blue="0.96862745100000003" alpha="1" colorSpace="calibratedRGB"/>
-                        </barButtonItem>
-                        <barButtonItem key="rightBarButtonItem" systemItem="add" id="wrg-t4-ubM">
-                            <color key="tintColor" red="0.094117647060000004" green="0.66274509800000003" blue="0.96862745100000003" alpha="1" colorSpace="calibratedRGB"/>
-                        </barButtonItem>
-                    </navigationItem>
+                    <navigationItem key="navigationItem" title="Loading…" id="WtS-co-OJ5"/>
                 </viewController>
             </viewControllers>
             <toolbar key="toolbar" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="vUe-16-zc1">
                 <autoresizingMask key="autoresizingMask"/>
             </toolbar>
-            <point key="canvasLocation" x="843" y="390"/>
+            <point key="canvasLocation" x="1287.0229007633586" y="274.64788732394368"/>
         </navigationController>
     </objects>
-    <resources>
-        <image name="gear" width="20" height="20"/>
-    </resources>
 </document>

--- a/Provenance/User Interface/ru.lproj/Default.xib
+++ b/Provenance/User Interface/ru.lproj/Default.xib
@@ -25,7 +25,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
-                    <navigationItem key="navigationItem" title="Loading…" id="WtS-co-OJ5"/>
+                    <navigationItem key="navigationItem" title="Загружается…" id="WtS-co-OJ5"/>
                 </viewController>
             </viewControllers>
             <toolbar key="toolbar" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="vUe-16-zc1">

--- a/Provenance/User Interface/zh-Hans.lproj/Default.xib
+++ b/Provenance/User Interface/zh-Hans.lproj/Default.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19158" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19141"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -25,14 +25,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
-                    <navigationItem key="navigationItem" title="加载中..." id="WtS-co-OJ5">
-                        <barButtonItem key="leftBarButtonItem" image="gear" id="zOf-qU-KPQ">
-                            <color key="tintColor" red="0.094117647060000004" green="0.66274509800000003" blue="0.96862745100000003" alpha="1" colorSpace="calibratedRGB"/>
-                        </barButtonItem>
-                        <barButtonItem key="rightBarButtonItem" systemItem="add" id="wrg-t4-ubM">
-                            <color key="tintColor" red="0.094117647060000004" green="0.66274509800000003" blue="0.96862745100000003" alpha="1" colorSpace="calibratedRGB"/>
-                        </barButtonItem>
-                    </navigationItem>
+                    <navigationItem key="navigationItem" title="加载中..." id="WtS-co-OJ5"/>
                 </viewController>
             </viewControllers>
             <toolbar key="toolbar" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="vUe-16-zc1">
@@ -41,7 +34,4 @@
             <point key="canvasLocation" x="1221.7391304347827" y="261.16071428571428"/>
         </navigationController>
     </objects>
-    <resources>
-        <image name="gear" width="20" height="20"/>
-    </resources>
 </document>


### PR DESCRIPTION
### What does this PR do
This pull request removes non-functional tab bar buttons from the first view that appears, they also do not match the style of the main view. The `Default.xib` can actually be removed entirely without breaking anything, this does result in a black screen for a brief moment though.

The "Loading…" text has been updated for other languages as only Chinese was localized. I wonder if a more unified localization solution would be preferable as `Provenance.storyboard` doesn't appear to be localized.

Before:
<img width="564" alt="Before" src="https://user-images.githubusercontent.com/2276355/200942043-e53a82e7-3554-4ba4-81a4-c7458583422d.png">

After:
<img width="564" alt="After" src="https://user-images.githubusercontent.com/2276355/200942021-fa48f1f8-f149-4fc1-a6fa-a18ee8e47bef.png">
