### PR TITLE
Add light theme for iOS

### DIFF
--- a/PVSupport/PVSupport.xcodeproj/project.pbxproj
+++ b/PVSupport/PVSupport.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		557DCAB1292A91E100045B02 /* ThemeOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 557DCAB0292A91E000045B02 /* ThemeOption.swift */; };
 		B302F8A420B73D6500C5E502 /* PVLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = B302F89A20B73D6200C5E502 /* PVLogging.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B302F8A620B73D6500C5E502 /* PVLogEntry.h in Headers */ = {isa = PBXBuildFile; fileRef = B302F89B20B73D6300C5E502 /* PVLogEntry.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B302F8A820B73D6500C5E502 /* PVProvenanceLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = B302F89C20B73D6300C5E502 /* PVProvenanceLogging.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -177,6 +178,8 @@
 		1ACEA69617F748F80031B1C9 /* TPCircularBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TPCircularBuffer.h; sourceTree = "<group>"; };
 		1ACEA6A017F74A5A0031B1C9 /* NSObject+PVAbstractAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSObject+PVAbstractAdditions.h"; sourceTree = "<group>"; };
 		1ACEA6A117F74A5A0031B1C9 /* NSObject+PVAbstractAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSObject+PVAbstractAdditions.m"; sourceTree = "<group>"; };
+		557DCAB0292A91E000045B02 /* ThemeOption.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeOption.swift; sourceTree = "<group>"; };
+		557DCAB2292A92A700045B02 /* File.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = File.swift; path = ../PVUI/PVUI/File.swift; sourceTree = "<group>"; };
 		B302F89920B73D5F00C5E502 /* PVLogEntry.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PVLogEntry.m; sourceTree = "<group>"; };
 		B302F89A20B73D6200C5E502 /* PVLogging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PVLogging.h; sourceTree = "<group>"; };
 		B302F89B20B73D6300C5E502 /* PVLogEntry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PVLogEntry.h; sourceTree = "<group>"; };
@@ -1119,6 +1122,7 @@
 		1ACEA63B17F7467D0031B1C9 = {
 			isa = PBXGroup;
 			children = (
+				557DCAB2292A92A700045B02 /* File.swift */,
 				B3173802278419A2002D3ACD /* Build.xcconfig */,
 				B3A4FB58278FE2F200A65248 /* Sources */,
 				B3532B3321A7B736006CDA0F /* Tests */,
@@ -1391,6 +1395,7 @@
 			children = (
 				B3447F9A218C1CD200557ACE /* PVSettingsModel.swift */,
 				B3532C3521A925C1006CDA0F /* SortOption.swift */,
+				557DCAB0292A91E000045B02 /* ThemeOption.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -3582,6 +3587,7 @@
 				B33FB2F3279BE1320013AAD8 /* CoreOptions+Protocols.swift in Sources */,
 				B34AB5762106DC4C00C45F09 /* UIDeviceExtension.swift in Sources */,
 				B30F8013290516B900F21217 /* ScreenType.swift in Sources */,
+				557DCAB1292A91E100045B02 /* ThemeOption.swift in Sources */,
 				B3CDEEC821D4C4E5000C55F7 /* SaveStateSupport.swift in Sources */,
 				B3AB37E721881B6D009D9244 /* iCadeControllerSetting.swift in Sources */,
 				B3AB37E021881955009D9244 /* PViCadeController.swift in Sources */,

--- a/PVSupport/Sources/PVSupport/Settings/PVSettingsModel.swift
+++ b/PVSupport/Sources/PVSupport/Settings/PVSettingsModel.swift
@@ -312,4 +312,6 @@ extension MirroredSettings {
 #if os(tvOS)
     public dynamic var largeGameArt = true
 #endif
+
+    public dynamic var theme: ThemeOptions = .dark
 }

--- a/PVSupport/Sources/PVSupport/Settings/ThemeOption.swift
+++ b/PVSupport/Sources/PVSupport/Settings/ThemeOption.swift
@@ -1,0 +1,46 @@
+//
+//  ThemeOption.swift
+//  PVSupport
+//
+//  Created by Dave Nicolson on 20.11.22.
+//  Copyright © 2022 Provenance Emu. All rights reserved.
+//
+
+import Foundation
+
+@objc
+public enum ThemeOptions: UInt, CustomStringConvertible, CaseIterable, UserDefaultsRepresentable {
+    case light
+    case dark
+    case auto
+
+    public var description: String {
+        switch self {
+        case .light: return "Light"
+        case .dark: return "Dark"
+        case .auto: return "Auto"
+        }
+    }
+
+    public var row: UInt {
+        return rawValue
+    }
+
+    public static var themes: [ThemeOptions] {
+        return allCases
+    }
+
+    public static func optionForRow(_ row: UInt) -> ThemeOptions {
+        switch row {
+        case 0:
+            return .light
+        case 1:
+            return .dark
+        case 2:
+            return .auto
+        default:
+            ELOG("Bad row \(row)")
+            return .dark
+        }
+    }
+}

--- a/Provenance/Controller/PViCadeControllerViewController.swift
+++ b/Provenance/Controller/PViCadeControllerViewController.swift
@@ -38,7 +38,7 @@ final class PViCadeControllerViewController: UITableViewController {
         cell.textLabel?.text = iCadeControllerSetting(rawValue: indexPath.row)?.description ?? "nil"
 
         #if os(iOS)
-            cell.backgroundColor = .systemBackground
+            cell.backgroundColor = .secondarySystemGroupedBackground
             cell.textLabel?.textColor = Theme.currentTheme.settingsCellText
         #endif
 

--- a/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
+++ b/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
@@ -464,8 +464,6 @@ final class PVGameLibraryViewController: GCEventViewController, UITextFieldDeleg
             collectionView.clipsToBounds = false
             collectionView.backgroundColor = .black
         #else
-            collectionView.backgroundColor = Theme.currentTheme.gameLibraryBackground
-
             let pinchGesture = UIPinchGestureRecognizer(target: self, action: #selector(PVGameLibraryViewController.didReceivePinchGesture(gesture:)))
             pinchGesture.cancelsTouchesInView = true
             collectionView.addGestureRecognizer(pinchGesture)

--- a/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
+++ b/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
@@ -1715,6 +1715,11 @@ extension PVGameLibraryViewController {
     override var canBecomeFirstResponder: Bool {
         return true
     }
+    
+    override func traitCollectionDidChange(_: UITraitCollection?) {
+        self.collectionView?.collectionViewLayout.invalidateLayout()
+        self.collectionView?.reloadData()
+    }
 
     #if os(tvOS)
         @objc

--- a/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
+++ b/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
@@ -188,6 +188,7 @@ final class PVGameLibraryViewController: GCEventViewController, UITextFieldDeleg
         NotificationCenter.default.addObserver(self, selector: #selector(PVGameLibraryViewController.handleAppDidBecomeActive(_:)), name: UIApplication.didBecomeActiveNotification, object: nil)
 
         #if os(iOS)
+            navigationController?.navigationBar.backgroundColor = Theme.currentTheme.navigationBarBackgroundColor
             navigationController?.navigationBar.tintColor = Theme.currentTheme.barButtonItemTint
 
             NotificationCenter.default.addObserver(forName: NSNotification.Name.PVInterfaceDidChangeNotification, object: nil, queue: nil, using: { (_: Notification) -> Void in

--- a/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
+++ b/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
@@ -189,7 +189,6 @@ final class PVGameLibraryViewController: GCEventViewController, UITextFieldDeleg
 
         #if os(iOS)
             navigationController?.navigationBar.tintColor = Theme.currentTheme.barButtonItemTint
-            navigationItem.leftBarButtonItem?.tintColor = Theme.currentTheme.barButtonItemTint
 
             NotificationCenter.default.addObserver(forName: NSNotification.Name.PVInterfaceDidChangeNotification, object: nil, queue: nil, using: { (_: Notification) -> Void in
                 DispatchQueue.main.async {

--- a/Provenance/Game Library/UI/Game Library/Reusable Views/PVGameLibrarySectionHeaderView.swift
+++ b/Provenance/Game Library/UI/Game Library/Reusable Views/PVGameLibrarySectionHeaderView.swift
@@ -92,9 +92,7 @@ final class PVGameLibrarySectionHeaderView: UICollectionReusableView {
             addSubview(bottomSeparator)
 
             // Style
-            backgroundColor = UIColor.black.withAlphaComponent(0.8)
             titleLabel.textAlignment = .left
-            titleLabel.backgroundColor = .clear
             titleLabel.textColor = UIColor(white: 1.0, alpha: 0.5)
 //        topSeparator.backgroundColor = UIColor(hex: "#262626")
 //        bottomSeparator.backgroundColor = UIColor(hex: "#262626")

--- a/Provenance/Game Library/UI/Game Library/Reusable Views/PVGameLibrarySectionHeaderView.swift
+++ b/Provenance/Game Library/UI/Game Library/Reusable Views/PVGameLibrarySectionHeaderView.swift
@@ -86,14 +86,14 @@ final class PVGameLibrarySectionHeaderView: UICollectionReusableView {
 //        addSubview(topSeparator)
 
             let bottomSeparator = UIView(frame: CGRect(x: 0, y: bounds.size.height, width: bounds.size.width, height: 1.0))
-            bottomSeparator.backgroundColor = UIColor(white: 1.0, alpha: 0.2)
+            bottomSeparator.backgroundColor = Theme.currentTheme.gameLibraryHeaderText
             bottomSeparator.autoresizingMask = .flexibleWidth
 
             addSubview(bottomSeparator)
 
             // Style
             titleLabel.textAlignment = .left
-            titleLabel.textColor = UIColor(white: 1.0, alpha: 0.5)
+            titleLabel.textColor = Theme.currentTheme.gameLibraryHeaderText
 //        topSeparator.backgroundColor = UIColor(hex: "#262626")
 //        bottomSeparator.backgroundColor = UIColor(hex: "#262626")
             clipsToBounds = false

--- a/Provenance/PVAppDelegate.swift
+++ b/Provenance/PVAppDelegate.swift
@@ -32,7 +32,8 @@ final class PVAppDelegate: UIResponder, UIApplicationDelegate {
         //        let currentTheme = PVSettingsModel.shared.theme
         //        Theme.currentTheme = currentTheme.theme
         DispatchQueue.main.async {
-            Theme.currentTheme = Theme.darkTheme
+            let darkTheme = (PVSettingsModel.shared.theme == .auto && self.window?.traitCollection.userInterfaceStyle == .dark) || PVSettingsModel.shared.theme == .dark
+            Theme.currentTheme = darkTheme ? Theme.darkTheme : Theme.lightTheme
         }
         #elseif os(tvOS)
         if PVSettingsModel.shared.debugOptions.tvOSThemes {
@@ -53,6 +54,8 @@ final class PVAppDelegate: UIResponder, UIApplicationDelegate {
         // Set root view controller and make windows visible
         let window = UIWindow.init(frame: UIScreen.main.bounds)
         self.window = window
+        let darkTheme = (PVSettingsModel.shared.theme == .auto && window.traitCollection.userInterfaceStyle == .dark) || PVSettingsModel.shared.theme == .dark
+        window.overrideUserInterfaceStyle = darkTheme ? .dark : .light
 
         #if os(tvOS)
         window.tintColor = .provenanceBlue

--- a/Provenance/Provenance-Info.plist
+++ b/Provenance/Provenance-Info.plist
@@ -262,8 +262,6 @@
 	</array>
 	<key>UISupportsDocumentBrowser</key>
 	<true/>
-	<key>UIUserInterfaceStyle</key>
-	<string>Dark</string>
 	<key>UTExportedTypeDeclarations</key>
 	<array>
 		<dict>

--- a/Provenance/Settings/Cells/PVSliderCell.swift
+++ b/Provenance/Settings/Cells/PVSliderCell.swift
@@ -24,8 +24,6 @@ final class PVSliderCell: SliderCell {
         let bg = UIView(frame: bounds)
         bg.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         #if os(iOS)
-            bg.backgroundColor = Theme.currentTheme.settingsCellBackground
-            textLabel?.textColor = Theme.currentTheme.settingsCellText
             slider.tintColor = Theme.currentTheme.defaultTintColor
 		#if !targetEnvironment(macCatalyst)
             slider.thumbTintColor = Theme.currentTheme.switchThumb

--- a/Provenance/Settings/Cells/PVSliderCell.swift
+++ b/Provenance/Settings/Cells/PVSliderCell.swift
@@ -20,6 +20,10 @@ final class PVSliderCell: SliderCell {
         style()
     }
 
+    override func traitCollectionDidChange(_: UITraitCollection?) {
+        style()
+    }
+    
     func style() {
         let bg = UIView(frame: bounds)
         bg.autoresizingMask = [.flexibleWidth, .flexibleHeight]

--- a/Provenance/Settings/Cells/PVSwitchCell.swift
+++ b/Provenance/Settings/Cells/PVSwitchCell.swift
@@ -18,6 +18,10 @@ final class PVSwitchCell: SwitchCell {
         super.init(coder: aDecoder)
         style()
     }
+    
+    override func traitCollectionDidChange(_: UITraitCollection?) {
+        style()
+    }
 
     func style() {
         let bg = UIView(frame: bounds)

--- a/Provenance/Settings/Cells/PVSwitchCell.swift
+++ b/Provenance/Settings/Cells/PVSwitchCell.swift
@@ -23,9 +23,6 @@ final class PVSwitchCell: SwitchCell {
         let bg = UIView(frame: bounds)
         bg.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         #if os(iOS)
-            bg.backgroundColor = Theme.currentTheme.settingsCellBackground
-            textLabel?.textColor = Theme.currentTheme.settingsCellText
-            detailTextLabel?.textColor = Theme.currentTheme.defaultTintColor
             switchControl.onTintColor = Theme.currentTheme.switchON
 		#if !targetEnvironment(macCatalyst)
             switchControl.thumbTintColor = Theme.currentTheme.switchThumb

--- a/Provenance/Settings/Custom Rows/SettingsOptionRow.swift
+++ b/Provenance/Settings/Custom Rows/SettingsOptionRow.swift
@@ -26,10 +26,6 @@ final class PVRadioOptionCell: UITableViewCell {
         let bg = UIView(frame: bounds)
         bg.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         #if os(iOS)
-            bg.backgroundColor = Theme.currentTheme.settingsCellBackground
-            textLabel?.textColor = Theme.currentTheme.settingsCellText
-            detailTextLabel?.textColor = Theme.currentTheme.defaultTintColor
-//            switchControl.onTintColor = Theme.currentTheme.switchON
         #if !targetEnvironment(macCatalyst)
 //            switchControl.thumbTintColor = Theme.currentTheme.switchThumb
         #endif

--- a/Provenance/Settings/PVSettingsViewController.swift
+++ b/Provenance/Settings/PVSettingsViewController.swift
@@ -394,7 +394,7 @@ final class PVSettingsViewController: PVQuickTableViewController {
                 icon: nil,
                 customization: { cell, _ in
                     if !masterBranch {
-                        cell.detailTextLabel?.textColor = UIColor(hex: "#F5F5A0")
+                        cell.detailTextLabel?.textColor = .systemYellow
                     }
                 },
                 action: nil

--- a/Provenance/Settings/PVSettingsViewController.swift
+++ b/Provenance/Settings/PVSettingsViewController.swift
@@ -89,11 +89,34 @@ final class PVSettingsViewController: PVQuickTableViewController {
 
         // -- Section : App
         let systemsRow = SegueNavigationRow(text: NSLocalizedString("Systems", comment: "Systems"), viewController: self, segue: "pushSystemSettings")
-        #if os(iOS)
-            let autolockRow = PVSettingsSwitchRow(text: NSLocalizedString("Disable Auto Lock", comment: "Disable Auto Lock"), detailText: .subtitle("This also disables the screensaver."), key: \PVSettingsModel.disableAutoLock)
-            let appRows: [TableRow] = [autolockRow, systemsRow]
-        #else
+
+        let systemMode = self.traitCollection.userInterfaceStyle == .dark ? "Dark" : "Light"
+        var theme = PVSettingsModel.shared.theme.description
+        if PVSettingsModel.shared.theme == .auto {
+            theme += " (\(systemMode))"
+        }
+        let themeRow = NavigationRow<SystemSettingsCell>(text: NSLocalizedString("Theme", comment: "Theme"), detailText: .value1(PVSettingsModel.shared.theme.description), action: { row in
+            let alert = UIAlertController(title: "Theme", message: "", preferredStyle: .actionSheet)
+            ThemeOptions.themes.forEach { mode in
+                let modeLabel = mode == .auto ? mode.description + " (\(systemMode))" : mode.description
+                let action = UIAlertAction(title: modeLabel, style: .default, handler: { _ in
+                    let darkTheme = (mode == .auto && self.traitCollection.userInterfaceStyle == .dark) || mode == .dark
+                    Theme.currentTheme = darkTheme ? Theme.darkTheme : Theme.lightTheme
+                    UIApplication.shared.windows.first!.overrideUserInterfaceStyle = darkTheme ? .dark : .light
+                    PVSettingsModel.shared.theme = mode
+
+                    self.generateTableViewViewModels()
+                })
+                alert.addAction(action)
+            }
+            self.present(alert, animated: true)
+        })
+        
+        #if os(tvOS)
             let appRows: [TableRow] = [systemsRow]
+        #else
+            let autolockRow = PVSettingsSwitchRow(text: NSLocalizedString("Disable Auto Lock", comment: "Disable Auto Lock"), detailText: .subtitle("This also disables the screensaver."), key: \PVSettingsModel.disableAutoLock)
+            let appRows: [TableRow] = [autolockRow, systemsRow, themeRow]
         #endif
 
         let appSection = Section(title: NSLocalizedString("App", comment: "App"), rows: appRows)

--- a/Provenance/Settings/SystemSettings/SystemSettingsCell.swift
+++ b/Provenance/Settings/SystemSettings/SystemSettingsCell.swift
@@ -24,11 +24,7 @@ public class SystemSettingsCell: UITableViewCell {
     func style() {
         let bg = UIView(frame: bounds)
         bg.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        #if os(iOS)
-            bg.backgroundColor = Theme.currentTheme.settingsCellBackground
-            textLabel?.textColor = Theme.currentTheme.settingsCellText
-            detailTextLabel?.textColor = Theme.currentTheme.defaultTintColor
-        #else
+        #if os(tvOS)
             bg.backgroundColor = UIColor.clear
             self.textLabel?.textColor = traitCollection.userInterfaceStyle != .light ? UIColor.white : UIColor.black
             self.detailTextLabel?.textColor = traitCollection.userInterfaceStyle != .light ? UIColor.lightGray : UIColor.darkGray

--- a/Provenance/Settings/SystemSettings/SystemSettingsHeaderCell.swift
+++ b/Provenance/Settings/SystemSettings/SystemSettingsHeaderCell.swift
@@ -11,12 +11,7 @@ import Foundation
 public final class SystemSettingsHeaderCell: SystemSettingsCell {
     override func style() {
         super.style()
-        #if os(iOS)
-            backgroundView?.backgroundColor = Theme.currentTheme.settingsHeaderBackground
-            textLabel?.textColor = Theme.currentTheme.settingsHeaderText
-            detailTextLabel?.textColor = Theme.currentTheme.settingsHeaderText
-            textLabel?.font = UIFont.preferredFont(forTextStyle: .footnote)
-        #else
+        #if os(tvOS)
             backgroundView?.backgroundColor = UIColor.clear
             textLabel?.textColor = .white
             detailTextLabel?.textColor = .lightGray

--- a/Provenance/Settings/SystemSettings/SystemsSettingsTableViewController.swift
+++ b/Provenance/Settings/SystemSettings/SystemsSettingsTableViewController.swift
@@ -123,7 +123,6 @@ final class SystemsSettingsTableViewController: QuickTableViewController {
         super.viewDidLoad()
 
         #if os(iOS)
-            tableView.backgroundColor = Theme.currentTheme.settingsHeaderBackground
             tableView.separatorStyle = .singleLine
         #else
             tableView.backgroundColor = UIColor.clear

--- a/Provenance/User Interface/Themes/Theme.swift
+++ b/Provenance/User Interface/Themes/Theme.swift
@@ -236,10 +236,10 @@ public final class Theme {
 			#endif
         }
 
-        UITableView.appearance {
-            $0.backgroundColor = theme.settingsHeaderBackground
-            $0.separatorColor = theme.settingsSeperator
-        }
+//        UITableView.appearance {
+//            $0.backgroundColor = theme.settingsHeaderBackground
+//            $0.separatorColor = theme.settingsSeperator
+//        }
 
         #endif
 

--- a/Provenance/User Interface/Themes/Theme.swift
+++ b/Provenance/User Interface/Themes/Theme.swift
@@ -211,14 +211,14 @@ public final class Theme {
     }
 
     private class func setTheme(_ theme: iOSTheme) {
-        UINavigationBar.appearance {
-            $0.backgroundColor = theme.navigationBarBackgroundColor
-            $0.tintColor = theme.barButtonItemTint
-            #if !os(tvOS)
-            $0.barStyle = theme.navigationBarStyle
-            #endif
-            $0.isTranslucent = true
-        }
+//        UINavigationBar.appearance {
+//            $0.backgroundColor = theme.navigationBarBackgroundColor
+//            $0.tintColor = theme.barButtonItemTint
+//            #if !os(tvOS)
+//            $0.barStyle = theme.navigationBarStyle
+//            #endif
+//            $0.isTranslucent = true
+//        }
 
 //        UIView.appearance {
 //            $0.tintColor = theme.defaultTintColor

--- a/Provenance/User Interface/Themes/Theme.swift
+++ b/Provenance/User Interface/Themes/Theme.swift
@@ -172,6 +172,11 @@ struct LightTheme: iOSTheme {
 
     let gameLibraryHeaderBackground: UIColor = Colors.white9alpha6
     let gameLibraryHeaderText: UIColor = .darkGray
+    
+    var navigationBarBackgroundColor: UIColor? { return .grey1C }
+    var settingsCellBackground: UIColor? { return .white }
+    var settingsCellText: UIColor? { return .black }
+    var settingsCellTextDetail: UIColor? { return .gray }
 }
 
 // @available(iOS 9.0, *)

--- a/Provenance/User Interface/Themes/Theme.swift
+++ b/Provenance/User Interface/Themes/Theme.swift
@@ -293,12 +293,12 @@ public final class Theme {
             $0.backgroundColor = theme.gameLibraryHeaderBackground
         }
 
-        appearance(in: [PVGameLibrarySectionHeaderView.self]) {
-            UILabel.appearance {
-                $0.backgroundColor = theme.gameLibraryHeaderBackground
-                $0.textColor = theme.gameLibraryHeaderText
-            }
-        }
+//        appearance(in: [PVGameLibrarySectionHeaderView.self]) {
+//            UILabel.appearance {
+//                $0.backgroundColor = theme.gameLibraryHeaderBackground
+//                $0.textColor = theme.gameLibraryHeaderText
+//            }
+//        }
 
         // Game Library Main
         appearance(inAny: [PVGameLibraryCollectionViewCell.self]) {

--- a/Provenance/Utilities/PVLogViewController.xib
+++ b/Provenance/Utilities/PVLogViewController.xib
@@ -73,7 +73,6 @@
                     </connections>
                 </textView>
             </subviews>
-            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <gestureRecognizers/>
             <constraints>
                 <constraint firstItem="ir3-aG-kbV" firstAttribute="leading" secondItem="1" secondAttribute="leading" id="1DP-R6-QxA"/>


### PR DESCRIPTION
### What does this PR do
This pull request removes a lot of redundant dark and light theme code by leveraging the appearance defaults in iOS 13+. Only a minimal set of changes were made to the Theme file, much more code can also be removed.

This works by setting the `overrideUserInterfaceStyle` on launch and provides a setting option to switch themes. The light theme can probably be improved upon in terms of design choices.

### Screenshots (important for UI changes)
https://user-images.githubusercontent.com/2276355/204145362-87ebd85d-3ef7-4c1d-bf4d-39b419e1b0c4.mov

