### PR TITLE
Fix keyboard input

### DIFF
--- a/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
+++ b/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
@@ -1665,36 +1665,46 @@ extension PVGameLibraryViewController {
             for (i, section) in dataSource.sectionModels.enumerated() {
                 let input = "\(i)"
                 let title = section.header
-                let command = UIKeyCommand(input: input, modifierFlags: flags, action: #selector(PVGameLibraryViewController.selectSection(_:)), discoverabilityTitle: title)
+                #if os(tvOS)
+                    let command = UIKeyCommand(input: input, modifierFlags: flags, action: #selector(PVGameLibraryViewController.selectSection(_:)))
+                    command.discoverabilityTitle = title
+                #elseif os(iOS)
+                    let command = UIKeyCommand(title: title, action: #selector(PVGameLibraryViewController.selectSection(_:)), input: input, modifierFlags: flags)
+                #endif
                 sectionCommands.append(command)
             }
         }
 
         #if os(tvOS)
             if focusedGame != nil {
-                let toggleFavoriteCommand = UIKeyCommand(input: "=", modifierFlags: flags, action: #selector(PVGameLibraryViewController.toggleFavoriteCommand), discoverabilityTitle: "Toggle Favorite")
+                let toggleFavoriteCommand = UIKeyCommand(input: "=", modifierFlags: flags, action: #selector(PVGameLibraryViewController.toggleFavoriteCommand))
+                toggleFavoriteCommand.discoverabilityTitle = "Toggle Favorite"
                 sectionCommands.append(toggleFavoriteCommand)
 
-                let showMoreInfo = UIKeyCommand(input: "i", modifierFlags: flags, action: #selector(PVGameLibraryViewController.showMoreInfoCommand), discoverabilityTitle: "More info…")
+                let showMoreInfo = UIKeyCommand(input: "i", modifierFlags: flags, action: #selector(PVGameLibraryViewController.showMoreInfoCommand))
+                showMoreInfo.discoverabilityTitle = "More info…"
                 sectionCommands.append(showMoreInfo)
 
-                let renameCommand = UIKeyCommand(input: "r", modifierFlags: flags, action: #selector(PVGameLibraryViewController.renameCommand), discoverabilityTitle: "Rename…")
+                let renameCommand = UIKeyCommand(input: "r", modifierFlags: flags, action: #selector(PVGameLibraryViewController.renameCommand))
+                renameCommand.discoverabilityTitle = "Rename…"
                 sectionCommands.append(renameCommand)
 
-                let deleteCommand = UIKeyCommand(input: "x", modifierFlags: flags, action: #selector(PVGameLibraryViewController.deleteCommand), discoverabilityTitle: "Delete…")
+                let deleteCommand = UIKeyCommand(input: "x", modifierFlags: flags, action: #selector(PVGameLibraryViewController.deleteCommand))
+                deleteCommand.discoverabilityTitle = "Delete…"
                 sectionCommands.append(deleteCommand)
 
-                let sortCommand = UIKeyCommand(input: "s", modifierFlags: flags, action: #selector(PVGameLibraryViewController.sortButtonTapped(_:)), discoverabilityTitle: "Sorting")
+                let sortCommand = UIKeyCommand(input: "s", modifierFlags: flags, action: #selector(PVGameLibraryViewController.sortButtonTapped(_:)))
+                sortCommand.discoverabilityTitle = "Sorting"
                 sectionCommands.append(sortCommand)
             }
         #elseif os(iOS)
-            let findCommand = UIKeyCommand(input: "f", modifierFlags: flags, action: #selector(PVGameLibraryViewController.selectSearch(_:)), discoverabilityTitle: "Find…")
+            let findCommand = UIKeyCommand(title: "Find…", action: #selector(PVGameLibraryViewController.selectSearch(_:)), input: "f", modifierFlags: flags)
             sectionCommands.append(findCommand)
 
-            let sortCommand = UIKeyCommand(input: "s", modifierFlags: flags, action: #selector(PVGameLibraryViewController.sortButtonTapped(_:)), discoverabilityTitle: "Sorting")
+            let sortCommand = UIKeyCommand(title: "Sorting", action: #selector(PVGameLibraryViewController.sortButtonTapped(_:)), input: "s", modifierFlags: flags)
             sectionCommands.append(sortCommand)
-
-            let settingsCommand = UIKeyCommand(input: ",", modifierFlags: flags, action: #selector(PVGameLibraryViewController.settingsCommand), discoverabilityTitle: "Settings")
+        
+            let settingsCommand = UIKeyCommand(title: "Settings", action: #selector(PVGameLibraryViewController.settingsCommand), input: ",", modifierFlags: flags)
             sectionCommands.append(settingsCommand)
         #endif
 

--- a/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
+++ b/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
@@ -1714,6 +1714,7 @@ extension PVGameLibraryViewController {
     @objc func selectSearch(_: UIKeyCommand) {
 		#if os(iOS)
 		navigationItem.searchController?.isActive = true
+        navigationItem.searchController?.searchBar.becomeFirstResponder()
 		#endif
     }
 

--- a/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
+++ b/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
@@ -1941,7 +1941,7 @@ extension PVGameLibraryViewController: ControllerButtonPress {
     // just hilight (with a cheesy overlay) the item
     private func select(_ indexPath:IndexPath?) {
 
-        guard var indexPath = indexPath else {
+        guard var indexPath = indexPath, collectionView!.numberOfSections > 0 else {
             _selectedIndexPath = nil
             _selectedIndexPathView?.frame = .zero
             return


### PR DESCRIPTION
### What does this PR do
This pull request prevents a crash when using the keyboard on an iPad, makes search input immediately focused and resolves `UIKeyCommand` deprecation warnings.

It's not clear if `discoverabilityTitle` is needed on tvOS anymore, but it's still a property.