### PR TITLE
PVPicoDrive 32X - Fix Sega 32X Aspect Ratio

### DIFF
--- a/Cores/PicoDrive/PicodriveGameCore.m
+++ b/Cores/PicoDrive/PicodriveGameCore.m
@@ -506,7 +506,8 @@ static void writeSaveFile(const char* path, int type)
 
 - (CGSize)aspectSize
 {
-    return CGSizeMake(320, 240);
+    float ratio =  32.0 / 35.0;
+    return CGSizeMake( ((320.0 / 224.0) * ratio), 1.0);
 }
 
 - (GLenum)pixelFormat


### PR DESCRIPTION
This properly sets the Aspect Ratio for the Sega 32X Core using PicoDrive in Pv.  Tested and confirmed with the 240P Monoscope pattern. This now displays a 1:1 matching Square.  Pv Integer mode now also scales accurately for the Genesis Core.

![pv_ar_examples_32x v01](https://user-images.githubusercontent.com/30782821/209000443-0d495991-556a-4a0d-812c-326cda254ea8.png)
