### PR TITLE
Fix tvOS styling

### DIFF
--- a/Provenance/Settings/Cells/PVSliderCell.swift
+++ b/Provenance/Settings/Cells/PVSliderCell.swift
@@ -31,10 +31,6 @@ final class PVSliderCell: SliderCell {
             slider.thumbTintColor = Theme.currentTheme.switchThumb
 		#endif
             slider.isContinuous = false
-        #else
-            bg.backgroundColor = UIColor.clear
-            self.textLabel?.textColor = traitCollection.userInterfaceStyle != .light ? UIColor.white : UIColor.black
-            self.detailTextLabel?.textColor = traitCollection.userInterfaceStyle != .light ? UIColor.lightGray : UIColor.darkGray
         #endif
         backgroundView = bg
     }

--- a/Provenance/Settings/Cells/PVSwitchCell.swift
+++ b/Provenance/Settings/Cells/PVSwitchCell.swift
@@ -30,10 +30,6 @@ final class PVSwitchCell: SwitchCell {
 		#if !targetEnvironment(macCatalyst)
             switchControl.thumbTintColor = Theme.currentTheme.switchThumb
 		#endif
-        #else
-            bg.backgroundColor = UIColor.clear
-            self.textLabel?.textColor = traitCollection.userInterfaceStyle != .light ? UIColor.white : UIColor.black
-            self.detailTextLabel?.textColor = traitCollection.userInterfaceStyle != .light ? UIColor.lightGray : UIColor.darkGray
         #endif
         backgroundView = bg
     }

--- a/Provenance/Settings/PVSettingsViewController.swift
+++ b/Provenance/Settings/PVSettingsViewController.swift
@@ -45,7 +45,7 @@ final class PVSettingsViewController: PVQuickTableViewController {
         tableView.reloadData()
 
         #if os(tvOS)
-            tableView.rowHeight = 80
+            tableView.rowHeight = UITableView.automaticDimension
             splitViewController?.view.backgroundColor = .black
             navigationController?.navigationBar.isTranslucent = false
             navigationController?.navigationBar.backgroundColor =  UIColor.black.withAlphaComponent(0.8)

--- a/Provenance/Settings/PVSettingsViewController.swift
+++ b/Provenance/Settings/PVSettingsViewController.swift
@@ -85,19 +85,12 @@ final class PVSettingsViewController: PVQuickTableViewController {
         typealias TableRow = Row & RowStyle
 
         // -- Section : App
-        #if os(tvOS)
-        let autolockRowDetailText:DetailText = .subtitle("This also disables the screensaver.")
-        #else
-        let autolockRowDetailText:DetailText? = nil
-        #endif
-        let autolockRow = PVSettingsSwitchRow(text: NSLocalizedString("Disable Auto Lock", comment: "Disable Auto Lock"), detailText: autolockRowDetailText, key: \PVSettingsModel.disableAutoLock)
-
         let systemsRow = SegueNavigationRow(text: NSLocalizedString("Systems", comment: "Systems"), viewController: self, segue: "pushSystemSettings")
-
-        #if os(tvOS)
-            let appRows: [TableRow] = [systemsRow]
-        #else
+        #if os(iOS)
+            let autolockRow = PVSettingsSwitchRow(text: NSLocalizedString("Disable Auto Lock", comment: "Disable Auto Lock"), detailText: .subtitle("This also disables the screensaver."), key: \PVSettingsModel.disableAutoLock)
             let appRows: [TableRow] = [autolockRow, systemsRow]
+        #else
+            let appRows: [TableRow] = [systemsRow]
         #endif
 
         let appSection = Section(title: NSLocalizedString("App", comment: "App"), rows: appRows)

--- a/Provenance/Settings/PVSettingsViewController.swift
+++ b/Provenance/Settings/PVSettingsViewController.swift
@@ -25,6 +25,9 @@ class PVQuickTableViewController: QuickTableViewController {
 
         #if os(iOS)
             (cell as? SliderCell)?.delegate = self
+        #else
+            cell.textLabel?.font = UIFont.systemFont(ofSize: 30, weight: UIFont.Weight.regular)
+            cell.detailTextLabel?.font = UIFont.systemFont(ofSize: 20, weight: UIFont.Weight.regular)
         #endif
 
         return cell
@@ -113,33 +116,12 @@ final class PVSettingsViewController: PVQuickTableViewController {
         let coreOptionsSection = Section(title: NSLocalizedString("Core Options", comment: "Core Options"), rows: cores)
 
         // -- Section : Saves
-        #if os(iOS)
         let saveRows: [TableRow] = [
             PVSettingsSwitchRow(text: NSLocalizedString("Auto Save", comment: "Auto Save"), key: \PVSettingsModel.autoSave),
             PVSettingsSwitchRow(text: NSLocalizedString("Timed Auto Saves", comment: "Timed Auto Saves"), key: \PVSettingsModel.timedAutoSaves),
             PVSettingsSwitchRow(text: NSLocalizedString("Auto Load Saves", comment: "Auto Load Saves"), key: \PVSettingsModel.autoLoadSaves),
             PVSettingsSwitchRow(text: NSLocalizedString("Ask to Load Saves", comment: "Ask to Load Saves"), key: \PVSettingsModel.askToAutoLoad)
         ]
-        #else
-        let saveRows: [TableRow] = [
-            PVSettingsSwitchRow(text: NSLocalizedString("Auto Save", comment: "Auto Save"), key: \PVSettingsModel.autoSave,
-                    customization: { cell, _ in
-                    cell.textLabel?.font = UIFont.systemFont(ofSize: 30, weight: UIFont.Weight.regular)
-                    }),
-            PVSettingsSwitchRow(text: NSLocalizedString("Timed Auto Saves", comment: "Timed Auto Saves"), key: \PVSettingsModel.timedAutoSaves,
-                    customization: { cell, _ in
-                    cell.textLabel?.font = UIFont.systemFont(ofSize: 30, weight: UIFont.Weight.regular)
-                    }),
-            PVSettingsSwitchRow(text: NSLocalizedString("Auto Load Saves", comment: "Auto Load Saves"), key: \PVSettingsModel.autoLoadSaves,
-                    customization: { cell, _ in
-                    cell.textLabel?.font = UIFont.systemFont(ofSize: 30, weight: UIFont.Weight.regular)
-                    }),
-            PVSettingsSwitchRow(text: NSLocalizedString("Ask to Load Saves", comment: "Ask to Load Saves"), key: \PVSettingsModel.askToAutoLoad,
-                    customization: { cell, _ in
-                    cell.textLabel?.font = UIFont.systemFont(ofSize: 30, weight: UIFont.Weight.regular)
-                    })
-        ]
-        #endif
 
         let savesSection = Section(title: NSLocalizedString("Saves", comment: "Saves"), rows: saveRows)
 
@@ -149,6 +131,7 @@ final class PVSettingsViewController: PVQuickTableViewController {
         #if os(iOS)
             avRows.append(contentsOf: [PVSettingsSwitchRow(text: NSLocalizedString("Volume HUD", comment: "Volume HUD"), key: \PVSettingsModel.volumeHUD)])
             avRows.append(PVSettingsSliderRow(text: NSLocalizedString("Volume", comment: "Volume"), detailText: nil, valueLimits: (min: 0.0, max: 1.0), key: \PVSettingsModel.volume))
+        #endif
         avRows.append(contentsOf: [
             PVSettingsSwitchRow(text: NSLocalizedString("Native Scale", comment: "Native Scale"), key: \PVSettingsModel.nativeScaleEnabled),
             PVSettingsSwitchRow(text: NSLocalizedString("Integer Scaling", comment: "Integer Scaling"), key: \PVSettingsModel.integerScaleEnabled),
@@ -157,36 +140,6 @@ final class PVSettingsViewController: PVQuickTableViewController {
             PVSettingsSwitchRow(text: NSLocalizedString("Image Smoothing", comment: "Image Smoothing"), key: \PVSettingsModel.imageSmoothing),
             PVSettingsSwitchRow(text: NSLocalizedString("FPS Counter", comment: "FPS Counter"), key: \PVSettingsModel.showFPSCount)
         ])
-        
-        #else
-        avRows.append(contentsOf: [
-            PVSettingsSwitchRow(text: NSLocalizedString("Native Scale", comment: "Native Scale"), key: \PVSettingsModel.nativeScaleEnabled,
-                customization: { cell, _ in
-                cell.textLabel?.font = UIFont.systemFont(ofSize: 30, weight: UIFont.Weight.regular)
-                }),
-            PVSettingsSwitchRow(text: NSLocalizedString("Integer Scaling", comment: "Integer Scaling"), key: \PVSettingsModel.integerScaleEnabled,
-                customization: { cell, _ in
-                cell.textLabel?.font = UIFont.systemFont(ofSize: 30, weight: UIFont.Weight.regular)
-                }),
-            PVSettingsSwitchRow(text: NSLocalizedString("CRT Filter", comment: "CRT Filter"), key: \PVSettingsModel.crtFilterEnabled,
-                customization: { cell, _ in
-                cell.textLabel?.font = UIFont.systemFont(ofSize: 30, weight: UIFont.Weight.regular)
-                }),
-            PVSettingsSwitchRow(text: NSLocalizedString("LCD Filter", comment: "LCD Filter"), detailText:.subtitle("Use CRT filter on LCD (mobile) screens. LCD filter coming."), key: \PVSettingsModel.lcdFilterEnabled,
-                customization: { cell, _ in
-                cell.textLabel?.font = UIFont.systemFont(ofSize: 30, weight: UIFont.Weight.regular)
-                }),
-            PVSettingsSwitchRow(text: NSLocalizedString("Image Smoothing", comment: "Image Smoothing"), key: \PVSettingsModel.imageSmoothing,
-                customization: { cell, _ in
-                cell.textLabel?.font = UIFont.systemFont(ofSize: 30, weight: UIFont.Weight.regular)
-                }),
-            PVSettingsSwitchRow(text: NSLocalizedString("FPS Counter", comment: "FPS Counter"), key: \PVSettingsModel.showFPSCount,
-                customization: { cell, _ in
-                cell.textLabel?.font = UIFont.systemFont(ofSize: 30, weight: UIFont.Weight.regular)
-                })
-        ]
-        )
-        #endif
 
         let avSection = Section(title: NSLocalizedString("Video Options", comment: "Video Options"), rows: avRows)
 
@@ -222,11 +175,7 @@ final class PVSettingsViewController: PVQuickTableViewController {
         ])
         #if os(tvOS)
         controllerRows.append(contentsOf: [
-            PVSettingsSwitchRow(text: NSLocalizedString("Enable 8BitDo M30 Mapping", comment: "Enable 8BitDo M30 Mapping"), detailText: .subtitle("For use with Sega Genesis/Mega Drive, Sega/Mega CD, 32X, Saturn and the \nTG16/PC Engine, TG16/PC Engine CD and SuperGrafx systems."), key: \PVSettingsModel.use8BitdoM30,
-            customization: { cell, _ in
-            cell.textLabel?.font = UIFont.systemFont(ofSize: 30, weight: UIFont.Weight.regular)
-            cell.detailTextLabel?.font =  UIFont.systemFont(ofSize: 20, weight: UIFont.Weight.regular)
-            })
+            PVSettingsSwitchRow(text: NSLocalizedString("Enable 8BitDo M30 Mapping", comment: "Enable 8BitDo M30 Mapping"), detailText: .subtitle("For use with Sega Genesis/Mega Drive, Sega/Mega CD, 32X, Saturn and the \nTG16/PC Engine, TG16/PC Engine CD and SuperGrafx systems."), key: \PVSettingsModel.use8BitdoM30)
         ])
         #endif
 
@@ -252,12 +201,10 @@ final class PVSettingsViewController: PVQuickTableViewController {
                 detailText: .subtitle(""),
                 key: \PVSettingsModel.webDavAlwaysOn,
                 customization: { cell, _ in
-                    cell.textLabel?.font = UIFont.systemFont(ofSize: 30, weight: UIFont.Weight.regular)
                     if PVSettingsModel.shared.webDavAlwaysOn {
                         let subTitleText = "WebDAV: \(PVWebServer.shared.webDavURLString)"
                         let subTitleAttributes = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 20), NSAttributedString.Key.foregroundColor: UIColor.gray]
                         let subTitleAttrString = NSMutableAttributedString(string: subTitleText, attributes: subTitleAttributes)
-                        // cell.detailTextLabel?.font = UIFont.systemFont(ofSize: 20, weight: UIFont.Weight.regular)
                         cell.detailTextLabel?.attributedText = subTitleAttrString
                     } else {
                         cell.detailTextLabel?.text = nil
@@ -344,57 +291,27 @@ final class PVSettingsViewController: PVQuickTableViewController {
         ]
         #else // tvOS
          let betaRows: [TableRow] = [
-	     	PVSettingsSwitchRow(text: NSLocalizedString("Use Metal", comment: "Use Metal"), detailText: .subtitle("Use experimental Metal backend instead of OpenGL"),
-                                key: \PVSettingsModel.debugOptions.useMetal,
-                                    customization: { cell, _ in
-                                    	cell.textLabel?.font = UIFont.systemFont(ofSize: 30, weight: UIFont.Weight.regular)
-                                    	cell.detailTextLabel?.font = UIFont.systemFont(ofSize: 20, weight: UIFont.Weight.regular)
-                                    }
-                               ),
-             PVSettingsSwitchRow(text: NSLocalizedString("iCloud Sync", comment: "iCloud Sync"),
+            PVSettingsSwitchRow(text: NSLocalizedString("Use Metal", comment: "Use Metal"), detailText: .subtitle("Use experimental Metal backend instead of OpenGL"),
+                                key: \PVSettingsModel.debugOptions.useMetal),
+            PVSettingsSwitchRow(text: NSLocalizedString("iCloud Sync", comment: "iCloud Sync"),
                                 detailText: .subtitle("Sync core & battery saves, screenshots and BIOS's to iCloud."),
-                                key: \PVSettingsModel.debugOptions.iCloudSync,
-                                    customization: { cell, _ in
-                                        cell.textLabel?.font = UIFont.systemFont(ofSize: 30, weight: UIFont.Weight.regular)
-                                        cell.detailTextLabel?.font = UIFont.systemFont(ofSize: 20, weight: UIFont.Weight.regular)
-                            }
-            ),
+                                key: \PVSettingsModel.debugOptions.iCloudSync),
 
-             PVSettingsSwitchRow(text: NSLocalizedString("Multi-threaded GL", comment: "Multi-threaded GL"),
+            PVSettingsSwitchRow(text: NSLocalizedString("Multi-threaded GL", comment: "Multi-threaded GL"),
                                 detailText: .subtitle("Use tvOS's EAGLContext multiThreaded. May improve or slow down GL performance."),
-                                key: \PVSettingsModel.debugOptions.multiThreadedGL,
-                                    customization: { cell, _ in
-                                        cell.textLabel?.font = UIFont.systemFont(ofSize: 30, weight: UIFont.Weight.regular)
-                                        cell.detailTextLabel?.font = UIFont.systemFont(ofSize: 20, weight: UIFont.Weight.regular)
-                            }
-            ),
+                                key: \PVSettingsModel.debugOptions.multiThreadedGL),
 
-             PVSettingsSwitchRow(text: NSLocalizedString("4X Multisampling GL", comment: "4X Multisampling GL"),
+            PVSettingsSwitchRow(text: NSLocalizedString("4X Multisampling GL", comment: "4X Multisampling GL"),
                                 detailText: .subtitle("Use tvOS's EAGLContext multisampling. Slower speed (slightly), smoother edges."),
-                                key: \PVSettingsModel.debugOptions.multiSampling,
-                                    customization: { cell, _ in
-                                        cell.textLabel?.font = UIFont.systemFont(ofSize: 30, weight: UIFont.Weight.regular)
-                                        cell.detailTextLabel?.font = UIFont.systemFont(ofSize: 20, weight: UIFont.Weight.regular)
-                                }
-            ),
+                                key: \PVSettingsModel.debugOptions.multiSampling),
 
             PVSettingsSwitchRow(text: NSLocalizedString("Use SwiftUI", comment: "Use SwiftUI"),
                                detailText: .subtitle("Don't use unless you enjoy empty windows."),
-                               key: \PVSettingsModel.debugOptions.multiSampling,
-                                   customization: { cell, _ in
-                                       cell.textLabel?.font = UIFont.systemFont(ofSize: 30, weight: UIFont.Weight.regular)
-                                       cell.detailTextLabel?.font = UIFont.systemFont(ofSize: 20, weight: UIFont.Weight.regular)
-                               }
-           ),
+                               key: \PVSettingsModel.debugOptions.multiSampling),
 
             PVSettingsSwitchRow(text: NSLocalizedString("Use Themes", comment: "Use Themes"),
                                detailText: .subtitle("Use iOS themes on tvOS"),
-                               key: \PVSettingsModel.debugOptions.tvOSThemes,
-                                   customization: { cell, _ in
-                                       cell.textLabel?.font = UIFont.systemFont(ofSize: 30, weight: UIFont.Weight.regular)
-                                       cell.detailTextLabel?.font = UIFont.systemFont(ofSize: 20, weight: UIFont.Weight.regular)
-                               }
-           )
+                               key: \PVSettingsModel.debugOptions.tvOSThemes)
                 ]
         #endif
 


### PR DESCRIPTION
### What does this PR do
This pull request removes some unused tvOS code (`PVSliderCell`), and some seemingly unneeded code (`PVSwitchCell`) and makes some improvements to cell font sizing on tvOS.

Before:
<img width="1156" alt="Before" src="https://user-images.githubusercontent.com/2276355/201197317-fa4bb964-593f-4e60-8fd6-85ff9facc402.png">

After:
<img width="1156" alt="After" src="https://user-images.githubusercontent.com/2276355/201197328-04b40cd6-5c58-449d-b86c-b07fd88f223e.png">
