### PR TITLE
Fix Catalyst build

### DIFF
--- a/Provenance/Controller/PVControllerViewController.swift
+++ b/Provenance/Controller/PVControllerViewController.swift
@@ -373,7 +373,7 @@ class PVControllerViewController<T: ResponderClient> : UIViewController, Control
 	}
 
 	func vibrate() {
-#if os(iOS)
+#if os(iOS) && !targetEnvironment(macCatalyst)
 		if PVSettingsModel.shared.buttonVibration {
 				// only iPhone 7 and 7 Plus support the taptic engine APIs for now.
 				// everything else should fall back to the vibration motor.


### PR DESCRIPTION
### What does this PR do
This pull request fixes the following error when building a Catalyst target:
```
Type 'UIDevice' has no member 'hasTapticMotor'
```