### PR TITLE
Fix tint after using the cancel action when selecting a controller

### DIFF
--- a/Provenance/Controller/PVControllerSelectionViewController.swift
+++ b/Provenance/Controller/PVControllerSelectionViewController.swift
@@ -132,8 +132,6 @@ final class PVControllerSelectionViewController: UITableViewController {
             PVControllerManager.shared.stopListeningForICadeControllers()
         }))
 
-        actionSheet.addAction(UIAlertAction(title: NSLocalizedString("Cancel", comment: "Cancel"), style: .cancel, handler: nil))
-
         present(actionSheet, animated: true, completion: { () -> Void in
             PVControllerManager.shared.listenForICadeControllers(window: actionSheet.view.window, preferredPlayer: indexPath.row + 1, completion: { () -> Void in
                 actionSheet.dismiss(animated: true) { () -> Void in }


### PR DESCRIPTION
### What does this PR do
This pull request prevents dismissing the modal without making a selection which leaves the cell with a tint. Dismissing the modal or selecting "Not Playing" also has the same effect.