### PR TITLE
SwiftUI flow — make landing screen the console carousel if any consoles available, reduce side menu open width

### DIFF
--- a/PVLibrary/PVLibrary/Database/PVGameLibrary.swift
+++ b/PVLibrary/PVLibrary/Database/PVGameLibrary.swift
@@ -49,7 +49,7 @@ public struct PVGameLibrary {
             .collection(from: self.mostPlayedResults)
             .mapMany { $0 }
 
-        self.activeSystems = database.all(PVSystem.self, filter: NSPredicate(format: "games.@count > 0")).sorted(byKeyPath: #keyPath(PVSystem.name), ascending: false)
+        self.activeSystems = database.all(PVSystem.self, filter: NSPredicate(format: "games.@count > 0")).sorted(byKeyPath: #keyPath(PVSystem.name), ascending: true)
     }
 
     public func search(for searchText: String) -> Observable<[PVGame]> {

--- a/Provenance/NewUI/Consoles/ConsoleGamesView.swift
+++ b/Provenance/NewUI/Consoles/ConsoleGamesView.swift
@@ -215,11 +215,4 @@ struct OptionsIndicator<Content: SwiftUI.View>: SwiftUI.View {
     }
 }
 
-// @available(iOS 14, tvOS 14, *)
-// struct HomeView_Previews: PreviewProvider {
-//    static var previews: some SwiftUI.View {
-//        HomeView()
-//    }
-// }
-
 #endif

--- a/Provenance/NewUI/Consoles/ConsolesWrapperView.swift
+++ b/Provenance/NewUI/Consoles/ConsolesWrapperView.swift
@@ -33,7 +33,7 @@ struct ConsolesWrapperView: SwiftUI.View {
     @ObservedResults(
         PVSystem.self,
         filter: NSPredicate(format: "games.@count > 0"),
-        sortDescriptor: SortDescriptor(keyPath: #keyPath(PVSystem.name), ascending: false)
+        sortDescriptor: SortDescriptor(keyPath: #keyPath(PVSystem.name), ascending: true)
     ) var consoles
 
     init(
@@ -50,7 +50,7 @@ struct ConsolesWrapperView: SwiftUI.View {
         TabView(selection: $delegate.selectedTab) {
             if consoles.count > 0 {
                 ForEach(
-                    viewModel.sortConsolesAscending == true
+                    viewModel.sortConsolesAscending == false
                         ? consoles.reversed()
                         : consoles.map { $0 },
                     id: \.self

--- a/Provenance/NewUI/PVRootViewController+DelegateMethods.swift
+++ b/Provenance/NewUI/PVRootViewController+DelegateMethods.swift
@@ -66,8 +66,6 @@ extension PVRootViewController: PVRootDelegate {
 extension PVRootViewController {
     func delete(game: PVGame) throws {
         try RomDatabase.sharedInstance.delete(game: game)
-//        loadLastKnownNavOption()
-        // we're still retaining a refernce to the removed game, causing a realm crash. Need to reload the view
     }
 }
 
@@ -143,6 +141,7 @@ extension PVRootViewController: PVMenuDelegate {
         for console in consoles {
             self.consoleIdentifiersAndNamesMap[console.identifier] = console.name
         }
+        selectedTabCancellable?.cancel()
         selectedTabCancellable = consolesWrapperViewDelegate.$selectedTab.sink { [weak self] tab in
             guard let self = self else { return }
             if let cachedTitle = self.consoleIdentifiersAndNamesMap[tab] {

--- a/Provenance/NewUI/PVRootViewController.swift
+++ b/Provenance/NewUI/PVRootViewController.swift
@@ -69,7 +69,7 @@ class PVRootViewController: UIViewController, GameLaunchingViewController, GameS
         self.view.addSubview(containerView)
         self.fillParentView(child: containerView, parent: self.view)
 
-        didTapHome()
+        self.determineInitialView()
 
         let hud = MBProgressHUD(view: view)!
         hud.isUserInteractionEnabled = false
@@ -104,6 +104,14 @@ class PVRootViewController: UIViewController, GameLaunchingViewController, GameS
 
     func closeMenu() {
         self.sideNavigationController?.closeSide()
+    }
+    
+    func determineInitialView() {
+        if let console = gameLibrary.activeSystems.first {
+            didTapConsole(with: console.identifier)
+        } else {
+            didTapHome()
+        }
     }
 
     func loadIntoContainer(_ navItem: PVNavOption, newVC: UIViewController) {

--- a/Provenance/PVAppDelegate.swift
+++ b/Provenance/PVAppDelegate.swift
@@ -69,7 +69,7 @@ final class PVAppDelegate: UIResponder, UIApplicationDelegate {
             let sideNav = SideNavigationController(mainViewController: UINavigationController(rootViewController: rootViewController))
             sideNav.leftSide(
                 viewController: SideMenuView.instantiate(gameLibrary: gameLibrary, viewModel: viewModel, delegate: rootViewController, rootDelegate: rootViewController),
-                options: .init(widthPercent: 0.8, animationDuration: 0.18, overlayColor: .clear, overlayOpacity: 1, shadowOpacity: 0.0)
+                options: .init(widthPercent: 0.7, animationDuration: 0.18, overlayColor: .clear, overlayOpacity: 1, shadowOpacity: 0.0)
             )
 
             window.rootViewController = sideNav


### PR DESCRIPTION
### What does this PR do
This updates the SwiftUI flow in two small-ish ways:
* the landing screen will now be the first console in the console page view if any consoles with games are available. Otherwise, it will still default to the Home view.
* reduces the open width of the side menu a bit. See attached screenshot.

### Any background context you want to provide
This stems from conversations about the usability of this flow now that it's in some peoples hands. 

### Screenshots (important for UI changes)
![IMG_D1DD4911A03F-1](https://user-images.githubusercontent.com/18663382/203604319-fe46daaa-48b3-4de3-9a4a-58f7d7f67cb0.jpeg)
