### PR TITLE
Play: Renderer Updates

### DIFF
--- a/Cores/Play/PVPlayCore.xcodeproj/project.pbxproj
+++ b/Cores/Play/PVPlayCore.xcodeproj/project.pbxproj
@@ -41,6 +41,9 @@
 		9360C5A3294CB5E8000322B9 /* number_theory.c in Sources */ = {isa = PBXBuildFile; fileRef = 9360C57E294CB5E6000322B9 /* number_theory.c */; };
 		9360C5A4294CB5E8000322B9 /* memory_manager.c in Sources */ = {isa = PBXBuildFile; fileRef = 9360C57F294CB5E6000322B9 /* memory_manager.c */; };
 		9360C5A8294CB607000322B9 /* PVPlayCore+Cheats.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9360C5A6294CB607000322B9 /* PVPlayCore+Cheats.mm */; };
+		936FDBC02957F9D70073628A /* libMoltenVK_Play.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 936FDBBF2957F9D60073628A /* libMoltenVK_Play.dylib */; };
+		936FDBC12957F9D70073628A /* libMoltenVK_Play.dylib in Embed Libraries */ = {isa = PBXBuildFile; fileRef = 936FDBBF2957F9D60073628A /* libMoltenVK_Play.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		936FDBCA295808D20073628A /* libMoltenVK_Play.dylib in Resources */ = {isa = PBXBuildFile; fileRef = 936FDBBF2957F9D60073628A /* libMoltenVK_Play.dylib */; };
 		939B19432948B05F0024133A /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 939B19422948B05F0024133A /* libsqlite3.tbd */; };
 		939B19442948B0780024133A /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 939B19422948B05F0024133A /* libsqlite3.tbd */; };
 		939B194A29490A840024133A /* CGSH_MTLViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 939B194929490A820024133A /* CGSH_MTLViewController.swift */; };
@@ -465,6 +468,17 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		936FDBC22957F9D70073628A /* Embed Libraries */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				936FDBC12957F9D70073628A /* libMoltenVK_Play.dylib in Embed Libraries */,
+			);
+			name = "Embed Libraries";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B30178D1207C901D0051B93D /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -497,6 +511,8 @@
 		9360C57E294CB5E6000322B9 /* number_theory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = number_theory.c; sourceTree = "<group>"; };
 		9360C57F294CB5E6000322B9 /* memory_manager.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = memory_manager.c; sourceTree = "<group>"; };
 		9360C5A6294CB607000322B9 /* PVPlayCore+Cheats.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "PVPlayCore+Cheats.mm"; sourceTree = "<group>"; };
+		936FDBA72957F9080073628A /* libMoltenVK.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libMoltenVK.dylib; path = ../../MoltenVK/MoltenVK/dylib/iOS/libMoltenVK.dylib; sourceTree = "<group>"; };
+		936FDBBF2957F9D60073628A /* libMoltenVK_Play.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libMoltenVK_Play.dylib; path = lib/libMoltenVK_Play.dylib; sourceTree = "<group>"; };
 		939B190D2948A59C0024133A /* GSH_VulkanPlatformDefs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GSH_VulkanPlatformDefs.h; sourceTree = "<group>"; };
 		939B19422948B05F0024133A /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.0.sdk/usr/lib/libsqlite3.tbd; sourceTree = DEVELOPER_DIR; };
 		939B194929490A820024133A /* CGSH_MTLViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGSH_MTLViewController.swift; sourceTree = "<group>"; };
@@ -1765,6 +1781,7 @@
 				B3A6209329478A7F00ED28E3 /* CoreGraphics.framework in Frameworks */,
 				B35E6BF9207D00D00040709A /* AVFoundation.framework in Frameworks */,
 				B35E6BF5207CD2740040709A /* CoreAudioKit.framework in Frameworks */,
+				936FDBC02957F9D70073628A /* libMoltenVK_Play.dylib in Frameworks */,
 				B35E6BF6207CD2740040709A /* CoreAudio.framework in Frameworks */,
 				B3135BAB26E4CDC50047F338 /* QuartzCore.framework in Frameworks */,
 				B3A6209529478A9B00ED28E3 /* MetalKit.framework in Frameworks */,
@@ -4026,6 +4043,8 @@
 		B3C7621B20783242009950E4 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				936FDBBF2957F9D60073628A /* libMoltenVK_Play.dylib */,
+				936FDBA72957F9080073628A /* libMoltenVK.dylib */,
 				B34A60972947A7080070ED25 /* libsqlite3.tbd */,
 				939B19422948B05F0024133A /* libsqlite3.tbd */,
 				B3A6209429478A9B00ED28E3 /* MetalKit.framework */,
@@ -4125,6 +4144,7 @@
 				B3C7620C20783162009950E4 /* Frameworks */,
 				B3C7620D20783162009950E4 /* Headers */,
 				B3C7620E20783162009950E4 /* Resources */,
+				936FDBC22957F9D70073628A /* Embed Libraries */,
 			);
 			buildRules = (
 			);
@@ -4419,6 +4439,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				936FDBCA295808D20073628A /* libMoltenVK_Play.dylib in Resources */,
 				B33350262078619C0036A448 /* Core.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4441,7 +4462,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\ncp ${SRCROOT}/PVPlayCore/Core/GSH_VulkanPlatformDefs.h ${SRCROOT}/Play-/Source/gs/GSH_Vulkan/\n\n\n";
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\ncp ${SRCROOT}/PVPlayCore/Core/GSH_VulkanPlatformDefs.h ${SRCROOT}/Play-/Source/gs/GSH_Vulkan/\ncp ${SRCROOT}/PVPlayCore/Core/Loader.cpp ${SRCROOT}/Play-/deps/Framework/src/vulkan/Loader.cpp\n\ncp ${SRCROOT}/../../MoltenVK/MoltenVK/dylib/iOS/libMoltenVK.dylib ${SRCROOT}/lib/libMoltenVK_Play.dylib\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -4808,6 +4829,10 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/lib",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.provenance-emu.pvplay";
 				PRODUCT_NAME = PVPlay;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -5026,6 +5051,10 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/lib",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.provenance-emu.pvplay";
 				PRODUCT_NAME = PVPlay;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -5076,6 +5105,10 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/lib",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.provenance-emu.pvplay";
 				PRODUCT_NAME = PVPlay;

--- a/Cores/Play/PVPlayCore/Core/CGSH_Provenance_OGL.mm
+++ b/Cores/Play/PVPlayCore/Core/CGSH_Provenance_OGL.mm
@@ -9,7 +9,7 @@ CGSH_Provenance_OGL::CGSH_Provenance_OGL(
 	int width,
 	int height,
 	int res_factor
-) : CGSH_OpenGL(false),
+) : CGSH_OpenGL(true),
 	m_layer(layer),
 	m_width(width),
 	m_height(height),

--- a/Cores/Play/PVPlayCore/Core/Loader.cpp
+++ b/Cores/Play/PVPlayCore/Core/Loader.cpp
@@ -1,0 +1,71 @@
+#ifdef _WIN32
+#include <Windows.h>
+#include <tchar.h>
+#else
+#include <vector>
+#include <dlfcn.h>
+#endif
+#include <stdexcept>
+#include <cassert>
+#include "vulkan/Loader.h"
+#include "string_format.h"
+
+using namespace Framework::Vulkan;
+
+CLoader::CLoader()
+{
+	LoadLibrary();
+}
+
+void* CLoader::GetLibraryProcAddr(const char* procName)
+{
+#ifdef _WIN32
+	return nullptr;
+#else
+	return dlsym(m_vulkanDl, procName);
+#endif
+}
+
+void CLoader::LoadLibrary()
+{
+#ifdef _WIN32
+	assert(m_vulkanModule == NULL);
+
+	m_vulkanModule = ::LoadLibrary(_T("vulkan-1.dll"));
+	if(m_vulkanModule == NULL)
+	{
+		throw std::runtime_error("Failed to load Vulkan library.");
+	}
+
+	vkCreateInstance      = reinterpret_cast<PFN_vkCreateInstance>(GetProcAddress(m_vulkanModule, "vkCreateInstance"));
+	vkGetInstanceProcAddr = reinterpret_cast<PFN_vkGetInstanceProcAddr>(GetProcAddress(m_vulkanModule, "vkGetInstanceProcAddr"));
+#else
+	assert(m_vulkanDl == nullptr);
+	
+	std::vector<const char*> libPaths;
+#ifdef __APPLE__
+	libPaths.push_back("@executable_path/Frameworks/libMoltenVK_Play.dylib");
+#else
+	libPaths.push_back("libvulkan.so");
+	libPaths.push_back("libvulkan.so.1");
+#endif
+	
+	for(const auto& libPath : libPaths)
+	{
+		m_vulkanDl = dlopen(libPath, RTLD_NOW | RTLD_LOCAL);
+		if(m_vulkanDl)
+		{
+			break;
+		}
+		printf("Warning: Failed attempt to load Vulkan library from '%s': %s.\n", libPath, dlerror());
+	}
+
+	if(!m_vulkanDl)
+	{
+		throw std::runtime_error("Failed to find an appropriate Vulkan library to load.");
+	}
+	
+	vkCreateInstance      = reinterpret_cast<PFN_vkCreateInstance>(dlsym(m_vulkanDl, "vkCreateInstance"));
+	vkGetInstanceProcAddr = reinterpret_cast<PFN_vkGetInstanceProcAddr>(dlsym(m_vulkanDl, "vkGetInstanceProcAddr"));
+#endif
+}

--- a/Cores/Play/PVPlayCore/Core/PVPlayCore+Controls.mm
+++ b/Cores/Play/PVPlayCore/Core/PVPlayCore+Controls.mm
@@ -70,6 +70,145 @@ s8 joyx[4], joyy[4];
 }
 
 #pragma mark - Control
+-(void)setupControllers {
+    for (NSInteger player = 0; player < 4; player++)
+    {
+        GCController *controller = nil;
+        if (self.controller1 && player == 0)
+        {
+            controller = self.controller1;
+        }
+        else if (self.controller2 && player == 1)
+        {
+            controller = self.controller2;
+        }
+        else if (self.controller3 && player == 2)
+        {
+            controller = self.controller3;
+        }
+        else if (self.controller4 && player == 3)
+        {
+            controller = self.controller4;
+        }
+        if (controller.extendedGamepad != nil)
+        {
+            controller.extendedGamepad.buttonA.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
+                padHandler->SetButtonState(PS2::CControllerInfo::CROSS, pressed);
+            };
+            controller.extendedGamepad.buttonB.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
+                padHandler->SetButtonState(PS2::CControllerInfo::CIRCLE, pressed);
+            };
+            controller.extendedGamepad.buttonX.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
+                padHandler->SetButtonState(PS2::CControllerInfo::SQUARE, pressed);
+            };
+            controller.extendedGamepad.buttonY.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
+                padHandler->SetButtonState(PS2::CControllerInfo::TRIANGLE, pressed);
+            };
+            controller.extendedGamepad.leftShoulder.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
+                padHandler->SetButtonState(PS2::CControllerInfo::L1, pressed);
+            };
+            controller.extendedGamepad.rightShoulder.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
+                padHandler->SetButtonState(PS2::CControllerInfo::R1, pressed);
+            };
+            controller.extendedGamepad.leftTrigger.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
+                padHandler->SetButtonState(PS2::CControllerInfo::L2, pressed);
+            };
+            controller.extendedGamepad.rightTrigger.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
+                padHandler->SetButtonState(PS2::CControllerInfo::R2, pressed);
+            };
+            controller.extendedGamepad.dpad.up.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
+                padHandler->SetButtonState(PS2::CControllerInfo::DPAD_UP, pressed);
+            };
+            controller.extendedGamepad.dpad.left.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
+                padHandler->SetButtonState(PS2::CControllerInfo::DPAD_LEFT, pressed);
+            };
+            controller.extendedGamepad.dpad.right.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
+                padHandler->SetButtonState(PS2::CControllerInfo::DPAD_RIGHT, pressed);
+            };
+            controller.extendedGamepad.dpad.down.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
+                padHandler->SetButtonState(PS2::CControllerInfo::DPAD_DOWN, pressed);
+            };
+            controller.extendedGamepad.buttonHome.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
+                padHandler->SetButtonState(PS2::CControllerInfo::SELECT, pressed);
+            };
+            controller.extendedGamepad.buttonMenu.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
+                padHandler->SetButtonState(PS2::CControllerInfo::START, pressed);
+            };
+            controller.extendedGamepad.leftThumbstick.xAxis.valueChangedHandler = ^(GCControllerAxisInput* xAxis, float value) {
+                padHandler->SetAxisState(PS2::CControllerInfo::ANALOG_LEFT_X, value);
+            };
+            controller.extendedGamepad.leftThumbstick.yAxis.valueChangedHandler = ^(GCControllerAxisInput* yAxis, float value) {
+                padHandler->SetAxisState(PS2::CControllerInfo::ANALOG_LEFT_Y, -value);
+            };
+            controller.extendedGamepad.rightThumbstick.xAxis.valueChangedHandler = ^(GCControllerAxisInput* xAxis, float value) {
+                padHandler->SetAxisState(PS2::CControllerInfo::ANALOG_RIGHT_X, value);
+            };
+            controller.extendedGamepad.rightThumbstick.yAxis.valueChangedHandler = ^(GCControllerAxisInput* yAxis, float value) {
+                padHandler->SetAxisState(PS2::CControllerInfo::ANALOG_RIGHT_Y, -value);
+            };
+            controller.extendedGamepad.leftThumbstickButton.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
+                padHandler->SetButtonState(PS2::CControllerInfo::L3, pressed);
+            };
+            controller.extendedGamepad.rightThumbstickButton.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
+                padHandler->SetButtonState(PS2::CControllerInfo::R3, pressed);
+            };
+        }
+        else if (controller.gamepad != nil)
+        {
+            controller.gamepad.buttonA.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
+                padHandler->SetButtonState(PS2::CControllerInfo::CROSS, pressed);
+            };
+            controller.gamepad.buttonB.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
+                padHandler->SetButtonState(PS2::CControllerInfo::CIRCLE, pressed);
+            };
+            controller.gamepad.buttonX.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
+                padHandler->SetButtonState(PS2::CControllerInfo::SQUARE, pressed);
+            };
+            controller.gamepad.buttonY.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
+                padHandler->SetButtonState(PS2::CControllerInfo::TRIANGLE, pressed);
+            };
+            controller.gamepad.leftShoulder.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
+                padHandler->SetButtonState(PS2::CControllerInfo::L1, pressed);
+            };
+            controller.gamepad.rightShoulder.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
+                padHandler->SetButtonState(PS2::CControllerInfo::R1, pressed);
+            };
+            controller.gamepad.dpad.up.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
+                padHandler->SetButtonState(PS2::CControllerInfo::DPAD_UP, pressed);
+            };
+            controller.gamepad.dpad.left.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
+                padHandler->SetButtonState(PS2::CControllerInfo::DPAD_LEFT, pressed);
+            };
+            controller.gamepad.dpad.right.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
+                padHandler->SetButtonState(PS2::CControllerInfo::DPAD_RIGHT, pressed);
+            };
+            controller.gamepad.dpad.down.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
+                padHandler->SetButtonState(PS2::CControllerInfo::DPAD_DOWN, pressed);
+            };
+        }
+        else if (controller.microGamepad != nil)
+        {
+            controller.microGamepad.buttonA.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
+                padHandler->SetButtonState(PS2::CControllerInfo::CROSS, pressed);
+            };
+            controller.microGamepad.buttonX.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
+                padHandler->SetButtonState(PS2::CControllerInfo::SQUARE, pressed);
+            };
+            controller.microGamepad.dpad.up.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
+                padHandler->SetButtonState(PS2::CControllerInfo::DPAD_UP, pressed);
+            };
+            controller.microGamepad.dpad.left.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
+                padHandler->SetButtonState(PS2::CControllerInfo::DPAD_LEFT, pressed);
+            };
+            controller.microGamepad.dpad.right.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
+                padHandler->SetButtonState(PS2::CControllerInfo::DPAD_RIGHT, pressed);
+            };
+            controller.microGamepad.dpad.down.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
+                padHandler->SetButtonState(PS2::CControllerInfo::DPAD_DOWN, pressed);
+            };
+        }
+    }
+}
 
 - (void)pollControllers {
     for (NSInteger playerIndex = 0; playerIndex < 4; playerIndex++)

--- a/Cores/Play/PVPlayCore/Core/PVPlayCore+Video.mm
+++ b/Cores/Play/PVPlayCore/Core/PVPlayCore+Video.mm
@@ -54,7 +54,9 @@ void MakeCurrentThreadRealTime();
 }
 
 - (void)executeFrameSkippingFrame:(BOOL)skip {
+    // The Play! handles the loop (Set GS Handler constructor to false, will manually step)
     //dispatch_semaphore_signal(mupenWaitToBeginFrameSemaphore);
+    /*
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         MakeCurrentThreadRealTime();
@@ -69,6 +71,7 @@ void MakeCurrentThreadRealTime();
         if(self.gsPreference == PREFERENCE_VALUE_VIDEO_GS_HANDLER_OPENGL)
             gsHandler->ProcessSingleFrame();
     }
+    */
 }
 
 - (void)executeFrame {
@@ -78,7 +81,7 @@ void MakeCurrentThreadRealTime();
 # pragma mark - Properties
 
 - (CGSize)bufferSize {
-    return CGSizeMake(self.videoWidth * self.resFactor, self.videoHeight * self.resFactor);
+    return CGSizeMake(0,0);
 }
 
 - (CGRect)screenRect {

--- a/Cores/Play/PVPlayCore/Core/PVPlayCore.h
+++ b/Cores/Play/PVPlayCore/Core/PVPlayCore.h
@@ -41,7 +41,7 @@
 
 @property (nonatomic, assign) int8_t gsPreference;
 
--(void)pollControllers;
+-(void)setupControllers;
 -(void)executeFrameSkippingFrame:(BOOL)skip;
 
 @end

--- a/Cores/Play/cmake/xcode_absolute_path_to_relative.py
+++ b/Cores/Play/cmake/xcode_absolute_path_to_relative.py
@@ -17,6 +17,12 @@ VULKAN_DIR = PROVENANCE_DIR + '/MoltenVK'
 # Relative path to Core Lib Project Directory
 CORE_LIB_DIR = "../Play-"
 
+# Places built library binaries under dolphin-ios/dolphin-build
+BUILD_DIR = "../lib"
+
+LIBS_TO_RENAME = []
+#LIBS_TO_RENAME.append([' = fmt;', ' = fmtd;'])
+
 # Paths to convert to relative path in XCode
 SRCROOT_PATH_TO_FIND = CORE_DIR + '/'
 SRCROOT_PATH_TO_REPLACE_WITH = '../'
@@ -31,26 +37,29 @@ SDKROOT_PATH_TO_REPLACE_WITH = 'SDKROOT = iphoneos;'
 PROJECT_DIR_PATH_TO_FIND = r'projectDirPath = ".*";'
 PROJECT_DIR_PATH_TO_REPLACE_WITH = f'projectDirPath = "{CORE_LIB_DIR}";'
 SYMROOT_DIR_PATH_TO_FIND = r'SYMROOT = .*;'
-SYMROOT_DIR_PATH_TO_REPLACE_WITH = ''
+SYMROOT_DIR_PATH_TO_REPLACE_WITH = f'BUILD_DIR = {BUILD_DIR};'
 CONFIG_BUILD_DIR_PATH_TO_FIND = r'CONFIGURATION_BUILD_DIR = .*;'
 CONFIG_BUILD_DIR_PATH_TO_REPLACE_WITH = ''
 TARGET_TEMP_DIR_PATH_TO_FIND = r'TARGET_TEMP_DIR = .*;'
 TARGET_TEMP_DIR_PATH_TO_REPLACE_WITH = ''
+BUILD_CONFIG_TO_FIND = r'buildConfiguration = ".*"'
+BUILD_CONFIG_TO_REPLACE_WITH = 'buildConfiguration = "Release"'
 
 # Replacements will be processed in this order
 replacements = []
 replacements.append([SRCROOT_PATH_TO_FIND,SRCROOT_PATH_TO_REPLACE_WITH])
 replacements.append([CMAKE_PATH_TO_FIND,CMAKE_PATH_TO_REPLACE_WITH])
-replacements.append([MOLTEN_PATH_TO_FIND,MOLTEN_PATH_TO_REPLACE_WITH])
-replacements.append([VULKAN_PATH_TO_FIND,VULKAN_PATH_TO_REPLACE_WITH])
+#replacements.append([MOLTEN_PATH_TO_FIND,MOLTEN_PATH_TO_REPLACE_WITH])
+#replacements.append([VULKAN_PATH_TO_FIND,VULKAN_PATH_TO_REPLACE_WITH])
 replacements.append([SDKROOT_PATH_TO_FIND,SDKROOT_PATH_TO_REPLACE_WITH])
 replacements.append([PROJECT_DIR_PATH_TO_FIND,PROJECT_DIR_PATH_TO_REPLACE_WITH])
 replacements.append([SYMROOT_DIR_PATH_TO_FIND,SYMROOT_DIR_PATH_TO_REPLACE_WITH])
 replacements.append([TARGET_TEMP_DIR_PATH_TO_FIND,TARGET_TEMP_DIR_PATH_TO_REPLACE_WITH])
 replacements.append([CONFIG_BUILD_DIR_PATH_TO_FIND,CONFIG_BUILD_DIR_PATH_TO_REPLACE_WITH])
+#replacements.append([BUILD_CONFIG_TO_FIND,BUILD_CONFIG_TO_REPLACE_WITH])
 
 # Extensions of files to process
-extensions = ['.pbxproj']
+extensions = ['.pbxproj', '.xcscheme']
 print(f'Reading Directory: {DIRECTORY_TO_READ}')
 print(f'$(SRCROOT) to find/replace:', replacements)
 print(f'Extensions to find:', extensions)
@@ -59,6 +68,10 @@ print(f'Extensions to find:', extensions)
 def find_and_replace(content):
   has_match=False
   for (find_string, replace_string) in replacements:
+    if re.search(find_string, content):
+      content=re.sub(find_string, replace_string, content)
+      has_match=True
+  for (find_string, replace_string) in LIBS_TO_RENAME:
     if re.search(find_string, content):
       content=re.sub(find_string, replace_string, content)
       has_match=True

--- a/PVSupport/Sources/PVSupport/EmulatorCore/PVEmulatorCore.h
+++ b/PVSupport/Sources/PVSupport/EmulatorCore/PVEmulatorCore.h
@@ -99,7 +99,7 @@ typedef NS_ENUM(NSInteger, PVEmulatorCoreErrorCode) {
 @property (nonatomic, readonly) BOOL supportsRumble;
 
 @property (atomic, assign) BOOL shouldResyncTime;
-
+@property (nonatomic, assign) BOOL skipEmulationLoop;
 typedef NS_ENUM(NSInteger, GameSpeed) {
 	GameSpeedSlow = 0,
 	GameSpeedNormal,

--- a/PVSupport/Sources/PVSupport/EmulatorCore/PVEmulatorCore.m
+++ b/PVSupport/Sources/PVSupport/EmulatorCore/PVEmulatorCore.m
@@ -76,6 +76,7 @@ NSString *const PVEmulatorCoreErrorDomain = @"org.provenance-emu.EmulatorCore.Er
         _isFrontBufferReady      = NO;
         _gameSpeed               = GameSpeedNormal;
         _isDoubleBufferedCached = [self isDoubleBuffered];
+        _skipEmulationLoop       = NO;
 	}
 	
 	return self;
@@ -121,11 +122,15 @@ NSString *const PVEmulatorCoreErrorDomain = @"org.provenance-emu.EmulatorCore.Er
 			self.isRunning  = YES;
 			shouldStop = NO;
             self.gameSpeed = GameSpeedNormal;
-			MAKEWEAK(self);
-			[NSThread detachNewThreadWithBlock:^{
-				MAKESTRONG(self);
-				[strongself emulationLoopThread];
-			}];
+            if (!_skipEmulationLoop) {
+                MAKEWEAK(self);
+                [NSThread detachNewThreadWithBlock:^{
+                    MAKESTRONG(self);
+                    [strongself emulationLoopThread];
+                }];
+            } else {
+                [self setIsFrontBufferReady:YES];
+            }
 		}
 	}
 }

--- a/Provenance.xcodeproj/project.pbxproj
+++ b/Provenance.xcodeproj/project.pbxproj
@@ -160,6 +160,8 @@
 		42BC83A917E6775E00E9A607 /* PVGameLibrarySectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42BC83A817E6775E00E9A607 /* PVGameLibrarySectionHeaderView.swift */; };
 		5504F77A295396A900D838B1 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5504F779295396A900D838B1 /* LaunchScreen.storyboard */; };
 		558B33FA29539AEF00709654 /* TVLaunchImage2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 558B33F929539AEE00709654 /* TVLaunchImage2x.png */; };
+		936FDBEB295855670073628A /* libMoltenVK_Play.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 936FDBEA295855670073628A /* libMoltenVK_Play.dylib */; };
+		936FDBEC295855A50073628A /* libMoltenVK_Play.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 936FDBEA295855670073628A /* libMoltenVK_Play.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		B302F31421713AFD000322B9 /* CenterFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B33468D120AB347300092CA6 /* CenterFlowLayout.swift */; };
 		B302F31521713B17000322B9 /* PillPageControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D534EB20B001D700A83D4E /* PillPageControl.swift */; };
 		B3054371272026E800F5257D /* PVPSPControllerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3054370272026E800F5257D /* PVPSPControllerViewController.swift */; };
@@ -870,6 +872,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				936FDBEC295855A50073628A /* libMoltenVK_Play.dylib in Embed Frameworks */,
 				B3FAC92A292B4505005E8B11 /* PVFCEU.framework in Embed Frameworks */,
 				B37CE667293F23B60010B746 /* PVDosBox.framework in Embed Frameworks */,
 				B34A60812947951E0070ED25 /* libMoltenVK.dylib in Embed Frameworks */,
@@ -1089,6 +1092,7 @@
 		5504F779295396A900D838B1 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		5525388625574D48004B00B6 /* PVTGBDual.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = PVTGBDual.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		558B33F929539AEE00709654 /* TVLaunchImage2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = TVLaunchImage2x.png; sourceTree = "<group>"; };
+		936FDBEA295855670073628A /* libMoltenVK_Play.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libMoltenVK_Play.dylib; path = Cores/Play/lib/libMoltenVK_Play.dylib; sourceTree = "<group>"; };
 		B30172C9274A34FA00B0E695 /* PVDuckStation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PVDuckStation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B302BFA320825ADC0029CEDB /* PVMupen64PlusVideoGlideN64.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PVMupen64PlusVideoGlideN64.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B305436D2720237400F5257D /* PVPPSSPP.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PVPPSSPP.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1694,6 +1698,7 @@
 				B3FAC94F292B45A6005E8B11 /* PVRSPCXD4.framework in Frameworks */,
 				1A2B0E8E1AD18961005FB77C /* libc++.dylib in Frameworks */,
 				B3FAC94D292B45A3005E8B11 /* PVPotator.framework in Frameworks */,
+				936FDBEB295855670073628A /* libMoltenVK_Play.dylib in Frameworks */,
 				1AECF4A91966D76100F8704E /* libsqlite3.dylib in Frameworks */,
 				B3AEDE22293F34370050BDB6 /* PVCrabEmu.framework in Frameworks */,
 				1AD4BC6F1BFD38D6007D6C7C /* AVFoundation.framework in Frameworks */,
@@ -2027,6 +2032,7 @@
 		1A3D409617B2DCE4004DFFFC /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				936FDBEA295855670073628A /* libMoltenVK_Play.dylib */,
 				B3AB13C229497E08005DCCDE /* libMoltenVK.dylib */,
 				B3AB13C029497DF5005DCCDE /* libMoltenVK.dylib */,
 				B34A607D294794B60070ED25 /* MoltenVK.xcframework */,
@@ -5153,6 +5159,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/MoltenVK/MoltenVK/dylib/iOS",
 					"$(PROJECT_DIR)/MoltenVK/MoltenVK/dylib/macOS",
+					"$(PROJECT_DIR)/Cores/Play/lib",
 				);
 				MTL_FAST_MATH = YES;
 				OTHER_CFLAGS = "-Wno-deprecated-declarations";
@@ -5211,6 +5218,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/MoltenVK/MoltenVK/dylib/iOS",
 					"$(PROJECT_DIR)/MoltenVK/MoltenVK/dylib/macOS",
+					"$(PROJECT_DIR)/Cores/Play/lib",
 				);
 				MTL_FAST_MATH = YES;
 				OTHER_CFLAGS = (
@@ -6986,6 +6994,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/MoltenVK/MoltenVK/dylib/iOS",
 					"$(PROJECT_DIR)/MoltenVK/MoltenVK/dylib/macOS",
+					"$(PROJECT_DIR)/Cores/Play/lib",
 				);
 				MTL_FAST_MATH = YES;
 				OTHER_CFLAGS = (

--- a/Provenance/Emulator/PVGLViewController/PVGLViewController.m
+++ b/Provenance/Emulator/PVGLViewController/PVGLViewController.m
@@ -687,6 +687,8 @@ PV_OBJC_DIRECT_MEMBERS
 
 - (void)glkView:(GLKView *)view drawInRect:(CGRect)rect
 {
+    if (self.emulatorCore.skipEmulationLoop)
+        return;
     __block CGRect screenRect;
     __block const void* videoBuffer;
     __block GLenum videoBufferPixelFormat;

--- a/Provenance/Emulator/PVGLViewController/PVMetalViewController.m
+++ b/Provenance/Emulator/PVGLViewController/PVMetalViewController.m
@@ -710,7 +710,8 @@ PV_OBJC_DIRECT_MEMBERS
  @discussion Called on the delegate when it is asked to render into the view
  */
 - (void)drawInMTKView:(nonnull MTKView *)view {
-
+    if (self.emulatorCore.skipEmulationLoop)
+        return;
     MAKEWEAK(self);
 
     void (^renderBlock)(void) = ^()


### PR DESCRIPTION
### What does this PR do
   Updates Play Core to run on its own loop. This has:
- Adds skipEmulationLoop option on EmulatorCore, PVGL and PVMetal updated to not draw when emulation loop is turned off (prevents competing loops from writing to same frame buffer)
- Adds input handler to get input notice and handle the input without polling on the Play Controller
- Updates the rendering surfaces
- Adds script to copy lib molten as Core/Play/lib/libMoltenVK_Play to embed such that Play is able to maintain its own versioning of Molten as the support is expanded. 
   Overall the emulation runs better with these changes, with less sound lags. It's been great playing this =] 
  
   Merry Christmas and Happy Holidays, wishing everyone a holidays filled with happiness.

### Where should the reviewer start

### How should this be manually tested

### Any background context you want to provide

### What are the relevant tickets

### Screenshots (important for UI changes)

### Questions
