### PR TITLE
Fix tvOS Simulator build error

### DIFF
--- a/Cores/Mupen64Plus/Config.xcconfig
+++ b/Cores/Mupen64Plus/Config.xcconfig
@@ -38,3 +38,4 @@ EXCLUDED_SOURCE_FILE_NAMES[sdk=appletvos*] = $(inherited) 3DMath.cpp RSP_LoadMat
 // tvOS Simulator
 GCC_PREPROCESSOR_DEFINITIONS[sdk=appletvsimulator*] = $(inherited) OS_IOS GLESX USE_GLES=1 NEON=1 SDL_VIDEO_OPENGL_ES2=1
 OTHER_CFLAGS[sdk=appletvsimulator*] = $(inherited) -DOS_IOS
+EXCLUDED_SOURCE_FILE_NAMES[sdk=appletvsimulator*] = $(inherited) 3DMath.cpp RSP_LoadMatrix.cpp CRC_OPT.cpp

--- a/Cores/Mupen64Plus/Config.xcconfig
+++ b/Cores/Mupen64Plus/Config.xcconfig
@@ -31,10 +31,10 @@ OTHER_CFLAGS[sdk=iphonesimulator*] = $(inherited) -DOS_IOS
 
 // tvOS Device
 GCC_PREPROCESSOR_DEFINITIONS[sdk=appletvos*] = $(inherited) OS_IOS GLESX USE_GLES=1 NEON=1 SDL_VIDEO_OPENGL_ES2=1
-OTHER_CFLAGS[sdk=appletvos*] = $(inherited) -DOS_IOS -mfpu=neon  -D__VEC4_OPT -D__NEON_OPT
-EXCLUDED_SOURCE_FILE_NAMES[sdk=appletvos*] = $(inherited) 3DMath.cpp  RSP_LoadMatrix.cpp CRC_OPT.cpp
+OTHER_CFLAGS[sdk=appletvos*] = $(inherited) -DOS_IOS -mfpu=neon -D__VEC4_OPT -D__NEON_OPT
+EXCLUDED_SOURCE_FILE_NAMES[sdk=appletvos*] = $(inherited) 3DMath.cpp RSP_LoadMatrix.cpp CRC_OPT.cpp
 // gSPNeon.cpp
 
 // tvOS Simulator
 GCC_PREPROCESSOR_DEFINITIONS[sdk=appletvsimulator*] = $(inherited) OS_IOS GLESX USE_GLES=1 NEON=1 SDL_VIDEO_OPENGL_ES2=1
-OTHER_CFLAGS[sdk=appletvsimulator*] = $(inherited) -DOS_IOS 
+OTHER_CFLAGS[sdk=appletvsimulator*] = $(inherited) -DOS_IOS


### PR DESCRIPTION
### What does this PR do
This pull request fixes the `13 duplicate symbols for architecture arm64` tvOS build error in the Simulator.