### PR TITLE
PPSSPP: Feature Implementation - Cmake Script, MemInit, Screen Resizing ..etc.

### DIFF
--- a/Cores/PPSSPP/BuildFlags.xcconfig
+++ b/Cores/PPSSPP/BuildFlags.xcconfig
@@ -17,4 +17,4 @@
 //// tv OS
 //OTHER_CFLAGS[sdk=appletvos*] = $(inherited) -DDRC_SH2 -D_USE_CZ80
 //OTHER_CFLAGS[sdk=appletvsimulator*] = $(inherited) -D_USE_CZ80
-OTHER_CFLAGS = $(inherited) -DXXH_VECTOR=XXH_SCALAR
+OTHER_CFLAGS = $(inherited) -DXXH_VECTOR=XXH_SCALAR -DMASKED_PSP_MEMORY=TRUE

--- a/Cores/PPSSPP/PVPPSSPP.xcodeproj/project.pbxproj
+++ b/Cores/PPSSPP/PVPPSSPP.xcodeproj/project.pbxproj
@@ -24,13 +24,14 @@
 		93928447295DFFA900F2AD12 /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93928433295DFFA900F2AD12 /* CoreMedia.framework */; };
 		939B19432948B05F0024133A /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 939B19422948B05F0024133A /* libsqlite3.tbd */; };
 		93AEC060295E7FEB00F9381C /* GLKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93AEC04C295E7FEB00F9381C /* GLKit.framework */; platformFilters = (ios, macos, tvos, ); };
+		93C33C38295F84EF008DFADD /* MemArenaDarwin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93C33C24295F84EF008DFADD /* MemArenaDarwin.cpp */; };
 		93E74163295B344F0028EB94 /* libarmips.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 93E740EE295B2FD20028EB94 /* libarmips.a */; platformFilters = (ios, maccatalyst, ); };
 		93E74164295B344F0028EB94 /* libcityhash.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 93E740F0295B2FD20028EB94 /* libcityhash.a */; platformFilters = (ios, maccatalyst, ); };
 		93E74165295B344F0028EB94 /* libCommon.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 93E740DC295B2FD20028EB94 /* libCommon.a */; platformFilters = (ios, maccatalyst, ); };
 		93E74166295B344F0028EB94 /* libCore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 93E740DE295B2FD20028EB94 /* libCore.a */; platformFilters = (ios, maccatalyst, ); };
 		93E74167295B344F0028EB94 /* libgason.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 93E740F8295B2FD20028EB94 /* libgason.a */; platformFilters = (ios, maccatalyst, ); };
 		93E74168295B344F0028EB94 /* libGenericCodeGen.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 93E740E0295B2FD20028EB94 /* libGenericCodeGen.a */; platformFilters = (ios, maccatalyst, ); };
-		93E74169295B344F0028EB94 /* libglslang.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 93E740FA295B2FD20028EB94 /* libglslang.a */; platformFilters = (ios, maccatalyst, ); };
+		93E74169295B344F0028EB94 /* libglslang-ppsspp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 93E740FA295B2FD20028EB94 /* libglslang-ppsspp.a */; platformFilters = (ios, maccatalyst, ); };
 		93E7416A295B344F0028EB94 /* libHLSL.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 93E740E2295B2FD20028EB94 /* libHLSL.a */; platformFilters = (ios, maccatalyst, ); };
 		93E7416B295B344F0028EB94 /* libkirk.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 93E740FC295B2FD20028EB94 /* libkirk.a */; platformFilters = (ios, maccatalyst, ); };
 		93E7416C295B344F0028EB94 /* liblibzip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 93E740FE295B2FD20028EB94 /* liblibzip.a */; platformFilters = (ios, maccatalyst, ); };
@@ -51,14 +52,14 @@
 		93E7417B295B344F0028EB94 /* libudis86.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 93E7411C295B2FD20028EB94 /* libudis86.a */; platformFilters = (ios, maccatalyst, ); };
 		93E7417C295B344F0028EB94 /* libvma.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 93E7411E295B2FD20028EB94 /* libvma.a */; platformFilters = (ios, maccatalyst, ); };
 		93E7417D295B344F0028EB94 /* libxbrz.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 93E74120295B2FD20028EB94 /* libxbrz.a */; platformFilters = (ios, maccatalyst, ); };
-		93E7417E295B344F0028EB94 /* libxxhash.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 93E74122295B2FD20028EB94 /* libxxhash.a */; platformFilters = (ios, maccatalyst, ); };
+		93E7417E295B344F0028EB94 /* libxxhash-ppsspp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 93E74122295B2FD20028EB94 /* libxxhash-ppsspp.a */; platformFilters = (ios, maccatalyst, ); };
 		93E74186295B35080028EB94 /* libavdevice.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 93E74180295B35060028EB94 /* libavdevice.a */; };
 		93E74187295B35080028EB94 /* libavutil.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 93E74181295B35060028EB94 /* libavutil.a */; };
 		93E74188295B35080028EB94 /* libswresample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 93E74182295B35070028EB94 /* libswresample.a */; };
 		93E74189295B35080028EB94 /* libswscale.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 93E74183295B35070028EB94 /* libswscale.a */; };
 		93E7418A295B35080028EB94 /* libavcodec.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 93E74184295B35070028EB94 /* libavcodec.a */; };
 		93E7418B295B35080028EB94 /* libavformat.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 93E74185295B35070028EB94 /* libavformat.a */; };
-		93E74191295B37970028EB94 /* libzstd.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 93E74102295B2FD20028EB94 /* libzstd.a */; platformFilters = (ios, maccatalyst, ); };
+		93E74191295B37970028EB94 /* libzstd-ppsspp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 93E74102295B2FD20028EB94 /* libzstd-ppsspp.a */; platformFilters = (ios, maccatalyst, ); };
 		93E741E8295B67C70028EB94 /* PVPPSSPPCore+Cheats.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9360C5A6294CB607000322B9 /* PVPPSSPPCore+Cheats.mm */; };
 		93E741E9295B67C70028EB94 /* PVPPSSPPCore+Controls.mm in Sources */ = {isa = PBXBuildFile; fileRef = B3447E97218B809300557ACE /* PVPPSSPPCore+Controls.mm */; };
 		93E741EA295B67C70028EB94 /* PPSSPPVulkanViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E74126295B31460028EB94 /* PPSSPPVulkanViewController.swift */; };
@@ -606,6 +607,7 @@
 		93928433295DFFA900F2AD12 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/System/Library/Frameworks/CoreMedia.framework; sourceTree = DEVELOPER_DIR; };
 		939B19422948B05F0024133A /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.0.sdk/usr/lib/libsqlite3.tbd; sourceTree = DEVELOPER_DIR; };
 		93AEC04C295E7FEB00F9381C /* GLKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLKit.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS16.1.sdk/System/Library/Frameworks/GLKit.framework; sourceTree = DEVELOPER_DIR; };
+		93C33C24295F84EF008DFADD /* MemArenaDarwin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MemArenaDarwin.cpp; sourceTree = "<group>"; };
 		93E74125295B31460028EB94 /* PPSSPPOGLViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PPSSPPOGLViewController.swift; sourceTree = "<group>"; };
 		93E74126295B31460028EB94 /* PPSSPPVulkanViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PPSSPPVulkanViewController.swift; sourceTree = "<group>"; };
 		93E74180295B35060028EB94 /* libavdevice.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libavdevice.a; path = ppsspp/ffmpeg/ios/universal/lib/libavdevice.a; sourceTree = "<group>"; };
@@ -699,7 +701,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				93E74191295B37970028EB94 /* libzstd.a in Frameworks */,
+				93E74191295B37970028EB94 /* libzstd-ppsspp.a in Frameworks */,
 				93E7416C295B344F0028EB94 /* liblibzip.a in Frameworks */,
 				93E74186295B35080028EB94 /* libavdevice.a in Frameworks */,
 				93E74187295B35080028EB94 /* libavutil.a in Frameworks */,
@@ -713,7 +715,7 @@
 				93E74166295B344F0028EB94 /* libCore.a in Frameworks */,
 				93E74167295B344F0028EB94 /* libgason.a in Frameworks */,
 				93E74168295B344F0028EB94 /* libGenericCodeGen.a in Frameworks */,
-				93E74169295B344F0028EB94 /* libglslang.a in Frameworks */,
+				93E74169295B344F0028EB94 /* libglslang-ppsspp.a in Frameworks */,
 				93E7416A295B344F0028EB94 /* libHLSL.a in Frameworks */,
 				93E7416B295B344F0028EB94 /* libkirk.a in Frameworks */,
 				93E7416D295B344F0028EB94 /* libMachineIndependent.a in Frameworks */,
@@ -733,7 +735,7 @@
 				93E7417B295B344F0028EB94 /* libudis86.a in Frameworks */,
 				93E7417C295B344F0028EB94 /* libvma.a in Frameworks */,
 				93E7417D295B344F0028EB94 /* libxbrz.a in Frameworks */,
-				93E7417E295B344F0028EB94 /* libxxhash.a in Frameworks */,
+				93E7417E295B344F0028EB94 /* libxxhash-ppsspp.a in Frameworks */,
 				939B19432948B05F0024133A /* libsqlite3.tbd in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -759,11 +761,11 @@
 				93E740F4295B2FD20028EB94 /* fullbench */,
 				93E740F6295B2FD20028EB94 /* fuzzer */,
 				93E740F8295B2FD20028EB94 /* libgason.a */,
-				93E740FA295B2FD20028EB94 /* libglslang.a */,
+				93E740FA295B2FD20028EB94 /* libglslang-ppsspp.a */,
 				93E740FC295B2FD20028EB94 /* libkirk.a */,
 				93E740FE295B2FD20028EB94 /* liblibzip.a */,
 				93E74100295B2FD20028EB94 /* libzstd.dylib */,
-				93E74102295B2FD20028EB94 /* libzstd.a */,
+				93E74102295B2FD20028EB94 /* libzstd-ppsspp.a */,
 				93E74104295B2FD20028EB94 /* libminiupnpc.a */,
 				93E74106295B2FD20028EB94 /* libnative.a */,
 				93E74108295B2FD20028EB94 /* paramgrill */,
@@ -779,7 +781,7 @@
 				93E7411C295B2FD20028EB94 /* libudis86.a */,
 				93E7411E295B2FD20028EB94 /* libvma.a */,
 				93E74120295B2FD20028EB94 /* libxbrz.a */,
-				93E74122295B2FD20028EB94 /* libxxhash.a */,
+				93E74122295B2FD20028EB94 /* libxxhash-ppsspp.a */,
 				93E74124295B2FD20028EB94 /* zstreamtest */,
 			);
 			name = Products;
@@ -788,6 +790,7 @@
 		B3447EB5218BCE2000557ACE /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				93C33C24295F84EF008DFADD /* MemArenaDarwin.cpp */,
 				93E7427A295C53890028EB94 /* OGLGraphicsContext.h */,
 				93E7427C295C55C80028EB94 /* VulkanGraphicsContext.h */,
 				93E74125295B31460028EB94 /* PPSSPPOGLViewController.swift */,
@@ -1136,10 +1139,10 @@
 			remoteRef = 93E740F7295B2FD20028EB94 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		93E740FA295B2FD20028EB94 /* libglslang.a */ = {
+		93E740FA295B2FD20028EB94 /* libglslang-ppsspp.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
-			path = libglslang.a;
+			path = "libglslang-ppsspp.a";
 			remoteRef = 93E740F9295B2FD20028EB94 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
@@ -1165,10 +1168,10 @@
 			remoteRef = 93E740FF295B2FD20028EB94 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		93E74102295B2FD20028EB94 /* libzstd.a */ = {
+		93E74102295B2FD20028EB94 /* libzstd-ppsspp.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
-			path = libzstd.a;
+			path = "libzstd-ppsspp.a";
 			remoteRef = 93E74101295B2FD20028EB94 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
@@ -1278,10 +1281,10 @@
 			remoteRef = 93E7411F295B2FD20028EB94 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		93E74122295B2FD20028EB94 /* libxxhash.a */ = {
+		93E74122295B2FD20028EB94 /* libxxhash-ppsspp.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
-			path = libxxhash.a;
+			path = "libxxhash-ppsspp.a";
 			remoteRef = 93E74121295B2FD20028EB94 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
@@ -1344,6 +1347,7 @@
 				93E741EE295B67C70028EB94 /* PVPPSSPPCore+Saves.mm in Sources */,
 				93E741F0295B67C70028EB94 /* PVPPSSPP.mm in Sources */,
 				93E741F1295B67C70028EB94 /* PVPPSSPPCore.mm in Sources */,
+				93C33C38295F84EF008DFADD /* MemArenaDarwin.cpp in Sources */,
 				93E741F2295B67C70028EB94 /* PVPPSSPPCore+Audio.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Cores/PPSSPP/PVPPSSPPCore/Core/MemArenaDarwin.cpp
+++ b/Cores/PPSSPP/PVPPSSPPCore/Core/MemArenaDarwin.cpp
@@ -1,0 +1,103 @@
+// Copyright (C) 2003 Dolphin Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official SVN repository and contact information can be found at
+// http://code.google.com/p/dolphin-emu/
+
+#include "ppsspp_config.h"
+#include <cstdint>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <cerrno>
+#include <cstring>
+
+#include <mach/mach.h>
+#include <mach/vm_map.h>
+
+#include "Common/Log.h"
+#include "Common/File/FileUtil.h"
+#include "Common/MemoryUtil.h"
+#include "Common/MemArena.h"
+
+size_t MemArena::roundup(size_t x) {
+    return x;
+}
+
+bool MemArena::GrabMemSpace(size_t size) {
+    vm_size = size;
+    kern_return_t retval = vm_allocate(mach_task_self(), &vm_mem, size, VM_FLAGS_ANYWHERE);
+    if (retval != KERN_SUCCESS) {
+        ERROR_LOG(MEMMAP, "Failed to grab a block of virtual memory");
+        return false;
+    } else {
+        INFO_LOG(MEMMAP, "Successfully allocated %d bytes at %p", (int)size, (void *)vm_mem);
+        return true;
+    }
+}
+
+void MemArena::ReleaseSpace() {
+    vm_deallocate(mach_task_self(), vm_mem, vm_size);
+    vm_size = 0;
+    vm_mem = 0;
+}
+
+void *MemArena::CreateView(s64 offset, size_t size, void *base) {
+    mach_port_t self = mach_task_self();
+    vm_address_t target = (vm_address_t)base;
+    uint64_t mask = 0;
+    bool anywhere = false;
+    vm_address_t source = vm_mem + offset;
+    vm_prot_t cur_protection = 0;
+    vm_prot_t max_protection = 0;
+    kern_return_t retval =
+        vm_remap(self, &target, size, mask, anywhere,
+                 self, source, false,
+                 &cur_protection, &max_protection, VM_INHERIT_DEFAULT);
+    if (retval != KERN_SUCCESS) {
+        // 1 == KERN_INVALID_ADDRESS
+        // 3 == KERN_NO_SPACE (race?)
+        // 4 == KERN_INVALID_ARGUMENT
+        ERROR_LOG(MEMMAP, "vm_remap failed (%d) - could not remap from %llx (offset %llx) of size %llx to %p",
+                  (int)retval, (uint64_t)source, (uint64_t)offset, (uint64_t)size, base);
+        return nullptr;
+    }
+    return (void *)target;
+}
+
+void MemArena::ReleaseView(void* view, size_t size) {
+    vm_address_t addr = (vm_address_t)view;
+    vm_deallocate(mach_task_self(), addr, size);
+}
+
+bool MemArena::NeedsProbing() {
+    return false;
+}
+
+u8* MemArena::Find4GBBase() {
+    size_t size;
+#if PPSSPP_ARCH(64BIT)
+    size = 0xE1000000;
+#else
+    size = 0x10000000;
+#endif
+    vm_address_t addr = 0;
+    kern_return_t retval;
+    while (retval != KERN_SUCCESS) {
+        retval = vm_allocate(mach_task_self(), &addr, size, VM_FLAGS_ANYWHERE);
+        // Don't need the memory now, was just probing.
+    }
+    vm_deallocate(mach_task_self(), addr, size);
+    return (u8 *)addr;
+}

--- a/Cores/PPSSPP/PVPPSSPPCore/Core/PPSSPPOGLViewController.swift
+++ b/Cores/PPSSPP/PVPPSSPPCore/Core/PPSSPPOGLViewController.swift
@@ -42,8 +42,8 @@ import os
 	@objc public override func viewDidLayoutSubviews() {
 		if core != nil {
 			NSLog("View Size Changed\n");
-			core.refreshScreenSize();
-		}
+            core.refreshScreenSize();
+        }
 	}
 
 }

--- a/Cores/PPSSPP/PVPPSSPPCore/Core/PVPPSSPPCore.h
+++ b/Cores/PPSSPP/PVPPSSPPCore/Core/PVPPSSPPCore.h
@@ -14,6 +14,7 @@
 #import <Metal/Metal.h>
 #import <MetalKit/MetalKit.h>
 
+#define MASKED_PSP_MEMORY 1
 #define GET_CURRENT_AND_RETURN(...) __strong __typeof__(_current) current = _current; if(current == nil) return __VA_ARGS__;
 #define GET_CURRENT_OR_RETURN(...)  __strong __typeof__(_current) current = _current; if(current == nil) return __VA_ARGS__;
 
@@ -35,6 +36,7 @@
 	int8_t tfOption;
 	int8_t tutypeOption;
 	int8_t msaa;
+    BOOL stretchOption;
 	BOOL fastMemory;
 	float sampleRate;
 	BOOL isNTSC;
@@ -57,10 +59,10 @@
 @property (nonatomic, assign) int8_t tuOption;
 @property (nonatomic, assign) int8_t tutypeOption;
 @property (nonatomic, assign) int8_t tfOption;
+@property (nonatomic, assign) bool stretchOption;
 @property (nonatomic, assign) int8_t msaa;
 @property (nonatomic, assign) bool fastMemory;
 @property (nonatomic, assign) bool isPaused;
-@property (nonatomic, assign) bool isStopping;
 - (void) runVM;
 - (void) stopVM:(bool)deinitViews;
 - (void) setupVideo;

--- a/Cores/PPSSPP/PVPPSSPPCore/Core/PVPPSSPPCore.swift
+++ b/Cores/PPSSPP/PVPPSSPPCore/Core/PVPPSSPPCore.swift
@@ -120,13 +120,22 @@ extension PVPPSSPPCore: CoreOptional {
 		let coreOptions: [CoreOption] = [
 			resolutionOption, gsOption, textureAnisotropicOption,
 			textureUpscaleTypeOption, textureUpscaleOption, textureFilterOption,
-			msaaOption, fastMemoryOption, cpuOption]
+			msaaOption, fastMemoryOption, cpuOption,
+            stretchDisplayOption]
 		let coreGroup:CoreOption = .group(.init(title: "PPSSPP! Core",
 												description: "Global options for PPSSPP!"),
 										  subOptions: coreOptions)
 		options.append(contentsOf: [coreGroup])
 		return options
 	}
+
+    static var stretchDisplayOption: CoreOption = {
+        .bool(.init(
+            title: "Stretch Display Size",
+            description: nil,
+            requiresRestart: true),
+        defaultValue: false)
+    }()
 }
 
 @objc public extension PVPPSSPPCore {
@@ -157,6 +166,9 @@ extension PVPPSSPPCore: CoreOptional {
 	@objc var fastMemoryOption: Bool{
 		PVPPSSPPCore.valueForOption(PVPPSSPPCore.fastMemoryOption).asBool
 	}
+    @objc var stretch: Bool{
+        PVPPSSPPCore.valueForOption(PVPPSSPPCore.stretchDisplayOption).asBool
+    }
 	func parseOptions() {
 		self.gsPreference = NSNumber(value: gs).int8Value
 		self.resFactor = NSNumber(value: resolution).int8Value
@@ -167,6 +179,7 @@ extension PVPPSSPPCore: CoreOptional {
 		self.tfOption = NSNumber(value:tf).int8Value
 		self.msaa = NSNumber(value: msaaOption).int8Value
 		self.fastMemory = fastMemoryOption
+        self.stretchOption = stretch
 	}
 }
 

--- a/Cores/PPSSPP/cmake/PPSSPP.xcodeproj/project.pbxproj
+++ b/Cores/PPSSPP/cmake/PPSSPP.xcodeproj/project.pbxproj
@@ -515,7 +515,6 @@
 		627D9FD4F4A14EF2A7CB8FF2 /* ArmRegCacheFPU.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1D18E74292D449939B2A076E /* ArmRegCacheFPU.cpp */; };
 		628639DEAB9D414B9134419F /* PrxDecrypter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 17B162D9D03D45C8AEFFDA7D /* PrxDecrypter.cpp */; };
 		62E4E9E4748F44E68248A03C /* Expression.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5AAEA62938C3493385EEF6F1 /* Expression.cpp */; };
-		63630028312D4863BB41CC54 /* MemArenaAndroid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 239A76C81EBD4BAEBB9D4238 /* MemArenaAndroid.cpp */; };
 		64409A7503DE457499825348 /* sceKernelMsgPipe.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 15AF479E948F4CBAA87DE0A8 /* sceKernelMsgPipe.cpp */; };
 		6445F40A4F9844FD84763AC6 /* PSPNpSigninDialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C6F3C4023A14509ADD32AF3 /* PSPNpSigninDialog.cpp */; };
 		649C97419A20493396DD9DE9 /* zstd_decompress.c in Sources */ = {isa = PBXBuildFile; fileRef = 88B4FFE0F1A1487CB092A8D7 /* zstd_decompress.c */; };
@@ -841,18 +840,15 @@
 		C627252BF20946F08FD410F8 /* draw_text.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F2D17C2195A2429EB3D62FB1 /* draw_text.cpp */; };
 		C62C0E6AC50E40AA9D9037FF /* datagen.c in Sources */ = {isa = PBXBuildFile; fileRef = 08C9087026484477A05FFA7A /* datagen.c */; };
 		C6309336EE424B5F956AA973 /* WebServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 32CAA30E92564CC5AC67C6BF /* WebServer.cpp */; };
-		C67CFEC8C8E647F08CB7981D /* MemArenaWin32.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A6369C089693421C816335C5 /* MemArenaWin32.cpp */; };
 		C6BE8FE29FD64EF6AC92BDE1 /* upnpcommands.c in Sources */ = {isa = PBXBuildFile; fileRef = E7CCC13F96CD4CE8993AEC02 /* upnpcommands.c */; };
 		C7569E6B770245368277CC56 /* xxhash.c in Sources */ = {isa = PBXBuildFile; fileRef = 8B0F629ACFCC4C688BE14DE1 /* xxhash.c */; };
 		C78842DCE4884A8BB470D1BD /* zstd_compress_literals.c in Sources */ = {isa = PBXBuildFile; fileRef = EBC69CA2D642482C96466655 /* zstd_compress_literals.c */; };
 		C7BF53B53C7A40AF9CB1B15A /* PSPGamedataInstallDialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5C57319F9A2741308BBA791C /* PSPGamedataInstallDialog.cpp */; };
 		C82F3BDCE9874C2DAFDBED8F /* sceUsb.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93A10FE9730B4DF3808C0E8B /* sceUsb.cpp */; };
 		C844BE3FDE8B4451977AA745 /* CArmInstruction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56C8EF62DD11446AA9E359CF /* CArmInstruction.cpp */; };
-		C899623F0A704032B729B7B7 /* MemArenaPosix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D7ABC5C4E039471495084DF8 /* MemArenaPosix.cpp */; };
 		C8CCF50AD484404994F817E9 /* pngrtran.c in Sources */ = {isa = PBXBuildFile; fileRef = ECDEB406B0D048B2BB00426E /* pngrtran.c */; };
 		C8CEBFA2AABB4C979A259F7A /* Pp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 909DADF21C5C41D8BAF6EBDB /* Pp.cpp */; };
 		C910DF7D329E49E693F3DA86 /* sceDisplay.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D8D02349D3A04B8B9D694D3F /* sceDisplay.cpp */; };
-		C9218C4D4FF64693B0A705A3 /* MemArenaDarwin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 523202359A0440E1A829906D /* MemArenaDarwin.cpp */; };
 		C9A1B5D5BD574E0AA3239644 /* proAdhocServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 70F3EBA247CD4B05B3F724E9 /* proAdhocServer.cpp */; };
 		C9B4085A8D9F401BA0059F6F /* TiltEventProcessor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5E3CA057BA094CE9B57640D2 /* TiltEventProcessor.cpp */; };
 		CA40D4324FED4416B16D4E38 /* IRCompLoadStore.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DCB6CAA3408E4BECB67CDA35 /* IRCompLoadStore.cpp */; };
@@ -9052,10 +9048,6 @@
 				8F1C07C27B084F848635DB9E /* matrix4x4.cpp in Sources */,
 				0C9705AC9BC84FB2B385C251 /* vec3.cpp in Sources */,
 				7F955AAC51B84DCDA17F68F8 /* math_util.cpp in Sources */,
-				63630028312D4863BB41CC54 /* MemArenaAndroid.cpp in Sources */,
-				C9218C4D4FF64693B0A705A3 /* MemArenaDarwin.cpp in Sources */,
-				C899623F0A704032B729B7B7 /* MemArenaPosix.cpp in Sources */,
-				C67CFEC8C8E647F08CB7981D /* MemArenaWin32.cpp in Sources */,
 				781C3CA0275548E8AA690B4E /* MemoryUtil.cpp in Sources */,
 				585D328A7C3945D9922AAF0D /* MipsCPUDetect.cpp in Sources */,
 				D9939CDDA3C945509E6F8D02 /* MipsEmitter.cpp in Sources */,

--- a/Cores/PPSSPP/cmake/README.md
+++ b/Cores/PPSSPP/cmake/README.md
@@ -1,0 +1,4 @@
+Steps Needed to Customize Core Lib XCode Project (PPSSPP.xcodeproj):
+1. Remove script from ZERO_CHECK build phase
+2. Remove mm files except iCoreAudio.mm from libnative
+3. Remove MemArenaDarwin.cpp, and other MemArena*.cpp (e.g. MemArenaAndroid.cpp) from libCommon 

--- a/Cores/PPSSPP/cmake/generate.sh
+++ b/Cores/PPSSPP/cmake/generate.sh
@@ -34,6 +34,13 @@ cmake \
 #    -DCMAKE_XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC=YES \
 #    -DCMAKE_XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_WEAK=YES \
 #    -DCMAKE_XCODE_ATTRIBUTE_CLANG_ENABLE_MODULES=YES 
-python3 xcode_absolute_path_to_relative.py
+rm -fr build
 rm -fr CMakeFiles/3.25.0/CompilerIdCXX/XCBuildData/
 rm -fr CMakeFiles/3.25.0/CompilerIdC/XCBuildData/
+rm -fr CMakeFiles/3.25.0/CompilerIdC/CompilerIdC.build/
+rm -fr CMakeFiles/3.25.0/CompilerIdCXX/CompilerIdCXX.build/
+rm -fr CMakeFiles/3.25.0/CompilerIdCXX/CompilerIdCXX.build/
+rm -fr PPSSPP.xcodeproj/project.xcworkspace/xcuserdata/
+rm -fr CMakeFiles
+python3 xcode_absolute_path_to_relative.py
+echo 'Please open / compile the project with  "open PPSSPP.xcodeproj", apply customizations / adjustments, then run "sh generate_post.sh"'

--- a/Cores/PPSSPP/cmake/generate_post.sh
+++ b/Cores/PPSSPP/cmake/generate_post.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+rm -fr build
+rm -fr CMakeFiles/3.25.0/CompilerIdCXX/XCBuildData/
+rm -fr CMakeFiles/3.25.0/CompilerIdC/XCBuildData/
+rm -fr CMakeFiles/3.25.0/CompilerIdC/CompilerIdC.build/
+rm -fr CMakeFiles/3.25.0/CompilerIdCXX/CompilerIdCXX.build/
+rm -fr CMakeFiles/3.25.0/CompilerIdCXX/CompilerIdCXX.build/
+rm -fr PPSSPP.xcodeproj/project.xcworkspace/xcuserdata/
+python3 xcode_absolute_path_to_relative.py

--- a/Cores/PPSSPP/cmake/xcode_absolute_path_to_relative.py
+++ b/Cores/PPSSPP/cmake/xcode_absolute_path_to_relative.py
@@ -60,7 +60,7 @@ replacements.append([CONFIG_BUILD_DIR_PATH_TO_FIND,CONFIG_BUILD_DIR_PATH_TO_REPL
 #replacements.append([BUILD_CONFIG_TO_FIND,BUILD_CONFIG_TO_REPLACE_WITH])
 
 # Extensions of files to process
-extensions = ['.pbxproj', '.xcscheme', '.log', '.txt', '.cmake', '.make', '.tcl' ] #.h .hxx
+extensions = ['.pbxproj', '.xcscheme', '.log', '.txt', '.cmake', '.make', '.tcl', '.h', '.hxx' ]
 print(f'Reading Directory: {DIRECTORY_TO_READ}')
 print(f'$(SRCROOT) to find/replace:', replacements)
 print(f'Extensions to find:', extensions)


### PR DESCRIPTION
### What does this PR do
  This has:
- Header / Absolute Path path adjustment script under cmake (updated generate.sh along with python script, created 2nd script generate_post.sh. To use this: 
   1. Run generate.sh 
   2. Open PPSSPP.xcodeproj / make appropriate customizations / compile / everything should compile ..etc
   3. Run generate_post.sh (as Xcode will populate various absolute paths during the 1st run)
- There were a whole bunch of times where Memory weren't being allocated during startup. To fix this, new MemoryArena.cpp is added to PVPPSSPPCore/Core/ that is modified version of MemoryArenaDarwin.cpp in ppsspp, but is modified to loop vm_allocate  until proper memory address is found, then return the address
- PPSSPP Project file is modified with this change. So this now adds 1 more step to customizations needed:
Steps Needed to Customize Core Lib XCode Project (PPSSPP.xcodeproj):
1. Remove script from ZERO_CHECK build phase
2. Remove mm files except iCoreAudio.mm from libnative
3. Remove MemArenaDarwin.cpp, and other MemArena*.cpp (e.g. MemArenaAndroid.cpp) from libCommon 
- Pause is implemented
- Save is implemented, with fixes for random freezing from async action where thread returning the block call is different from original (so set to same)
- Adds Screen Stretching Option and Screen Resizing 

These are all included in this PR, with this PPSSPP should always launch games, with reliable saving / loading ..etc.


### Where should the reviewer start

### How should this be manually tested

### Any background context you want to provide

### What are the relevant tickets

### Screenshots (important for UI changes)

### Questions
