### PR TITLE
Update PVGameLibraryViewController.swift - tvOS Header and Margin tweaks.

### DIFF
--- a/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
+++ b/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
@@ -202,7 +202,7 @@ final class PVGameLibraryViewController: GCEventViewController, UITextFieldDeleg
             let blurEffect = UIBlurEffect(style: UIBlurEffect.Style.dark)
             let blurEffectView = UIVisualEffectView(effect: blurEffect)
             let bounds = (self.navigationController?.navigationBar.bounds)!
-            blurEffectView.frame = CGRect(x: bounds.minX, y: bounds.minY, width: bounds.width, height: bounds.height + 49)
+            blurEffectView.frame = CGRect(x: bounds.minX, y: bounds.minY, width: bounds.width, height: bounds.height + 20)
             self.navigationController?.navigationBar.addSubview(blurEffectView)
             self.navigationController?.navigationBar.sendSubviewToBack(blurEffectView)
             navigationController?.navigationBar.backgroundColor = UIColor.black.withAlphaComponent(0.5)
@@ -500,11 +500,11 @@ final class PVGameLibraryViewController: GCEventViewController, UITextFieldDeleg
             NSLayoutConstraint.activate([
                 collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
                 collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-                collectionView.topAnchor.constraint(equalTo: guide.topAnchor, constant: 49),
+                collectionView.topAnchor.constraint(equalTo: guide.topAnchor, constant: 20),
                 collectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
             ])
         #endif
-        layout.sectionInsetReference = .fromSafeArea
+        
         // Force touch
         #if os(iOS)
             registerForPreviewing(with: self, sourceView: collectionView)
@@ -512,6 +512,7 @@ final class PVGameLibraryViewController: GCEventViewController, UITextFieldDeleg
 
         #if os(iOS)
             view.bringSubviewToFront(libraryInfoContainerView)
+            layout.sectionInsetReference = .fromSafeArea
         #endif
 
         let hud = MBProgressHUD(view: view)!


### PR DESCRIPTION
This (slight) tweak restores the original GameCollection Library View margins, thereby once again allowing for up to 7 titles on tvOS.  Moved the layout.sectionInsetReference addition that broke all of this on tvOS back into an already existing #if os(iOS) section.

Also reduced the Header Height extension by @dnicolson from 49px back down to 20px in order to have more real-estate for the Library view on tvOS.