### PR TITLE
Fix missing artwork background

### DIFF
--- a/Provenance/Game Library/UI/Game Library/Reusable Views/PVGameLibraryCollectionViewCell.swift
+++ b/Provenance/Game Library/UI/Game Library/Reusable Views/PVGameLibraryCollectionViewCell.swift
@@ -771,7 +771,7 @@ final class PVGameLibraryCollectionViewCell: UICollectionViewCell {
 
     func image(withText text: String) -> UIImage? {
         #if os(iOS)
-            let backgroundColor: UIColor = .systemBackground
+            let backgroundColor: UIColor = .systemGray5
         #else
             let backgroundColor: UIColor = UIColor(white: 0.18, alpha: 1.0)
         #endif

--- a/Provenance/Game Library/UI/PVGameMoreInfoViewController.swift
+++ b/Provenance/Game Library/UI/PVGameMoreInfoViewController.swift
@@ -401,7 +401,7 @@ final class PVGameMoreInfoViewController: UIViewController, GameLaunchingViewCon
 
     func image(withText text: String) -> UIImage? {
         #if os(iOS)
-            let backgroundColor: UIColor = .systemBackground
+            let backgroundColor: UIColor = .systemGray5
         #else
             let backgroundColor: UIColor = UIColor(white: 0.9, alpha: 0.9)
         #endif

--- a/Provenance/Settings/PVSettingsViewController.swift
+++ b/Provenance/Settings/PVSettingsViewController.swift
@@ -109,6 +109,11 @@ final class PVSettingsViewController: QuickTableViewController {
                 })
                 alert.addAction(action)
             }
+            alert.addAction(UIAlertAction(title: NSLocalizedString("Cancel", comment: "Cancel"), style: .cancel, handler: { _ in
+                if let indexPathForSelectedRow = self.tableView.indexPathForSelectedRow {
+                    self.tableView.deselectRow(at: indexPathForSelectedRow, animated: false)
+                }
+            }))
             self.present(alert, animated: true)
         })
 


### PR DESCRIPTION
### What does this PR do
This pull request fixes the missing artwork game cell background colors, the ability to cancel the theme change alert makes it more consistent with other alerts.

### Screenshots (important for UI changes)
Before and afters:
<img width="50%" alt="Screenshot 2022-12-17 at 20 21 11" src="https://user-images.githubusercontent.com/2276355/208264693-a6e21cb7-53ea-4339-ab5c-072671e6f49a.png"><img width="50%" alt="Screenshot 2022-12-17 at 20 21 30" src="https://user-images.githubusercontent.com/2276355/208264695-deed73e8-6391-460b-8224-94a58d82eccb.png">
<img width="50%" alt="Screenshot 2022-12-17 at 20 21 57" src="https://user-images.githubusercontent.com/2276355/208264700-f3a4e5eb-82d8-4778-8f01-a670bc7ad277.png"><img width="50%" alt="Screenshot 2022-12-17 at 20 21 40" src="https://user-images.githubusercontent.com/2276355/208264698-f4542325-46cb-4d63-a43e-9c3a056c845a.png">