### PR TITLE
Prevent game library header separators from disappearing

### DIFF
--- a/Provenance/Game Library/UI/Game Library/Reusable Views/PVGameLibrarySectionHeaderView.swift
+++ b/Provenance/Game Library/UI/Game Library/Reusable Views/PVGameLibrarySectionHeaderView.swift
@@ -85,7 +85,7 @@ final class PVGameLibrarySectionHeaderView: UICollectionReusableView {
 //
 //        addSubview(topSeparator)
 
-            let bottomSeparator = UIView(frame: CGRect(x: 0, y: bounds.size.height, width: bounds.size.width, height: 1.0))
+            let bottomSeparator = UIView(frame: CGRect(x: 0, y: bounds.size.height - 1, width: bounds.size.width, height: 1.0))
             bottomSeparator.backgroundColor = Theme.currentTheme.gameLibraryHeaderText
             bottomSeparator.autoresizingMask = .flexibleWidth
 


### PR DESCRIPTION
### What does this PR do
This pull request adjusts the position of the game library header separators.

### Screenshots (important for UI changes)
Before and after:
<img width="50%" alt="Screenshot 2022-12-01 at 17 57 30" src="https://user-images.githubusercontent.com/2276355/205119881-adb9fe23-a3b4-4873-abfd-f5a282c68617.png"><img width="50%" alt="Screenshot 2022-12-01 at 17 57 50" src="https://user-images.githubusercontent.com/2276355/205119907-a6df84f2-4315-4456-93b6-78c924f38b79.png">
