### PR TITLE
Fix import alert on iOS

### DIFF
--- a/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
+++ b/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
@@ -830,12 +830,9 @@ final class PVGameLibraryViewController: GCEventViewController, UITextFieldDeleg
                 webServerAction.isEnabled = false
             }
 
-            if let barButtonItem = sender as? UIBarButtonItem {
+            if traitCollection.userInterfaceIdiom == .pad, let barButtonItem = sender as? UIBarButtonItem {
                 actionSheet.popoverPresentationController?.barButtonItem = barButtonItem
                 actionSheet.popoverPresentationController?.sourceView = collectionView
-            } else if let button = sender as? UIButton {
-                actionSheet.popoverPresentationController?.sourceView = collectionView
-                actionSheet.popoverPresentationController?.sourceRect = view.convert(libraryInfoContainerView.convert(button.frame, to: view), to: collectionView)
             }
 
             actionSheet.preferredContentSize = CGSize(width: 300, height: 150)


### PR DESCRIPTION
### What does this PR do
This pull request prevents the iOS alert from using the [.automatic](https://github.com/Provenance-Emu/Provenance/blame/28007c1/ProvenanceTV/TVAlertController.swift#L246) `modalPresentationStyle`.

### Screenshots (important for UI changes)
Before and after:
<img width="50%" alt="Screenshot 2022-12-17 at 19 42 36" src="https://user-images.githubusercontent.com/2276355/208264912-d31a5888-18c7-4b19-b105-e4c116a831da.png"><img width="50%" alt="Screenshot 2022-12-17 at 19 42 56" src="https://user-images.githubusercontent.com/2276355/208264915-bd2b80ed-4897-4538-8b28-c1fe0c582c54.png">

### Questions
I'm wondering if it's better to fix this in the `TVAlertController`? I don't know what is happening in Catalyst.