### PR TITLE
Reduce width of log buttons

### DIFF
--- a/Provenance/Utilities/PVLogViewController.xib
+++ b/Provenance/Utilities/PVLogViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.iPad.XIB" version="3.0" toolsVersion="19158" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.iPad.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
     <device id="ipad9_7" orientation="portrait" layout="fullscreen" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19141"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -25,7 +25,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7">
-                    <rect key="frame" x="0.0" y="20" width="768" height="44"/>
+                    <rect key="frame" x="0.0" y="0.0" width="768" height="44"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="44" id="REJ-bi-77z"/>
                     </constraints>
@@ -33,7 +33,7 @@
                         <barButtonItem style="plain" systemItem="flexibleSpace" id="16"/>
                         <barButtonItem style="plain" id="18">
                             <segmentedControl key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="bar" selectedSegmentIndex="0" id="17">
-                                <rect key="frame" x="246.5" y="5.5" width="275" height="33"/>
+                                <rect key="frame" x="270.5" y="5.5" width="227" height="33"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <segments>
                                     <segment title="Live Log"/>
@@ -57,11 +57,11 @@
                     </connections>
                 </toolbar>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ir3-aG-kbV" userLabel="contentview">
-                    <rect key="frame" x="0.0" y="64" width="768" height="960"/>
+                    <rect key="frame" x="0.0" y="44" width="768" height="980"/>
                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 </view>
                 <textView clipsSubviews="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" editable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4">
-                    <rect key="frame" x="0.0" y="64" width="768" height="960"/>
+                    <rect key="frame" x="0.0" y="44" width="768" height="980"/>
                     <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                     <color key="textColor" systemColor="darkTextColor"/>
                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
@@ -88,7 +88,7 @@
                 <constraint firstItem="ir3-aG-kbV" firstAttribute="top" secondItem="7" secondAttribute="bottom" id="zCc-qL-G0A"/>
             </constraints>
             <simulatedStatusBarMetrics key="simulatedStatusBarMetrics" statusBarStyle="blackOpaque"/>
-            <point key="canvasLocation" x="118" y="42"/>
+            <point key="canvasLocation" x="117.96875" y="41.6015625"/>
         </view>
         <barButtonItem title="Select File" id="BF8-Bz-b6R">
             <connections>


### PR DESCRIPTION
### What does this PR do
This pull request slightly reduces the width of the log buttons to allow the "Select File" button to appear properly.

### Screenshots (important for UI changes)
Before:
<img width="564" alt="Before" src="https://user-images.githubusercontent.com/2276355/201486117-fff22ba1-2dc3-4f26-bd67-2a5bd85f3dfa.png">

After:
<img width="564" alt="After" src="https://user-images.githubusercontent.com/2276355/201486111-881e17fc-10ae-4bc6-83cd-e81e1a5b2d43.png">
