### PR TITLE
Fix UICollectionViewFlowLayout warning

### DIFF
--- a/Provenance/Game Library/UI/CollectionViewInACell/CollectionViewInCollectionViewCell.swift
+++ b/Provenance/Game Library/UI/CollectionViewInACell/CollectionViewInCollectionViewCell.swift
@@ -40,7 +40,7 @@ class CollectionViewInCollectionViewCell<Item: SubCellItem>: UICollectionViewCel
 
     var subCellSize: CGSize {
         #if os(tvOS)
-            return CGSize(width: 350, height: 280)
+            return CGSize(width: 350, height: 244)
         #else
             let ratio = 5.0 / 4.0
             let width = 100.0
@@ -142,7 +142,7 @@ class CollectionViewInCollectionViewCell<Item: SubCellItem>: UICollectionViewCel
 
         internalCollectionView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 0).isActive = true
         internalCollectionView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: 0).isActive = true
-        internalCollectionView.heightAnchor.constraint(equalTo: margins.heightAnchor, constant: 0).isActive = true
+        internalCollectionView.heightAnchor.constraint(equalTo: margins.heightAnchor, constant: 36).isActive = true
 
         // setup page indicator layout
         addSubview(pageIndicator)


### PR DESCRIPTION
### What does this PR do
This pull request fixes the following warning:
```
2022-12-15 17:16:01.327562+0100 Provenance[69893:59795708] The behavior of the UICollectionViewFlowLayout is not defined because:
2022-12-15 17:16:01.327708+0100 Provenance[69893:59795708] the item height must be less than the height of the UICollectionView minus the section insets top and bottom values, minus the content insets top and bottom values.
2022-12-15 17:16:01.328053+0100 Provenance[69893:59795708] The relevant UICollectionViewFlowLayout instance is <Provenance.CenterViewFlowLayout: 0x125111e50>, and it is attached to <UICollectionView: 0x12601e800; frame = (0 0; 1920 244); gestureRecognizers = <NSArray: 0x600003660030>; layer = <CALayer: 0x600003ed09e0>; contentOffset: {-80, 0}; contentSize: {0, 0}; adjustedContentInset: {0, 80, 0, 27}; layout: <Provenance.CenterViewFlowLayout: 0x125111e50>; dataSource: <RxCocoa.RxCollectionViewDataSourceProxy: 0x600001c89320>>.
2022-12-15 17:16:01.328145+0100 Provenance[69893:59795708] Make a symbolic breakpoint at UICollectionViewFlowLayoutBreakForInvalidSizes to catch this in the debugger.
```