### PR TITLE
Use TVAlertController everywhere

### DIFF
--- a/Provenance/Game Library/UI/GameLaunchingViewController.swift
+++ b/Provenance/Game Library/UI/GameLaunchingViewController.swift
@@ -637,17 +637,12 @@ extension GameLaunchingViewController where Self: UIViewController {
                     // Add a save this setting toggle
                     alert.addTextField { textField in
                         textField.text = "Auto Load Saves"
-                        textField.backgroundColor = Theme.currentTheme.settingsCellBackground
-                        textField.textColor = Theme.currentTheme.settingsCellText
-                        textField.tintColor = Theme.currentTheme.settingsCellBackground
                         textField.rightViewMode = .always
                         textField.rightView = switchControl
                         textField.borderStyle = .none
                         textField.layer.borderColor = Theme.currentTheme.settingsCellBackground!.cgColor
                         textField.delegate = textEditBlocker // Weak ref
-
-                        switchControl.translatesAutoresizingMaskIntoConstraints = false
-                        switchControl.transform = CGAffineTransform(scaleX: 0.55, y: 0.55)
+                        switchControl.transform = CGAffineTransform(scaleX: 0.90, y: 0.90)
                     }
                 #endif
 

--- a/ProvenanceTV/TVAlertController.swift
+++ b/ProvenanceTV/TVAlertController.swift
@@ -47,20 +47,9 @@ protocol UIAlertControllerProtocol : UIViewController {
      var preferredStyle: UIAlertController.Style { get }
 }
 
-// take over (aka mock) the UIAlertController initializer and return our class sometimes....
+// take over (aka mock) the UIAlertController initializer and return our class
 func UIAlertController(title: String?, message: String?, preferredStyle style: UIAlertController.Style) -> UIAlertControllerProtocol {
-    #if os(tvOS)
-        return TVAlertController.init(title:title, message: message, preferredStyle: style)
-    #else
-        if style == .alert {
-            // always use system Alert on iOS
-            return UIAlertController.init(title:title, message: message, preferredStyle: style)
-        } else {
-            // maybe use custom ActionSheet
-            // return UIAlertController.init(title:title, message: message, preferredStyle: style)
-            return TVAlertController.init(title:title, message: message, preferredStyle: style)
-        }
-    #endif
+    TVAlertController.init(title:title, message: message, preferredStyle: style)
 }
 
 extension UIAlertController : UIAlertControllerProtocol { }


### PR DESCRIPTION
### What does this PR do
This pull request uses `TVAlertController` for all alerts instead of ignoring `.alert` styles.

### Any background context you want to provide
There doesn't seem to be any reason not to use this everywhere, system alerts still work and it seems to work fine with:
- Launch Web Server
- Refresh Game Library
- Empty Image Cache
- Save State Detected (a small change in 6da54ef)
- Delete Save State

### Screenshots (important for UI changes)
<img width="50%" alt="Native alert" src="https://user-images.githubusercontent.com/2276355/202535023-143c95f1-bc57-4ccd-84d5-14830858d2ac.png">

Before and after:
<img width="50%" alt="Before" src="https://user-images.githubusercontent.com/2276355/202535018-8511c361-5552-49c5-bad4-b1e591a6acf3.png"><img width="50%" alt="After" src="https://user-images.githubusercontent.com/2276355/202534989-d30446ac-7815-49d7-8689-49df18bbd45f.png">
