### PR TITLE
Extend navigation bar on tvOS

### DIFF
--- a/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
+++ b/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
@@ -201,7 +201,8 @@ final class PVGameLibraryViewController: GCEventViewController, UITextFieldDeleg
             navigationController?.navigationBar.isTranslucent = false
             let blurEffect = UIBlurEffect(style: UIBlurEffect.Style.dark)
             let blurEffectView = UIVisualEffectView(effect: blurEffect)
-            blurEffectView.frame = (self.navigationController?.navigationBar.bounds)!
+            let bounds = (self.navigationController?.navigationBar.bounds)!
+            blurEffectView.frame = CGRect(x: bounds.minX, y: bounds.minY, width: bounds.width, height: bounds.height + 49)
             self.navigationController?.navigationBar.addSubview(blurEffectView)
             self.navigationController?.navigationBar.sendSubviewToBack(blurEffectView)
             navigationController?.navigationBar.backgroundColor = UIColor.black.withAlphaComponent(0.5)
@@ -493,17 +494,24 @@ final class PVGameLibraryViewController: GCEventViewController, UITextFieldDeleg
         // Adjust collection view layout for iPhone X Safe areas
         // Can remove this when we go iOS 9+ and just use safe areas
         // in the story board directly - jm
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
+        let guide = view.safeAreaLayoutGuide
         #if os(iOS)
-            collectionView.translatesAutoresizingMaskIntoConstraints = false
-            let guide = view.safeAreaLayoutGuide
             NSLayoutConstraint.activate([
                 collectionView.trailingAnchor.constraint(equalTo: guide.trailingAnchor),
                 collectionView.leadingAnchor.constraint(equalTo: guide.leadingAnchor),
                 collectionView.topAnchor.constraint(equalTo: view.topAnchor),
                 collectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
             ])
-            layout.sectionInsetReference = .fromSafeArea
+        #else
+            NSLayoutConstraint.activate([
+                collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+                collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+                collectionView.topAnchor.constraint(equalTo: guide.topAnchor, constant: 49),
+                collectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+            ])
         #endif
+        layout.sectionInsetReference = .fromSafeArea
         // Force touch
         #if os(iOS)
             registerForPreviewing(with: self, sourceView: collectionView)

--- a/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
+++ b/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
@@ -1368,11 +1368,7 @@ final class PVGameLibraryViewController: GCEventViewController, UITextFieldDeleg
     #endif
 
     func collectionView(_: UICollectionView, layout _: UICollectionViewLayout, referenceSizeForHeaderInSection _: Int) -> CGSize {
-        #if os(tvOS)
-            return CGSize(width: view.bounds.size.width, height: 40)
-        #else
-            return CGSize(width: view.bounds.size.width, height: 40)
-        #endif
+        return CGSize(width: view.bounds.size.width, height: 40)
     }
 
     // MARK: - Image Picker Delegate


### PR DESCRIPTION
### What does this PR do
This pull request increases the perceived height of the navigation bar by adding a constraint to the game library view and also by extending a navigation bar subview. It [doesn't seem possible](https://stackoverflow.com/a/47916936/2693925) anymore to change the height of the navigation bar directly. It is possible to make some changes in the navigation bar in the `viewDidLayoutSubviews` method, but it doesn't seem possible to change the height.

### Screenshots (important for UI changes)
Before:
<img width="1156" alt="Before" src="https://user-images.githubusercontent.com/2276355/201479045-ed3a718c-bc77-47fe-8eab-f0ba566bb2cd.png">

After:
<img width="1156" alt="After" src="https://user-images.githubusercontent.com/2276355/201479043-dfae792f-5397-4e10-80a1-bbb0cd9de8a2.png">