### PR TITLE
Fix TVAlertController button height constraint warning

### DIFF
--- a/ProvenanceTV/TVAlertController.swift
+++ b/ProvenanceTV/TVAlertController.swift
@@ -370,7 +370,9 @@ final class TVAlertController: UIViewController, UIAlertControllerProtocol {
         btn.setGrowDelta(_inset * 0.25, for: .selected)
 
         let h = font.lineHeight * 1.5
-        btn.addConstraint(NSLayoutConstraint(item:btn, attribute:.height, relatedBy:.equal, toItem:nil, attribute:.notAnAttribute, multiplier:1.0, constant:h))
+        let constraint = NSLayoutConstraint(item:btn, attribute:.height, relatedBy:.equal, toItem:nil, attribute:.notAnAttribute, multiplier:1.0, constant:h)
+        constraint.priority = .defaultHigh
+        btn.addConstraint(constraint)
         btn.layer.cornerRadius = h/4
 
         btn.addTarget(self, action: #selector(buttonPress(_:)), for: .primaryActionTriggered)

--- a/ProvenanceTV/TVAlertController.swift
+++ b/ProvenanceTV/TVAlertController.swift
@@ -195,6 +195,9 @@ final class TVAlertController: UIViewController, UIAlertControllerProtocol {
 
         let menu = UIView()
         menu.addSubview(stack)
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.centerXAnchor.constraint(equalTo:menu.centerXAnchor).isActive = true
+        stack.centerYAnchor.constraint(equalTo:menu.centerYAnchor).isActive = true
         view.addSubview(menu)
 
         menu.layer.cornerRadius = _inset
@@ -370,9 +373,7 @@ final class TVAlertController: UIViewController, UIAlertControllerProtocol {
         btn.setGrowDelta(_inset * 0.25, for: .selected)
 
         let h = font.lineHeight * 1.5
-        let constraint = NSLayoutConstraint(item:btn, attribute:.height, relatedBy:.equal, toItem:nil, attribute:.notAnAttribute, multiplier:1.0, constant:h)
-        constraint.priority = .defaultHigh
-        btn.addConstraint(constraint)
+        btn.addConstraint(NSLayoutConstraint(item:btn, attribute:.height, relatedBy:.equal, toItem:nil, attribute:.notAnAttribute, multiplier:1.0, constant:h))
         btn.layer.cornerRadius = h/4
 
         btn.addTarget(self, action: #selector(buttonPress(_:)), for: .primaryActionTriggered)


### PR DESCRIPTION
### What does this PR do
This pull request fixes two constraint warnings, the height one was fixed with d4a2591 but was superseded by c6b7839 which fixes both. The UIStackView issue is discussed [here](https://stackoverflow.com/questions/33073127/nested-uistackviews-broken-constraints).