### PR TITLE
Tweak settings button and navigation bar fixes

### DIFF
--- a/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
+++ b/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
@@ -246,6 +246,10 @@ final class PVGameLibraryViewController: GCEventViewController, UITextFieldDeleg
             let font = UIFont.boldSystemFont(ofSize: 48)
             let icon = "pv_dark_logo"
             let icon_size = font.capHeight
+
+            if let bbi = settingsBarButtonItem {
+                bbi.image = UIImage(systemName:"gear", withConfiguration:UIImage.SymbolConfiguration(font:font))
+            }
         #endif
         if let icon = UIImage(named:icon)?.resize(to:CGSize(width:0, height:icon_size))
         {
@@ -261,11 +265,6 @@ final class PVGameLibraryViewController: GCEventViewController, UITextFieldDeleg
             stack.alignment = .center
             stack.frame = CGRect(origin:.zero, size:stack.systemLayoutSizeFitting(.zero))
             navigationItem.titleView = stack
-        }
-
-        // we cant use a SF Symbol in the Storyboard cuz of back version support, so change it here in code.
-        if let bbi = settingsBarButtonItem {
-            bbi.image = UIImage(systemName:"gear", withConfiguration:UIImage.SymbolConfiguration(font:font))
         }
 
         // Persist some settings, could probably be done in a better way

--- a/Provenance/User Interface/en.lproj/Default.xib
+++ b/Provenance/User Interface/en.lproj/Default.xib
@@ -26,7 +26,7 @@
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
                     <navigationItem key="navigationItem" title="Loading…" id="hEE-db-CVg">
-                        <barButtonItem key="leftBarButtonItem" image="gear" id="HKB-UT-nWv"/>
+                        <barButtonItem key="leftBarButtonItem" image="gear" catalog="system" id="HKB-UT-nWv"/>
                         <rightBarButtonItems>
                             <barButtonItem systemItem="add" id="rh0-jO-Eea"/>
                             <barButtonItem image="sort" id="NtV-ij-HLA"/>
@@ -41,7 +41,7 @@
         </navigationController>
     </objects>
     <resources>
-        <image name="gear" width="20" height="20"/>
+        <image name="gear" catalog="system" width="128" height="122"/>
         <image name="sort" width="20" height="20"/>
     </resources>
 </document>

--- a/Provenance/User Interface/en.lproj/Default.xib
+++ b/Provenance/User Interface/en.lproj/Default.xib
@@ -25,7 +25,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
-                    <navigationItem key="navigationItem" title="Loading..." id="hEE-db-CVg">
+                    <navigationItem key="navigationItem" title="Loading…" id="hEE-db-CVg">
                         <barButtonItem key="leftBarButtonItem" image="gear" id="HKB-UT-nWv"/>
                         <rightBarButtonItems>
                             <barButtonItem systemItem="add" id="rh0-jO-Eea"/>

--- a/Provenance/User Interface/en.lproj/Provenance.storyboard
+++ b/Provenance/User Interface/en.lproj/Provenance.storyboard
@@ -461,7 +461,7 @@
                     <navigationItem key="navigationItem" id="LoK-Fl-znC">
                         <nil key="title"/>
                         <leftBarButtonItems>
-                            <barButtonItem image="gear" id="daz-L9-06G">
+                            <barButtonItem image="gear" catalog="system" id="daz-L9-06G">
                                 <connections>
                                     <segue destination="dRa-ou-OcL" kind="modal" identifier="SettingsSegue" modalPresentationStyle="formSheet" id="PHC-9h-QIz"/>
                                 </connections>
@@ -562,7 +562,7 @@
     </scenes>
     <color key="tintColor" red="0.51793235540390015" green="0.5159609317779541" blue="0.53913700580596924" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
     <resources>
-        <image name="gear" width="20" height="20"/>
+        <image name="gear" catalog="system" width="128" height="122"/>
         <image name="sort" width="20" height="20"/>
         <systemColor name="secondarySystemBackgroundColor">
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Provenance/User Interface/es.lproj/Default.xib
+++ b/Provenance/User Interface/es.lproj/Default.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" launchScreen="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -13,33 +11,37 @@
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <navigationController id="fEE-cw-wxX">
             <navigationBar key="navigationBar" contentMode="scaleToFill" barStyle="black" id="0cy-Jv-W3f">
-                <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                 <autoresizingMask key="autoresizingMask"/>
             </navigationBar>
             <viewControllers>
                 <viewController id="r0W-Lf-3pt">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="dyu-Jb-HLF"/>
+                        <viewControllerLayoutGuide type="bottom" id="Nhq-a0-vKI"/>
+                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="CBZ-2S-KGQ">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
-                    <navigationItem key="navigationItem" title="Loading…" id="WtS-co-OJ5">
-                        <barButtonItem key="leftBarButtonItem" image="gear" id="zOf-qU-KPQ">
-                            <color key="tintColor" red="0.094117647060000004" green="0.66274509800000003" blue="0.96862745100000003" alpha="1" colorSpace="calibratedRGB"/>
-                        </barButtonItem>
-                        <barButtonItem key="rightBarButtonItem" systemItem="add" id="wrg-t4-ubM">
-                            <color key="tintColor" red="0.094117647060000004" green="0.66274509800000003" blue="0.96862745100000003" alpha="1" colorSpace="calibratedRGB"/>
-                        </barButtonItem>
+                    <navigationItem key="navigationItem" title="Loading…" id="hEE-db-CVg">
+                        <barButtonItem key="leftBarButtonItem" image="gear" catalog="system" id="HKB-UT-nWv"/>
+                        <rightBarButtonItems>
+                            <barButtonItem systemItem="add" id="rh0-jO-Eea"/>
+                            <barButtonItem image="sort" id="NtV-ij-HLA"/>
+                        </rightBarButtonItems>
                     </navigationItem>
                 </viewController>
             </viewControllers>
             <toolbar key="toolbar" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="vUe-16-zc1">
                 <autoresizingMask key="autoresizingMask"/>
             </toolbar>
-            <point key="canvasLocation" x="843" y="390"/>
+            <point key="canvasLocation" x="1287.0229007633586" y="274.64788732394368"/>
         </navigationController>
     </objects>
     <resources>
-        <image name="gear" width="20" height="20"/>
+        <image name="gear" catalog="system" width="128" height="122"/>
+        <image name="sort" width="20" height="20"/>
     </resources>
 </document>

--- a/Provenance/User Interface/es.lproj/Provenance.storyboard
+++ b/Provenance/User Interface/es.lproj/Provenance.storyboard
@@ -457,10 +457,11 @@
                             <constraint firstItem="ooQ-n9-WR1" firstAttribute="centerY" secondItem="AH0-kg-WTv" secondAttribute="centerY" id="x9M-lZ-qfE"/>
                         </constraints>
                     </view>
+                    <extendedEdge key="edgesForExtendedLayout"/>
                     <navigationItem key="navigationItem" id="LoK-Fl-znC">
                         <nil key="title"/>
                         <leftBarButtonItems>
-                            <barButtonItem image="gear" id="daz-L9-06G">
+                            <barButtonItem image="gear" catalog="system" id="daz-L9-06G">
                                 <connections>
                                     <segue destination="dRa-ou-OcL" kind="modal" identifier="SettingsSegue" modalPresentationStyle="formSheet" id="PHC-9h-QIz"/>
                                 </connections>
@@ -561,7 +562,7 @@
     </scenes>
     <color key="tintColor" red="0.51793235540390015" green="0.5159609317779541" blue="0.53913700580596924" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
     <resources>
-        <image name="gear" width="20" height="20"/>
+        <image name="gear" catalog="system" width="128" height="122"/>
         <image name="sort" width="20" height="20"/>
         <systemColor name="secondarySystemBackgroundColor">
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Provenance/User Interface/it.lproj/Default.xib
+++ b/Provenance/User Interface/it.lproj/Default.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" launchScreen="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -13,33 +11,37 @@
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <navigationController id="fEE-cw-wxX">
             <navigationBar key="navigationBar" contentMode="scaleToFill" barStyle="black" id="0cy-Jv-W3f">
-                <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                 <autoresizingMask key="autoresizingMask"/>
             </navigationBar>
             <viewControllers>
                 <viewController id="r0W-Lf-3pt">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="dyu-Jb-HLF"/>
+                        <viewControllerLayoutGuide type="bottom" id="Nhq-a0-vKI"/>
+                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="CBZ-2S-KGQ">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
-                    <navigationItem key="navigationItem" title="Loading…" id="WtS-co-OJ5">
-                        <barButtonItem key="leftBarButtonItem" image="gear" id="zOf-qU-KPQ">
-                            <color key="tintColor" red="0.094117647060000004" green="0.66274509800000003" blue="0.96862745100000003" alpha="1" colorSpace="calibratedRGB"/>
-                        </barButtonItem>
-                        <barButtonItem key="rightBarButtonItem" systemItem="add" id="wrg-t4-ubM">
-                            <color key="tintColor" red="0.094117647060000004" green="0.66274509800000003" blue="0.96862745100000003" alpha="1" colorSpace="calibratedRGB"/>
-                        </barButtonItem>
+                    <navigationItem key="navigationItem" title="Loading…" id="hEE-db-CVg">
+                        <barButtonItem key="leftBarButtonItem" image="gear" catalog="system" id="HKB-UT-nWv"/>
+                        <rightBarButtonItems>
+                            <barButtonItem systemItem="add" id="rh0-jO-Eea"/>
+                            <barButtonItem image="sort" id="NtV-ij-HLA"/>
+                        </rightBarButtonItems>
                     </navigationItem>
                 </viewController>
             </viewControllers>
             <toolbar key="toolbar" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="vUe-16-zc1">
                 <autoresizingMask key="autoresizingMask"/>
             </toolbar>
-            <point key="canvasLocation" x="843" y="390"/>
+            <point key="canvasLocation" x="1287.0229007633586" y="274.64788732394368"/>
         </navigationController>
     </objects>
     <resources>
-        <image name="gear" width="20" height="20"/>
+        <image name="gear" catalog="system" width="128" height="122"/>
+        <image name="sort" width="20" height="20"/>
     </resources>
 </document>

--- a/Provenance/User Interface/it.lproj/Provenance.storyboard
+++ b/Provenance/User Interface/it.lproj/Provenance.storyboard
@@ -461,7 +461,7 @@
                     <navigationItem key="navigationItem" id="LoK-Fl-znC">
                         <nil key="title"/>
                         <leftBarButtonItems>
-                            <barButtonItem image="gear" id="daz-L9-06G">
+                            <barButtonItem image="gear" catalog="system" id="daz-L9-06G">
                                 <connections>
                                     <segue destination="dRa-ou-OcL" kind="modal" identifier="SettingsSegue" modalPresentationStyle="formSheet" id="PHC-9h-QIz"/>
                                 </connections>
@@ -562,7 +562,7 @@
     </scenes>
     <color key="tintColor" red="0.51793235540390015" green="0.5159609317779541" blue="0.53913700580596924" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
     <resources>
-        <image name="gear" width="20" height="20"/>
+        <image name="gear" catalog="system" width="128" height="122"/>
         <image name="sort" width="20" height="20"/>
         <systemColor name="secondarySystemBackgroundColor">
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Provenance/User Interface/ja.lproj/Default.xib
+++ b/Provenance/User Interface/ja.lproj/Default.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" launchScreen="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -13,33 +11,37 @@
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <navigationController id="fEE-cw-wxX">
             <navigationBar key="navigationBar" contentMode="scaleToFill" barStyle="black" id="0cy-Jv-W3f">
-                <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                 <autoresizingMask key="autoresizingMask"/>
             </navigationBar>
             <viewControllers>
                 <viewController id="r0W-Lf-3pt">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="dyu-Jb-HLF"/>
+                        <viewControllerLayoutGuide type="bottom" id="Nhq-a0-vKI"/>
+                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="CBZ-2S-KGQ">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
-                    <navigationItem key="navigationItem" title="Loading…" id="WtS-co-OJ5">
-                        <barButtonItem key="leftBarButtonItem" image="gear" id="zOf-qU-KPQ">
-                            <color key="tintColor" red="0.094117647060000004" green="0.66274509800000003" blue="0.96862745100000003" alpha="1" colorSpace="calibratedRGB"/>
-                        </barButtonItem>
-                        <barButtonItem key="rightBarButtonItem" systemItem="add" id="wrg-t4-ubM">
-                            <color key="tintColor" red="0.094117647060000004" green="0.66274509800000003" blue="0.96862745100000003" alpha="1" colorSpace="calibratedRGB"/>
-                        </barButtonItem>
+                    <navigationItem key="navigationItem" title="Loading…" id="hEE-db-CVg">
+                        <barButtonItem key="leftBarButtonItem" image="gear" catalog="system" id="HKB-UT-nWv"/>
+                        <rightBarButtonItems>
+                            <barButtonItem systemItem="add" id="rh0-jO-Eea"/>
+                            <barButtonItem image="sort" id="NtV-ij-HLA"/>
+                        </rightBarButtonItems>
                     </navigationItem>
                 </viewController>
             </viewControllers>
             <toolbar key="toolbar" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="vUe-16-zc1">
                 <autoresizingMask key="autoresizingMask"/>
             </toolbar>
-            <point key="canvasLocation" x="843" y="390"/>
+            <point key="canvasLocation" x="1287.0229007633586" y="274.64788732394368"/>
         </navigationController>
     </objects>
     <resources>
-        <image name="gear" width="20" height="20"/>
+        <image name="gear" catalog="system" width="128" height="122"/>
+        <image name="sort" width="20" height="20"/>
     </resources>
 </document>

--- a/Provenance/User Interface/ja.lproj/Provenance.storyboard
+++ b/Provenance/User Interface/ja.lproj/Provenance.storyboard
@@ -461,7 +461,7 @@
                     <navigationItem key="navigationItem" id="LoK-Fl-znC">
                         <nil key="title"/>
                         <leftBarButtonItems>
-                            <barButtonItem image="gear" id="daz-L9-06G">
+                            <barButtonItem image="gear" catalog="system" id="daz-L9-06G">
                                 <connections>
                                     <segue destination="dRa-ou-OcL" kind="modal" identifier="SettingsSegue" modalPresentationStyle="formSheet" id="PHC-9h-QIz"/>
                                 </connections>
@@ -562,7 +562,7 @@
     </scenes>
     <color key="tintColor" red="0.51793235540390015" green="0.5159609317779541" blue="0.53913700580596924" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
     <resources>
-        <image name="gear" width="20" height="20"/>
+        <image name="gear" catalog="system" width="128" height="122"/>
         <image name="sort" width="20" height="20"/>
         <systemColor name="secondarySystemBackgroundColor">
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Provenance/User Interface/nl.lproj/Default.xib
+++ b/Provenance/User Interface/nl.lproj/Default.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" launchScreen="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -13,33 +11,37 @@
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <navigationController id="fEE-cw-wxX">
             <navigationBar key="navigationBar" contentMode="scaleToFill" barStyle="black" id="0cy-Jv-W3f">
-                <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                 <autoresizingMask key="autoresizingMask"/>
             </navigationBar>
             <viewControllers>
                 <viewController id="r0W-Lf-3pt">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="dyu-Jb-HLF"/>
+                        <viewControllerLayoutGuide type="bottom" id="Nhq-a0-vKI"/>
+                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="CBZ-2S-KGQ">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
-                    <navigationItem key="navigationItem" title="Loading…" id="WtS-co-OJ5">
-                        <barButtonItem key="leftBarButtonItem" image="gear" id="zOf-qU-KPQ">
-                            <color key="tintColor" red="0.094117647060000004" green="0.66274509800000003" blue="0.96862745100000003" alpha="1" colorSpace="calibratedRGB"/>
-                        </barButtonItem>
-                        <barButtonItem key="rightBarButtonItem" systemItem="add" id="wrg-t4-ubM">
-                            <color key="tintColor" red="0.094117647060000004" green="0.66274509800000003" blue="0.96862745100000003" alpha="1" colorSpace="calibratedRGB"/>
-                        </barButtonItem>
+                    <navigationItem key="navigationItem" title="Loading…" id="hEE-db-CVg">
+                        <barButtonItem key="leftBarButtonItem" image="gear" catalog="system" id="HKB-UT-nWv"/>
+                        <rightBarButtonItems>
+                            <barButtonItem systemItem="add" id="rh0-jO-Eea"/>
+                            <barButtonItem image="sort" id="NtV-ij-HLA"/>
+                        </rightBarButtonItems>
                     </navigationItem>
                 </viewController>
             </viewControllers>
             <toolbar key="toolbar" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="vUe-16-zc1">
                 <autoresizingMask key="autoresizingMask"/>
             </toolbar>
-            <point key="canvasLocation" x="843" y="390"/>
+            <point key="canvasLocation" x="1287.0229007633586" y="274.64788732394368"/>
         </navigationController>
     </objects>
     <resources>
-        <image name="gear" width="20" height="20"/>
+        <image name="gear" catalog="system" width="128" height="122"/>
+        <image name="sort" width="20" height="20"/>
     </resources>
 </document>

--- a/Provenance/User Interface/nl.lproj/Provenance.storyboard
+++ b/Provenance/User Interface/nl.lproj/Provenance.storyboard
@@ -461,7 +461,7 @@
                     <navigationItem key="navigationItem" id="LoK-Fl-znC">
                         <nil key="title"/>
                         <leftBarButtonItems>
-                            <barButtonItem image="gear" id="daz-L9-06G">
+                            <barButtonItem image="gear" catalog="system" id="daz-L9-06G">
                                 <connections>
                                     <segue destination="dRa-ou-OcL" kind="modal" identifier="SettingsSegue" modalPresentationStyle="formSheet" id="PHC-9h-QIz"/>
                                 </connections>
@@ -562,7 +562,7 @@
     </scenes>
     <color key="tintColor" red="0.51793235540390015" green="0.5159609317779541" blue="0.53913700580596924" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
     <resources>
-        <image name="gear" width="20" height="20"/>
+        <image name="gear" catalog="system" width="128" height="122"/>
         <image name="sort" width="20" height="20"/>
         <systemColor name="secondarySystemBackgroundColor">
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Provenance/User Interface/pt-BR.lproj/Default.xib
+++ b/Provenance/User Interface/pt-BR.lproj/Default.xib
@@ -23,23 +23,10 @@
                     <view key="view" contentMode="scaleToFill" id="CBZ-2S-KGQ">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <imageView opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" alpha="0.050000000000000003" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="pv_dark_logo" translatesAutoresizingMaskIntoConstraints="NO" id="DpG-sO-5zK">
-                                <rect key="frame" x="67.5" y="269.5" width="240" height="128"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" secondItem="DpG-sO-5zK" secondAttribute="height" multiplier="15:8" id="8Hj-mS-tFY"/>
-                                </constraints>
-                            </imageView>
-                        </subviews>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        <constraints>
-                            <constraint firstItem="DpG-sO-5zK" firstAttribute="width" secondItem="CBZ-2S-KGQ" secondAttribute="width" multiplier="0.64" id="R2q-OM-SD4"/>
-                            <constraint firstItem="DpG-sO-5zK" firstAttribute="centerX" secondItem="CBZ-2S-KGQ" secondAttribute="centerX" id="YjK-yJ-gGQ"/>
-                            <constraint firstItem="DpG-sO-5zK" firstAttribute="centerY" secondItem="CBZ-2S-KGQ" secondAttribute="centerY" id="dVg-lM-R4L"/>
-                        </constraints>
                     </view>
-                    <navigationItem key="navigationItem" title="Loading..." style="browser" id="hEE-db-CVg">
-                        <barButtonItem key="leftBarButtonItem" image="gear" id="HKB-UT-nWv"/>
+                    <navigationItem key="navigationItem" title="Loading…" id="hEE-db-CVg">
+                        <barButtonItem key="leftBarButtonItem" image="gear" catalog="system" id="HKB-UT-nWv"/>
                         <rightBarButtonItems>
                             <barButtonItem systemItem="add" id="rh0-jO-Eea"/>
                             <barButtonItem image="sort" id="NtV-ij-HLA"/>
@@ -54,8 +41,7 @@
         </navigationController>
     </objects>
     <resources>
-        <image name="gear" width="20" height="20"/>
-        <image name="pv_dark_logo" width="800" height="370"/>
+        <image name="gear" catalog="system" width="128" height="122"/>
         <image name="sort" width="20" height="20"/>
     </resources>
 </document>

--- a/Provenance/User Interface/ru.lproj/Default.xib
+++ b/Provenance/User Interface/ru.lproj/Default.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" launchScreen="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -13,33 +11,37 @@
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <navigationController id="fEE-cw-wxX">
             <navigationBar key="navigationBar" contentMode="scaleToFill" barStyle="black" id="0cy-Jv-W3f">
-                <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                 <autoresizingMask key="autoresizingMask"/>
             </navigationBar>
             <viewControllers>
                 <viewController id="r0W-Lf-3pt">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="dyu-Jb-HLF"/>
+                        <viewControllerLayoutGuide type="bottom" id="Nhq-a0-vKI"/>
+                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="CBZ-2S-KGQ">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
-                    <navigationItem key="navigationItem" title="Loading…" id="WtS-co-OJ5">
-                        <barButtonItem key="leftBarButtonItem" image="gear" id="zOf-qU-KPQ">
-                            <color key="tintColor" red="0.094117647060000004" green="0.66274509800000003" blue="0.96862745100000003" alpha="1" colorSpace="calibratedRGB"/>
-                        </barButtonItem>
-                        <barButtonItem key="rightBarButtonItem" systemItem="add" id="wrg-t4-ubM">
-                            <color key="tintColor" red="0.094117647060000004" green="0.66274509800000003" blue="0.96862745100000003" alpha="1" colorSpace="calibratedRGB"/>
-                        </barButtonItem>
+                    <navigationItem key="navigationItem" title="Loading…" id="hEE-db-CVg">
+                        <barButtonItem key="leftBarButtonItem" image="gear" catalog="system" id="HKB-UT-nWv"/>
+                        <rightBarButtonItems>
+                            <barButtonItem systemItem="add" id="rh0-jO-Eea"/>
+                            <barButtonItem image="sort" id="NtV-ij-HLA"/>
+                        </rightBarButtonItems>
                     </navigationItem>
                 </viewController>
             </viewControllers>
             <toolbar key="toolbar" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="vUe-16-zc1">
                 <autoresizingMask key="autoresizingMask"/>
             </toolbar>
-            <point key="canvasLocation" x="843" y="390"/>
+            <point key="canvasLocation" x="1287.0229007633586" y="274.64788732394368"/>
         </navigationController>
     </objects>
     <resources>
-        <image name="gear" width="20" height="20"/>
+        <image name="gear" catalog="system" width="128" height="122"/>
+        <image name="sort" width="20" height="20"/>
     </resources>
 </document>

--- a/Provenance/User Interface/ru.lproj/Provenance.storyboard
+++ b/Provenance/User Interface/ru.lproj/Provenance.storyboard
@@ -461,7 +461,7 @@
                     <navigationItem key="navigationItem" id="LoK-Fl-znC">
                         <nil key="title"/>
                         <leftBarButtonItems>
-                            <barButtonItem image="gear" id="daz-L9-06G">
+                            <barButtonItem image="gear" catalog="system" id="daz-L9-06G">
                                 <connections>
                                     <segue destination="dRa-ou-OcL" kind="modal" identifier="SettingsSegue" modalPresentationStyle="formSheet" id="PHC-9h-QIz"/>
                                 </connections>
@@ -562,7 +562,7 @@
     </scenes>
     <color key="tintColor" red="0.51793235540390015" green="0.5159609317779541" blue="0.53913700580596924" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
     <resources>
-        <image name="gear" width="20" height="20"/>
+        <image name="gear" catalog="system" width="128" height="122"/>
         <image name="sort" width="20" height="20"/>
         <systemColor name="secondarySystemBackgroundColor">
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Provenance/User Interface/zh-Hans.lproj/Default.xib
+++ b/Provenance/User Interface/zh-Hans.lproj/Default.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19158" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19141"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -17,31 +17,31 @@
             <viewControllers>
                 <viewController id="r0W-Lf-3pt">
                     <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="KXq-Fl-hOM"/>
-                        <viewControllerLayoutGuide type="bottom" id="vN1-cS-2JG"/>
+                        <viewControllerLayoutGuide type="top" id="dyu-Jb-HLF"/>
+                        <viewControllerLayoutGuide type="bottom" id="Nhq-a0-vKI"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="CBZ-2S-KGQ">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
-                    <navigationItem key="navigationItem" title="加载中..." id="WtS-co-OJ5">
-                        <barButtonItem key="leftBarButtonItem" image="gear" id="zOf-qU-KPQ">
-                            <color key="tintColor" red="0.094117647060000004" green="0.66274509800000003" blue="0.96862745100000003" alpha="1" colorSpace="calibratedRGB"/>
-                        </barButtonItem>
-                        <barButtonItem key="rightBarButtonItem" systemItem="add" id="wrg-t4-ubM">
-                            <color key="tintColor" red="0.094117647060000004" green="0.66274509800000003" blue="0.96862745100000003" alpha="1" colorSpace="calibratedRGB"/>
-                        </barButtonItem>
+                    <navigationItem key="navigationItem" title="Loading…" id="hEE-db-CVg">
+                        <barButtonItem key="leftBarButtonItem" image="gear" catalog="system" id="HKB-UT-nWv"/>
+                        <rightBarButtonItems>
+                            <barButtonItem systemItem="add" id="rh0-jO-Eea"/>
+                            <barButtonItem image="sort" id="NtV-ij-HLA"/>
+                        </rightBarButtonItems>
                     </navigationItem>
                 </viewController>
             </viewControllers>
             <toolbar key="toolbar" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="vUe-16-zc1">
                 <autoresizingMask key="autoresizingMask"/>
             </toolbar>
-            <point key="canvasLocation" x="1221.7391304347827" y="261.16071428571428"/>
+            <point key="canvasLocation" x="1287.0229007633586" y="274.64788732394368"/>
         </navigationController>
     </objects>
     <resources>
-        <image name="gear" width="20" height="20"/>
+        <image name="gear" catalog="system" width="128" height="122"/>
+        <image name="sort" width="20" height="20"/>
     </resources>
 </document>


### PR DESCRIPTION
### What does this PR do
This pull request uses the system gear icon for the settings button in the loading view and uses the default size in the game library view for consistency.

### Screenshots (important for UI changes)
Before and after:
<img width="50%" alt="Screenshot 2022-11-19 at 17 31 39" src="https://user-images.githubusercontent.com/2276355/202862372-d5c708ae-9534-4f86-9a5c-e76c1b53ac5e.png"><img width="50%" alt="Screenshot 2022-11-19 at 17 43 04" src="https://user-images.githubusercontent.com/2276355/202862376-40f02729-91ca-484f-8e83-c1f39fadc509.png">
