### PR TITLE
Fix game description character encoding

### DIFF
--- a/PVLibrary/PVLibrary/Importer/Services/GameImporter.swift
+++ b/PVLibrary/PVLibrary/Importer/Services/GameImporter.swift
@@ -1000,7 +1000,7 @@ public extension GameImporter {
 
                 if let gameDescription = chosenResult["gameDescription"] as? String, !gameDescription.isEmpty, overwrite || game.gameDescription == nil {
                     let options = [NSAttributedString.DocumentReadingOptionKey.documentType: NSAttributedString.DocumentType.html]
-                    let htmlDecodedGameDescription = try! NSMutableAttributedString(data: gameDescription.data(using: .utf8)!, options: options, documentAttributes: nil)
+                    let htmlDecodedGameDescription = try! NSMutableAttributedString(data: gameDescription.data(using: .isoLatin1)!, options: options, documentAttributes: nil)
                     game.gameDescription = htmlDecodedGameDescription.string.replacingOccurrences(of: "(\\.|\\!|\\?)([A-Z][A-Za-z\\s]{2,})", with: "$1\n\n$2", options: .regularExpression)
                 }
 


### PR DESCRIPTION
### What does this PR do
This pull request fixes the character encoding of game imports. For example, "Pokémon" appears as "PokÃ©mon".

The issue appeared after https://github.com/Provenance-Emu/Provenance/pull/1319, it is not clear why the text is no longer encoded with UTF-8. The database is encoded in UTF-8:
```
sqlite3 openvgdb.sqlite
SQLite version 3.39.4 2022-09-07 20:51:41
Enter ".help" for usage hints.
sqlite> pragma encoding;
UTF-8
```