### PR TITLE
Update crt_filter_ps.metal - Metal version always uses Filtering for smoother edges and AA.

### DIFF
--- a/Provenance/Emulator/Shaders/Shaders/Metal/Filters/crt_filter_ps.metal
+++ b/Provenance/Emulator/Shaders/Shaders/Metal/Filters/crt_filter_ps.metal
@@ -128,7 +128,8 @@ float3 getShadowMaskRGB( constant CRT_Data& cbData, float2 uv )
 INLINE
 float3 sampleRGB( texture2d<float> EmulatedImage, sampler Sampler, constant CRT_Data& cbData, float2 uv, float2 warpedUV )
 {
-    float3 inputSample = ToLinear( EmulatedImage.sample(Sampler, UV_TO_INPUTCOORD( warpedUV, cbData )).rgb );
+    constexpr sampler SamplerF(address::clamp_to_zero, filter::linear);
+    float3 inputSample = ToLinear( EmulatedImage.sample(SamplerF, UV_TO_INPUTCOORD( warpedUV, cbData )).rgb );
     
     float3 scanlineMultiplier = float3( 1.0 );
 #if USE_SCANLINES


### PR DESCRIPTION
Adds in always-on Linear filtering for the MTL CRT Filter and fixed edge clamping behavior.
