### PR TITLE
Add Larger Game Library Artwork Display Option for tvOS

### DIFF
--- a/PVSupport/Sources/PVSupport/Settings/PVSettingsModel.swift
+++ b/PVSupport/Sources/PVSupport/Settings/PVSettingsModel.swift
@@ -308,4 +308,8 @@ extension MirroredSettings {
 
     public dynamic var haveWarnedAboutDebug = false
     public dynamic var collapsedSystems = Set<String>()
+
+#if os(tvOS) // mrj
+    public dynamic var largeGameArt = true // mrj
+#endif // mrj
 }

--- a/PVSupport/Sources/PVSupport/Settings/PVSettingsModel.swift
+++ b/PVSupport/Sources/PVSupport/Settings/PVSettingsModel.swift
@@ -309,7 +309,7 @@ extension MirroredSettings {
     public dynamic var haveWarnedAboutDebug = false
     public dynamic var collapsedSystems = Set<String>()
 
-#if os(tvOS) // mrj
-    public dynamic var largeGameArt = true // mrj
-#endif // mrj
+#if os(tvOS)
+    public dynamic var largeGameArt = true
+#endif
 }

--- a/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController+CollectionView.swift
+++ b/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController+CollectionView.swift
@@ -66,15 +66,15 @@ extension PVGameLibraryViewController: UICollectionViewDelegateFlowLayout {
                 // TODO: Multirow?
                 let numberOfRows: CGFloat = 1.0
                 let width = viewWidth // - collectionView.contentInset.left - collectionView.contentInset.right / 4
-                let height = (tvOSCellUnit + PageIndicatorHeight + 24) * numberOfRows
+                let height = (((PVSettingsModel.shared.largeGameArt ? 32 : 0) + tvOSCellUnit) + PageIndicatorHeight + 24) * numberOfRows
                 return PVSaveStateCollectionViewCell.cellSize(forImageSize: CGSize(width: width, height: height))
             case .favorites, .recents:
                 let numberOfRows: CGFloat = 1.0
                 let width = viewWidth // - collectionView.contentInset.left - collectionView.contentInset.right / 5
-                let height: CGFloat = tvOSCellUnit * numberOfRows + PageIndicatorHeight
+                let height: CGFloat = ((PVSettingsModel.shared.largeGameArt ? 32 : 0) + tvOSCellUnit) * numberOfRows + PageIndicatorHeight
                 return PVSaveStateCollectionViewCell.cellSize(forImageSize: CGSize(width: width, height: height))
             case .game(let game):
-                let boxartSize = CGSize(width: tvOSCellUnit, height: round(tvOSCellUnit / game.boxartAspectRatio.rawValue))
+                let boxartSize = CGSize(width: ((PVSettingsModel.shared.largeGameArt ? 32 : 0) + tvOSCellUnit), height: round(((PVSettingsModel.shared.largeGameArt ? 32 : 0) + tvOSCellUnit) / game.boxartAspectRatio.rawValue))
                 return PVGameLibraryCollectionViewCell.cellSize(forImageSize: boxartSize)
             }
         }

--- a/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController+CollectionView.swift
+++ b/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController+CollectionView.swift
@@ -66,12 +66,12 @@ extension PVGameLibraryViewController: UICollectionViewDelegateFlowLayout {
                 // TODO: Multirow?
                 let numberOfRows: CGFloat = 1.0
                 let width = viewWidth // - collectionView.contentInset.left - collectionView.contentInset.right / 4
-                let height = (((PVSettingsModel.shared.largeGameArt ? 32 : 0) + tvOSCellUnit) + PageIndicatorHeight + 24) * numberOfRows
+                let height = (tvOSCellUnit + PageIndicatorHeight + 24) * numberOfRows
                 return PVSaveStateCollectionViewCell.cellSize(forImageSize: CGSize(width: width, height: height))
             case .favorites, .recents:
                 let numberOfRows: CGFloat = 1.0
                 let width = viewWidth // - collectionView.contentInset.left - collectionView.contentInset.right / 5
-                let height: CGFloat = ((PVSettingsModel.shared.largeGameArt ? 32 : 0) + tvOSCellUnit) * numberOfRows + PageIndicatorHeight
+                let height: CGFloat = tvOSCellUnit * numberOfRows + PageIndicatorHeight
                 return PVSaveStateCollectionViewCell.cellSize(forImageSize: CGSize(width: width, height: height))
             case .game(let game):
                 let boxartSize = CGSize(width: ((PVSettingsModel.shared.largeGameArt ? 32 : 0) + tvOSCellUnit), height: round(((PVSettingsModel.shared.largeGameArt ? 32 : 0) + tvOSCellUnit) / game.boxartAspectRatio.rawValue))

--- a/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
+++ b/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
@@ -1534,7 +1534,11 @@ extension PVGameLibraryViewController: UITableViewDataSource {
     }
 
     func tableView(_: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return section == 0 ? SortOptions.count : 4
+        #if os(tvOS)
+            return section == 0 ? SortOptions.count : 5
+        #else
+            return section == 0 ? SortOptions.count : 4
+        #endif
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -1575,7 +1579,12 @@ extension PVGameLibraryViewController: UITableViewDelegate {
             case 3:
                 cell.textLabel?.text = "Show Game Badges"
                 cell.accessoryType = PVSettingsModel.shared.showGameBadges ? .checkmark : .none
-            default:
+            #if os(tvOS)
+            case 4:
+                cell.textLabel?.text = "Show Large Game Artwork"
+                cell.accessoryType = PVSettingsModel.shared.largeGameArt ? .checkmark : .none
+            #endif            
+	    default:
                 fatalError("Invalid row")
             }
         } else {
@@ -1603,7 +1612,11 @@ extension PVGameLibraryViewController: UITableViewDelegate {
                 showSaveStates.onNext(!PVSettingsModel.shared.showRecentSaveStates)
             case 3:
                 PVSettingsModel.shared.showGameBadges = !PVSettingsModel.shared.showGameBadges
-            default:
+	    #if os(tvOS)
+            case 4:
+                PVSettingsModel.shared.largeGameArt = !PVSettingsModel.shared.largeGameArt
+            #endif            
+	    default:
                 fatalError("Invalid row")
             }
             // dont call reloadRows or we will loose focus on tvOS

--- a/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
+++ b/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
@@ -1521,9 +1521,9 @@ extension PVGameLibraryViewController: UITableViewDataSource {
     func tableView(_: UITableView, titleForHeaderInSection section: Int) -> String? {
         switch section {
         case 0:
-            return "Sort By"
+            return "Sort By:"
         case 1:
-            return "View Options"
+            return "Game Library Display Options:"
         default:
             return nil
         }


### PR DESCRIPTION
Add in large Game Art Setting to allow the user to toggle between 6 columns of Title Artwork, or 7. 

(This defaults to 7 which results in smaller Title Artwork.)