### PR TITLE
Dolphin/PPSSPP: Additional Settings

### DIFF
--- a/Cores/Dolphin/PVDolphinCore/Core/PVDolphinCore+Controls.mm
+++ b/Cores/Dolphin/PVDolphinCore/Core/PVDolphinCore+Controls.mm
@@ -330,390 +330,244 @@ s8 joyx[4], joyy[4];
 		if (controller.extendedGamepad != nil)
 		{
 			controller.extendedGamepad.buttonA.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
-                if (self.isWii) {
-                    [self gamepadEventOnPad:player
-                                     button:ButtonManager::ButtonType::WIIMOTE_BUTTON_2
-                                     action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)
-                    ];
-                    [self gamepadEventOnPad:player
-                                     button:ButtonManager::ButtonType::CLASSIC_BUTTON_A
-                                     action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)
-                    ];
-                } else
-					[self gamepadEventOnPad:player button:ButtonManager::ButtonType::BUTTON_A action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:4
+                     button:ButtonManager::ButtonType::WIIMOTE_BUTTON_2
+                     action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:4
+                     button:ButtonManager::ButtonType::CLASSIC_BUTTON_A
+                     action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+					[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_A
+                     action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			};
 			controller.extendedGamepad.buttonB.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
-                if (self.isWii) {
-                    [self gamepadEventOnPad:player button:ButtonManager::ButtonType::WIIMOTE_BUTTON_A action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-                    [self gamepadEventOnPad:player
-                                     button:ButtonManager::ButtonType::CLASSIC_BUTTON_B
-                                     action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)
-                    ];
-                } else
-					[self gamepadEventOnPad:player button:ButtonManager::ButtonType::BUTTON_B action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_BUTTON_A
+                     action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:4
+                     button:ButtonManager::ButtonType::CLASSIC_BUTTON_B
+                     action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_B
+                     action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			};
 			controller.extendedGamepad.buttonX.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
-                if (self.isWii) {
-                    [self gamepadEventOnPad:player button:ButtonManager::ButtonType::WIIMOTE_BUTTON_1 action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-                    [self gamepadEventOnPad:player
-                                     button:ButtonManager::ButtonType::CLASSIC_BUTTON_X
-                                     action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)
-                    ];
-                } else
-					[self gamepadEventOnPad:player button:ButtonManager::ButtonType::BUTTON_X action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_BUTTON_1
+                     action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:4
+                     button:ButtonManager::ButtonType::CLASSIC_BUTTON_X
+                     action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+					[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_X
+                     action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			};
 			controller.extendedGamepad.buttonY.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
-                if (self.isWii) {
-                    [self gamepadEventOnPad:player
-                                     button:ButtonManager::ButtonType::WIIMOTE_BUTTON_B action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-                    [self gamepadEventOnPad:player
-                                     button:ButtonManager::ButtonType::CLASSIC_BUTTON_Y
-                                     action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)
-                    ];
-                } else
-				   [self gamepadEventOnPad:player button:ButtonManager::ButtonType::BUTTON_Y action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:4
+                     button:ButtonManager::ButtonType::WIIMOTE_BUTTON_B
+                     action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:4
+                     button:ButtonManager::ButtonType::CLASSIC_BUTTON_Y
+                     action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+				    [self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_Y action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			};
 			controller.extendedGamepad.leftShoulder.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
-                if (self.isWii) {
-                    [self gamepadEventOnPad:player button:ButtonManager::ButtonType::WIIMOTE_BUTTON_PLUS action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-                    [self gamepadEventOnPad:player
-                                     button:ButtonManager::ButtonType::CLASSIC_BUTTON_ZL
-                                     action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)
-                    ];
-                } else
-					[self gamepadEventOnPad:player button:ButtonManager::ButtonType::TRIGGER_L action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_BUTTON_PLUS action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:4
+					 button:ButtonManager::ButtonType::CLASSIC_BUTTON_ZL
+					 action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+					[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::TRIGGER_L action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			};
 			controller.extendedGamepad.rightShoulder.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
-                if (self.isWii) {
-                    [self gamepadEventOnPad:player button:ButtonManager::ButtonType::WIIMOTE_BUTTON_MINUS action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-                    [self gamepadEventOnPad:player
-                                     button:ButtonManager::ButtonType::CLASSIC_BUTTON_ZR
-                                     action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)
-                    ];
-                } else
-					[self gamepadEventOnPad:player button:ButtonManager::ButtonType::TRIGGER_R action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_BUTTON_MINUS action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:4
+					 button:ButtonManager::ButtonType::CLASSIC_BUTTON_ZR
+					 action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+					[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::TRIGGER_R action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			};
 			controller.extendedGamepad.leftTrigger.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
-                if (self.isWii) {
-                    [self gamepadEventOnPad:player button:ButtonManager::ButtonType::NUNCHUK_BUTTON_C action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-                    [self gamepadEventOnPad:player
-                                     button:ButtonManager::ButtonType::CLASSIC_TRIGGER_L
-                                     action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)
-                    ];
-                } else
-                    [self gamepadEventOnPad:player button:ButtonManager::ButtonType::TRIGGER_L action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:4 button:ButtonManager::ButtonType::NUNCHUK_BUTTON_C action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:4
+					 button:ButtonManager::ButtonType::CLASSIC_TRIGGER_L
+					 action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:0 button:ButtonManager::ButtonType::TRIGGER_L action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			};
 			controller.extendedGamepad.rightTrigger.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
-                if (self.isWii) {
-                    [self gamepadEventOnPad:player button:ButtonManager::ButtonType::NUNCHUK_BUTTON_Z action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-                    [self gamepadEventOnPad:player
-                                     button:ButtonManager::ButtonType::CLASSIC_TRIGGER_R
-                                     action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)
-                    ];
-                } else
-                    [self gamepadEventOnPad:player button:ButtonManager::ButtonType::TRIGGER_R action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:4 button:ButtonManager::ButtonType::NUNCHUK_BUTTON_Z action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:4
+					 button:ButtonManager::ButtonType::CLASSIC_TRIGGER_R
+					 action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:0 button:ButtonManager::ButtonType::TRIGGER_R action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			};
 			controller.extendedGamepad.dpad.up.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
-                if (self.isWii) {
-                    [self gamepadEventOnPad:player button:ButtonManager::ButtonType::WIIMOTE_RIGHT action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-                    [self gamepadEventOnPad:player
-                                     button:ButtonManager::ButtonType::CLASSIC_DPAD_UP
-                                     action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)
-                    ];
-                } else
-					[self gamepadEventOnPad:player button:ButtonManager::ButtonType::BUTTON_UP action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_RIGHT action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:4
+					 button:ButtonManager::ButtonType::CLASSIC_DPAD_UP
+					 action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadMoveEventOnPad:4 axis:NUNCHUK_STICK_UP value:pressed?CGFloat(-1):CGFloat(0)];
+					[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_UP action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			};
 			controller.extendedGamepad.dpad.left.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
-                if (self.isWii) {
-                    [self gamepadEventOnPad:player button:ButtonManager::ButtonType::WIIMOTE_UP action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-                    [self gamepadEventOnPad:player
-                                     button:ButtonManager::ButtonType::CLASSIC_DPAD_LEFT
-                                     action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)
-                    ];
-                } else
-					[self gamepadEventOnPad:player button:ButtonManager::ButtonType::BUTTON_LEFT action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_UP action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:4
+					 button:ButtonManager::ButtonType::CLASSIC_DPAD_LEFT
+					 action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadMoveEventOnPad:4 axis:NUNCHUK_STICK_LEFT value:pressed?CGFloat(-1):CGFloat(0)];
+					[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_LEFT action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			};
 			controller.extendedGamepad.dpad.right.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
-                if (self.isWii) {
-                    [self gamepadEventOnPad:player button:ButtonManager::ButtonType::WIIMOTE_DOWN action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-                    [self gamepadEventOnPad:player
-                                     button:ButtonManager::ButtonType::CLASSIC_DPAD_RIGHT
-                                     action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)
-                    ];
-                } else
-					[self gamepadEventOnPad:player button:ButtonManager::ButtonType::BUTTON_RIGHT action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_DOWN action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:4
+					 button:ButtonManager::ButtonType::CLASSIC_DPAD_RIGHT
+					 action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadMoveEventOnPad:4 axis:NUNCHUK_STICK_RIGHT value:pressed?CGFloat(1):CGFloat(0)];
+					[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_RIGHT action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			};
 			controller.extendedGamepad.dpad.down.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
-                if (self.isWii) {
-                    [self gamepadEventOnPad:player button:ButtonManager::ButtonType::WIIMOTE_LEFT action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-                    [self gamepadEventOnPad:player
-                                     button:ButtonManager::ButtonType::CLASSIC_DPAD_DOWN
-                                     action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)
-                    ];
-                } else
-					[self gamepadEventOnPad:player button:ButtonManager::ButtonType::BUTTON_DOWN action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_LEFT action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:4
+                         button:ButtonManager::ButtonType::CLASSIC_DPAD_DOWN
+                         action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadMoveEventOnPad:4 axis:NUNCHUK_STICK_DOWN
+                        value:pressed?CGFloat(1):CGFloat(0)];
+					[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_DOWN action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			};
 			controller.extendedGamepad.buttonHome.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
-                [self gamepadEventOnPad:player button:ButtonManager::ButtonType::WIIMOTE_BUTTON_HOME
+                [self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_BUTTON_HOME
                     action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-				[self gamepadEventOnPad:player button:ButtonManager::ButtonType::WIIMOTE_IR_RECENTER action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+				[self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_IR_RECENTER action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+				[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_START action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			};
             controller.extendedGamepad.leftThumbstick.xAxis.valueChangedHandler = ^(GCControllerAxisInput* xAxis, float value) {
-                if (self.isWii) {
-                    [self gamepadMoveEventOnPad:player axis:114 value:CGFloat(value)];
-                    [self gamepadMoveEventOnPad:player axis:115 value:CGFloat(value)];
-                } else {
-                    [self gamepadMoveEventOnPad:player axis:13 value:CGFloat(value)];
-                    [self gamepadMoveEventOnPad:player axis:14 value:CGFloat(value)];
-                }
+                    [self gamepadMoveEventOnPad:4 axis:114 value:CGFloat(value)];
+                    [self gamepadMoveEventOnPad:4 axis:115 value:CGFloat(value)];
+					// GC
+                    [self gamepadMoveEventOnPad:0 axis:13 value:CGFloat(value)];
+                    [self gamepadMoveEventOnPad:0 axis:14 value:CGFloat(value)];
             };
             controller.extendedGamepad.leftThumbstick.yAxis.valueChangedHandler = ^(GCControllerAxisInput* yAxis, float value) {
-                if (self.isWii) {
-                    [self gamepadMoveEventOnPad:player axis:112 value:CGFloat(-value)];
-                    [self gamepadMoveEventOnPad:player axis:113 value:CGFloat(-value)];
-                } else {
-                    [self gamepadMoveEventOnPad:player axis:11 value:CGFloat(-value)];
-                    [self gamepadMoveEventOnPad:player axis:12 value:CGFloat(-value)];
-                }
+                    [self gamepadMoveEventOnPad:4 axis:112 value:CGFloat(-value)];
+                    [self gamepadMoveEventOnPad:4 axis:113 value:CGFloat(-value)];
+					// GC
+                    [self gamepadMoveEventOnPad:0 axis:11 value:CGFloat(-value)];
+                    [self gamepadMoveEventOnPad:0 axis:12 value:CGFloat(-value)];
             };
             controller.extendedGamepad.rightThumbstick.xAxis.valueChangedHandler = ^(GCControllerAxisInput* xAxis, float value) {
-                if (self.isWii) {
-                    [self gamepadMoveEventOnPad:player axis:213 value:CGFloat(-value)];
-                    [self gamepadMoveEventOnPad:player axis:125 value:CGFloat(-value)];
-                } else {
-                    [self gamepadMoveEventOnPad:player axis:18 value:CGFloat(value)];
-                    [self gamepadMoveEventOnPad:player axis:19 value:CGFloat(value)];
-                }
+                    [self gamepadMoveEventOnPad:4 axis:213 value:CGFloat(-value)];
+                    [self gamepadMoveEventOnPad:4 axis:125 value:CGFloat(-value)];
+					// GC
+                    [self gamepadMoveEventOnPad:0 axis:18 value:CGFloat(value)];
+                    [self gamepadMoveEventOnPad:0 axis:19 value:CGFloat(value)];
             };
             controller.extendedGamepad.rightThumbstick.yAxis.valueChangedHandler = ^(GCControllerAxisInput* yAxis, float value) {
-                if (self.isWii) {
-                    [self gamepadMoveEventOnPad:player axis:212 value:CGFloat(value)];
-                    [self gamepadMoveEventOnPad:player axis:124 value:CGFloat(value)];
-                } else {
-                    [self gamepadMoveEventOnPad:player axis:16 value:CGFloat(-value)];
-                    [self gamepadMoveEventOnPad:player axis:17 value:CGFloat(-value)];
-                }
+                    [self gamepadMoveEventOnPad:4 axis:212 value:CGFloat(value)];
+                    [self gamepadMoveEventOnPad:4 axis:124 value:CGFloat(value)];
+					// GC
+                    [self gamepadMoveEventOnPad:0 axis:16 value:CGFloat(-value)];
+                    [self gamepadMoveEventOnPad:0 axis:17 value:CGFloat(-value)];
             };
             controller.extendedGamepad.leftThumbstickButton.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
-                if (self.isWii) {
-                    [self gamepadEventOnPad:player button:ButtonManager::ButtonType::WIIMOTE_BUTTON_PLUS action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-                    [self gamepadEventOnPad:player button:ButtonManager::ButtonType::WIIMOTE_IR_RECENTER action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-                } else {
-                    [self gamepadEventOnPad:player button:ButtonManager::ButtonType::BUTTON_START action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-                }
+                    [self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_BUTTON_PLUS action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_IR_RECENTER action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+					// GC
+                    [self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_START action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
             };
             controller.extendedGamepad.rightThumbstickButton.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
-                if (self.isWii) {
-                    [self gamepadEventOnPad:player button:ButtonManager::ButtonType::WIIMOTE_BUTTON_MINUS action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-                    [self gamepadEventOnPad:player button:ButtonManager::ButtonType::WIIMOTE_IR_RECENTER action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-                } else {
-                    [self gamepadEventOnPad:player button:ButtonManager::ButtonType::BUTTON_START action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-                }
+					[self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_BUTTON_MINUS
+					 action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+					[self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_IR_RECENTER
+					 action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+					[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_START
+					 action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
             };
 		}
 		else if (controller.gamepad != nil)
 		{
             controller.gamepad.buttonA.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
-                if (self.isWii)
-                    [self gamepadEventOnPad:player
-                         button:ButtonManager::ButtonType::WIIMOTE_BUTTON_2
-                         action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)
-                    ];
-                else
-                    [self gamepadEventOnPad:player button:ButtonManager::ButtonType::BUTTON_A action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:4
+					 button:ButtonManager::ButtonType::WIIMOTE_BUTTON_2
+					 action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_A action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
             };
             controller.gamepad.buttonB.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
-                if (self.isWii)
-                    [self gamepadEventOnPad:player button:ButtonManager::ButtonType::WIIMOTE_BUTTON_A action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-                else
-                    [self gamepadEventOnPad:player button:ButtonManager::ButtonType::BUTTON_B action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_BUTTON_A action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_B action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
             };
             controller.gamepad.buttonX.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
-                if (self.isWii)
-                    [self gamepadEventOnPad:player button:ButtonManager::ButtonType::WIIMOTE_BUTTON_1 action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-                else
-                    [self gamepadEventOnPad:player button:ButtonManager::ButtonType::BUTTON_X action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_BUTTON_1 action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_X action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
             };
             controller.gamepad.buttonY.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
-                if (self.isWii)
-                   [self gamepadEventOnPad:player button:ButtonManager::ButtonType::WIIMOTE_BUTTON_B action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-               else
-                   [self gamepadEventOnPad:player button:ButtonManager::ButtonType::BUTTON_Y action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                   [self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_BUTTON_B action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                   [self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_Y action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
             };
             controller.gamepad.leftShoulder.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
-                if (self.isWii)
-                    [self gamepadEventOnPad:player button:ButtonManager::ButtonType::WIIMOTE_BUTTON_PLUS action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-                else
-                    [self gamepadEventOnPad:player button:ButtonManager::ButtonType::TRIGGER_L action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_BUTTON_PLUS action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:0 button:ButtonManager::ButtonType::TRIGGER_L action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
             };
             controller.gamepad.rightShoulder.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
-                if (self.isWii)
-                    [self gamepadEventOnPad:player button:ButtonManager::ButtonType::WIIMOTE_BUTTON_MINUS action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-                else
-                    [self gamepadEventOnPad:player button:ButtonManager::ButtonType::TRIGGER_R action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_BUTTON_MINUS action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:0 button:ButtonManager::ButtonType::TRIGGER_R action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
             };
 			controller.gamepad.dpad.up.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
-				if (self.isWii)
-					[self gamepadEventOnPad:player button:ButtonManager::ButtonType::WIIMOTE_RIGHT action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-				else
-					[self gamepadEventOnPad:player button:ButtonManager::ButtonType::BUTTON_UP action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+					[self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_RIGHT action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+					[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_UP action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 
 			};
 			controller.gamepad.dpad.left.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
-				if (self.isWii)
-					[self gamepadEventOnPad:player button:ButtonManager::ButtonType::WIIMOTE_UP action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-				else
-					[self gamepadEventOnPad:player button:ButtonManager::ButtonType::BUTTON_LEFT action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+					[self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_UP action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+					[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_LEFT action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			};
 			controller.gamepad.dpad.right.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
-				if (self.isWii)
-					[self gamepadEventOnPad:player button:ButtonManager::ButtonType::WIIMOTE_DOWN action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-				else
-					[self gamepadEventOnPad:player button:ButtonManager::ButtonType::BUTTON_LEFT action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+					[self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_DOWN action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+					[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_LEFT action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			};
 			controller.gamepad.dpad.down.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
-				if (self.isWii)
-					[self gamepadEventOnPad:player button:ButtonManager::ButtonType::WIIMOTE_LEFT action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-				else
-					[self gamepadEventOnPad:player button:ButtonManager::ButtonType::BUTTON_DOWN action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+					[self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_LEFT action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+					[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_DOWN action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			};
 		}
 		else if (controller.microGamepad != nil)
 		{
-            controller.microGamepad.buttonA.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
-                if (self.isWii)
-                    [self gamepadEventOnPad:player
-                         button:ButtonManager::ButtonType::WIIMOTE_BUTTON_2
-                         action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)
-                    ];
-                else
-                    [self gamepadEventOnPad:player button:ButtonManager::ButtonType::BUTTON_A action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+            controller.microGamepad.buttonA.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {                if (self.isWii)
+                    [self gamepadEventOnPad:4
+					 button:ButtonManager::ButtonType::WIIMOTE_BUTTON_2
+					 action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_A action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
             };
             controller.microGamepad.buttonX.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
-                if (self.isWii)
-                    [self gamepadEventOnPad:player button:ButtonManager::ButtonType::WIIMOTE_BUTTON_1 action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-                else
-                    [self gamepadEventOnPad:player button:ButtonManager::ButtonType::BUTTON_X action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_BUTTON_1 action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+                    [self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_X action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
             };
 			controller.microGamepad.dpad.up.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
-				if (self.isWii)
-					[self gamepadEventOnPad:player button:ButtonManager::ButtonType::WIIMOTE_RIGHT action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-				else
-					[self gamepadEventOnPad:player button:ButtonManager::ButtonType::BUTTON_UP action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+					[self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_RIGHT action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+					[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_UP action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			};
 			controller.microGamepad.dpad.left.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
-				if (self.isWii)
-					[self gamepadEventOnPad:player button:ButtonManager::ButtonType::WIIMOTE_UP action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-				else
-					[self gamepadEventOnPad:player button:ButtonManager::ButtonType::BUTTON_LEFT action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+					[self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_UP action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+					[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_LEFT action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			};
 			controller.microGamepad.dpad.right.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
-				if (self.isWii)
-					[self gamepadEventOnPad:player button:ButtonManager::ButtonType::WIIMOTE_DOWN action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-				else
-					[self gamepadEventOnPad:player button:ButtonManager::ButtonType::BUTTON_RIGHT action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+					[self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_DOWN action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+					[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_RIGHT action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			};
 			controller.microGamepad.dpad.down.pressedChangedHandler = ^(GCControllerButtonInput* button, float value, bool pressed) {
-				if (self.isWii)
-					[self gamepadEventOnPad:player button:ButtonManager::ButtonType::WIIMOTE_LEFT action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-				else
-					[self gamepadEventOnPad:player button:ButtonManager::ButtonType::BUTTON_DOWN action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+					[self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_LEFT action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+					[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_DOWN action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			};
 		}
 	}
 }
 
-- (void)pollControllers {
-	for (NSInteger playerIndex = 0; playerIndex < 4; playerIndex++)
-	{
-		GCController *controller = nil;
-
-		if (self.controller1 && playerIndex == 0)
-		{
-			controller = self.controller1;
-		}
-		else if (self.controller2 && playerIndex == 1)
-		{
-			controller = self.controller2;
-		}
-		else if (self.controller3 && playerIndex == 2)
-		{
-			controller = self.controller3;
-		}
-		else if (self.controller4 && playerIndex == 3)
-		{
-			controller = self.controller4;
-		}
-
-		if ([controller extendedGamepad])
-		{
-			GCExtendedGamepad *gamepad     = [controller extendedGamepad];
-			GCControllerDirectionPad *dpad = [gamepad dpad];
-
-			dpad.up.isPressed ? kcode[playerIndex] &= ~(DC_DPAD_UP) : kcode[playerIndex] |= (DC_DPAD_UP);
-			dpad.down.isPressed ? kcode[playerIndex] &= ~(DC_DPAD_DOWN) : kcode[playerIndex] |= (DC_DPAD_DOWN);
-			dpad.left.isPressed ? kcode[playerIndex] &= ~(DC_DPAD_LEFT) : kcode[playerIndex] |= (DC_DPAD_LEFT);
-			dpad.right.isPressed ? kcode[playerIndex] &= ~(DC_DPAD_RIGHT) : kcode[playerIndex] |= (DC_DPAD_RIGHT);
-
-			gamepad.buttonA.isPressed ? kcode[playerIndex] &= ~(DC_BTN_A) : kcode[playerIndex] |= (DC_BTN_A);
-			gamepad.buttonB.isPressed ? kcode[playerIndex] &= ~(DC_BTN_B) : kcode[playerIndex] |= (DC_BTN_B);
-			gamepad.buttonX.isPressed ? kcode[playerIndex] &= ~(DC_BTN_X) : kcode[playerIndex] |= (DC_BTN_X);
-			gamepad.buttonY.isPressed ? kcode[playerIndex] &= ~(DC_BTN_Y) : kcode[playerIndex] |= (DC_BTN_Y);
-
-			gamepad.leftShoulder.isPressed ? kcode[playerIndex] &= ~(DC_AXIS_LT) : kcode[playerIndex] |= (DC_AXIS_LT);
-			gamepad.rightShoulder.isPressed ? kcode[playerIndex] &= ~(DC_AXIS_RT) : kcode[playerIndex] |= (DC_AXIS_RT);
-
-			gamepad.leftTrigger.isPressed ? kcode[playerIndex] &= ~(DC_BTN_Z) : kcode[playerIndex] |= (DC_BTN_Z);
-			gamepad.rightTrigger.isPressed ? kcode[playerIndex] &= ~(DC_BTN_START) : kcode[playerIndex] |= (DC_BTN_START);
-
-
-			float xvalue = gamepad.leftThumbstick.xAxis.value;
-			s8 x=(s8)(xvalue*127);
-			joyx[0] = x;
-
-			float yvalue = gamepad.leftThumbstick.yAxis.value;
-			s8 y=(s8)(yvalue*127 * - 1); //-127 ... + 127 range
-			joyy[0] = y;
-		} else if ([controller gamepad]) {
-			GCGamepad *gamepad = [controller gamepad];
-			GCControllerDirectionPad *dpad = [gamepad dpad];
-
-			dpad.up.isPressed ? kcode[playerIndex] &= ~(DC_DPAD_UP) : kcode[playerIndex] |= (DC_DPAD_UP);
-			dpad.down.isPressed ? kcode[playerIndex] &= ~(DC_DPAD_DOWN) : kcode[playerIndex] |= (DC_DPAD_DOWN);
-			dpad.left.isPressed ? kcode[playerIndex] &= ~(DC_DPAD_LEFT) : kcode[playerIndex] |= (DC_DPAD_LEFT);
-			dpad.right.isPressed ? kcode[playerIndex] &= ~(DC_DPAD_RIGHT) : kcode[playerIndex] |= (DC_DPAD_RIGHT);
-
-			gamepad.buttonA.isPressed ? kcode[playerIndex] &= ~(DC_BTN_A) : kcode[playerIndex] |= (DC_BTN_A);
-			gamepad.buttonB.isPressed ? kcode[playerIndex] &= ~(DC_BTN_B) : kcode[playerIndex] |= (DC_BTN_B);
-			gamepad.buttonX.isPressed ? kcode[playerIndex] &= ~(DC_BTN_X) : kcode[playerIndex] |= (DC_BTN_X);
-			gamepad.buttonY.isPressed ? kcode[playerIndex] &= ~(DC_BTN_Y) : kcode[playerIndex] |= (DC_BTN_Y);
-
-			gamepad.leftShoulder.isPressed ? kcode[playerIndex] &= ~(DC_AXIS_LT) : kcode[playerIndex] |= (DC_AXIS_LT);
-			gamepad.rightShoulder.isPressed ? kcode[playerIndex] &= ~(DC_AXIS_RT) : kcode[playerIndex] |= (DC_AXIS_RT);
-		}
-#if TARGET_OS_TV
-		else if ([controller microGamepad]) {
-			GCMicroGamepad *gamepad = [controller microGamepad];
-			GCControllerDirectionPad *dpad = [gamepad dpad];
-		}
-#endif
-	}
-}
-
+// pad == 4 is WiiMote, pad == 0 is GC (in both GC / Wii Modes)
 - (void)gamepadEventOnPad:(int)pad button:(int)button action:(int)action
 {
-	int controller = self.isWii ? 4 : 0;
-	ButtonManager::GamepadEvent("Touchscreen", controller, button, action);
+	ButtonManager::GamepadEvent("Touchscreen", pad, button, action);
 }
 
 - (void)gamepadMoveEventOnPad:(int)pad axis:(int)axis value:(CGFloat)value
 {
-	int controller = self.isWii ? 4 : 0;
-	ButtonManager::GamepadAxisEvent("Touchscreen", controller, axis, value);
+	ButtonManager::GamepadAxisEvent("Touchscreen", pad, axis, value);
 }
 
 - (void)gamepadEventIrRecenter:(int)action
 {
+	// 4-8 are Wii Controllers
 	for (int i = 4; i < 8; i++) {
 	  ELOG(@"Received IR %d \n", action);
 	  ButtonManager::GamepadEvent("Touchscreen", i, ButtonManager::ButtonType::WIIMOTE_IR_RECENTER, action);
@@ -722,7 +576,7 @@ s8 joyx[4], joyy[4];
 
 -(void)didPushWiiButton:(PVWiiMoteButton)button forPlayer:(NSInteger)player {
 	if(_isInitialized) {
-		[self sendWiiButtonInput:(PVWiiMoteButton)button isPressed:true withValue:0.0
+		[self sendWiiButtonInput:(PVWiiMoteButton)button isPressed:true withValue:1.0
 		 forPlayer:player];
 	}
 }
@@ -761,67 +615,114 @@ s8 joyx[4], joyy[4];
 }
 
 -(void)didMoveJoystick:(NSInteger)button withValue:(CGFloat)value forPlayer:(NSInteger)player {
-	ELOG(@"Onscreen Button Moved %d %d %d\n",button, value, player);
 	[self didMoveWiiJoystickDirection:(PVWiiMoteButton)button withValue:value forPlayer:player];
 }
 
 - (void)didPush:(NSInteger)button forPlayer:(NSInteger)player {
-	ELOG(@"OnScreen Button Pushed %d %d\n",button,player);
 	[self didPushWiiButton:(PVWiiMoteButton)button forPlayer:player];
 }
 
 - (void)didRelease:(NSInteger)button forPlayer:(NSInteger)player {
-	ELOG(@"OnScreen Button Released %d %d\n",button,player);
 	[self didReleaseWiiButton:(PVWiiMoteButton)button forPlayer:player];
 }
-
 
 -(void)sendWiiButtonInput:(enum PVWiiMoteButton)button isPressed:(bool)pressed withValue:(CGFloat)value forPlayer:(NSInteger)player {
 	switch (button) {
 		case(PVWiiMoteButtonWiiHome):
-			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::WIIMOTE_BUTTON_HOME action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+			[self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_BUTTON_HOME
+             action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+            [self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_START
+             action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			break;
 		case(PVWiiMoteButtonWiiDPadLeft):
-			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::WIIMOTE_UP action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-            [self gamepadMoveEventOnPad:player axis:WIIMOTE_IR_LEFT value:pressed?CGFloat(-1):CGFloat(0)];
+			[self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_UP
+             action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+            [self gamepadMoveEventOnPad:4 axis:WIIMOTE_IR_LEFT value:pressed?CGFloat(-1):CGFloat(0)];
+            [self gamepadMoveEventOnPad:4 axis:NUNCHUK_STICK_LEFT value:pressed?CGFloat(-1):CGFloat(0)];
+            [self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_LEFT
+             action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			break;
 		case(PVWiiMoteButtonWiiDPadRight):
-			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::WIIMOTE_DOWN action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-            [self gamepadMoveEventOnPad:player axis:WIIMOTE_IR_RIGHT value:pressed?CGFloat(1):CGFloat(0)];
+			[self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_DOWN
+             action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+            [self gamepadMoveEventOnPad:4 axis:WIIMOTE_IR_RIGHT value:pressed?CGFloat(1):CGFloat(0)];
+            [self gamepadMoveEventOnPad:4 axis:NUNCHUK_STICK_RIGHT value:pressed?CGFloat(1):CGFloat(0)];
+            [self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_RIGHT
+             action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			break;
 		case(PVWiiMoteButtonWiiDPadUp):
-			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::WIIMOTE_RIGHT action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-            [self gamepadMoveEventOnPad:player axis:WIIMOTE_IR_UP value:pressed?CGFloat(-1):CGFloat(0)];
+			[self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_RIGHT
+             action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+            [self gamepadMoveEventOnPad:4 axis:WIIMOTE_IR_UP value:pressed?CGFloat(-1):CGFloat(0)];
+            [self gamepadMoveEventOnPad:4 axis:NUNCHUK_STICK_UP value:pressed?CGFloat(-1):CGFloat(0)];
+            [self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_UP
+             action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			break;
 		case(PVWiiMoteButtonWiiDPadDown):
-			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::WIIMOTE_LEFT action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-            [self gamepadMoveEventOnPad:player axis:WIIMOTE_IR_DOWN value:pressed?CGFloat(1):CGFloat(0)];
+			[self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_LEFT
+             action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+            [self gamepadMoveEventOnPad:4 axis:WIIMOTE_IR_DOWN value:pressed?CGFloat(1):CGFloat(0)];
+            [self gamepadMoveEventOnPad:4 axis:NUNCHUK_STICK_DOWN value:pressed?CGFloat(1):CGFloat(0)];
+            [self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_DOWN
+             action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			break;
 		case(PVWiiMoteButtonWiiA):
-			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::WIIMOTE_BUTTON_A action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+			[self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_BUTTON_A
+             action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_A
+             action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			break;
 		case(PVWiiMoteButtonWiiB):
-			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::WIIMOTE_BUTTON_B action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+			[self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_BUTTON_B
+             action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_B
+             action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			break;
 		case(PVWiiMoteButtonWiiOne):
-			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::WIIMOTE_BUTTON_1 action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-			break;
-		case(PVWiiMoteButtonWiiTwo):
-			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::WIIMOTE_BUTTON_2 action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
-			break;
+			[self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_BUTTON_1
+             action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_Y
+             action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+            break;
+        case(PVWiiMoteButtonWiiTwo):
+            [self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_BUTTON_2
+             action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+            [self gamepadMoveEventOnPad:4 axis:212 value:CGFloat(value)];
+            [self gamepadMoveEventOnPad:4 axis:220 value:CGFloat(value)];
+            [self gamepadMoveEventOnPad:4 axis:221 value:CGFloat(value)];
+            [self gamepadMoveEventOnPad:4 axis:222 value:CGFloat(value)];
+			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_X
+             action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+            break;
 		case(PVWiiMoteButtonWiiPlus):
-			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::WIIMOTE_BUTTON_PLUS action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+			[self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_BUTTON_PLUS
+             action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::TRIGGER_R
+             action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			break;
 		case(PVWiiMoteButtonWiiMinus):
-			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::WIIMOTE_BUTTON_MINUS action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+			[self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_BUTTON_MINUS
+             action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::TRIGGER_L
+             action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			break;
 		case(PVWiiMoteButtonNunchunkC):
-			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::NUNCHUK_BUTTON_C action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+			[self gamepadEventOnPad:4 button:ButtonManager::ButtonType::NUNCHUK_BUTTON_C
+             action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::TRIGGER_R
+             action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			break;
 		case(PVWiiMoteButtonNunchunkZ):
-			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::NUNCHUK_BUTTON_Z action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+			[self gamepadEventOnPad:4 button:ButtonManager::ButtonType::NUNCHUK_BUTTON_Z
+             action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_Z
+             action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			break;
 		default:
+			[self gamepadEventOnPad:4 button:ButtonManager::ButtonType::WIIMOTE_BUTTON_HOME
+             action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+            [self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_START
+             action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			break;
 	}
 }
@@ -830,52 +731,52 @@ s8 joyx[4], joyy[4];
 -(void)sendGCButtonInput:(enum PVGCButton)button isPressed:(bool)pressed withValue:(CGFloat)value forPlayer:(NSInteger)player {
 	switch (button) {
 		case(PVGCButtonStart):
-			[self gamepadEventOnPad:player button:ButtonManager::ButtonType::BUTTON_START action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_START action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			break;
 		case(PVGCButtonLeft):
-			[self gamepadEventOnPad:player button:ButtonManager::ButtonType::BUTTON_LEFT action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_LEFT action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			break;
 		case(PVGCButtonRight):
-			[self gamepadEventOnPad:player button:ButtonManager::ButtonType::BUTTON_RIGHT action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_RIGHT action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			break;
 		case(PVGCButtonUp):
-			[self gamepadEventOnPad:player button:ButtonManager::ButtonType::BUTTON_UP action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_UP action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			break;
 		case(PVGCButtonDown):
-			[self gamepadEventOnPad:player button:ButtonManager::ButtonType::BUTTON_DOWN action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_DOWN action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			break;
 		case(PVGCButtonCUp):
-			[self gamepadEventOnPad:player button:ButtonManager::ButtonType::STICK_C_UP action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::STICK_C_UP action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			break;
 		case(PVGCButtonCDown):
-			[self gamepadEventOnPad:player button:ButtonManager::ButtonType::STICK_C_DOWN action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::STICK_C_DOWN action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			break;
 		case(PVGCButtonCLeft):
-			[self gamepadEventOnPad:player button:ButtonManager::ButtonType::STICK_C_LEFT action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::STICK_C_LEFT action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			break;
 		case(PVGCButtonCRight):
-			[self gamepadEventOnPad:player button:ButtonManager::ButtonType::STICK_C_RIGHT action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::STICK_C_RIGHT action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			break;
 		case(PVGCButtonZ):
-			[self gamepadEventOnPad:player button:ButtonManager::ButtonType::BUTTON_Z action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_Z action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			break;
 		case(PVGCButtonL):
-			[self gamepadEventOnPad:player button:ButtonManager::ButtonType::TRIGGER_L action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::TRIGGER_L action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			break;
 		case(PVGCButtonR):
-			[self gamepadEventOnPad:player button:ButtonManager::ButtonType::TRIGGER_R action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::TRIGGER_R action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			break;
 		case(PVGCButtonX):
-			[self gamepadEventOnPad:player button:ButtonManager::ButtonType::BUTTON_X action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_X action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			break;
 		case(PVGCButtonY):
-			[self gamepadEventOnPad:player button:ButtonManager::ButtonType::BUTTON_Y action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_Y action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			break;
 		case(PVGCButtonA):
-			[self gamepadEventOnPad:player button:ButtonManager::ButtonType::BUTTON_A action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_A action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			break;
 		case(PVGCButtonB):
-			[self gamepadEventOnPad:player button:ButtonManager::ButtonType::BUTTON_B action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
+			[self gamepadEventOnPad:0 button:ButtonManager::ButtonType::BUTTON_B action:(pressed?ButtonManager::BUTTON_PRESSED:ButtonManager::BUTTON_RELEASED)];
 			break;
 		default:
 			break;
@@ -884,7 +785,7 @@ s8 joyx[4], joyy[4];
 
 // Required ini file for the Button Manager WiiMote is at 4-8 port
 -(void) writeWiiIniFile {
-	NSString *fileName = [NSString stringWithFormat:@"%@/saves/Config/WiimoteNew.ini",
+	NSString *fileName = [NSString stringWithFormat:@"%@/../DolphinData/Config/WiimoteNew.ini",
 						  self.batterySavesPath];
 	NSString *content =
 	@"[Wiimote1]\n"
@@ -1035,6 +936,9 @@ s8 joyx[4], joyy[4];
 	@"Guitar/Stick/Calibration = 100.00 141.42 100.00 141.42 100.00 141.42 100.00 141.42\n"
 	@"Drums/Stick/Calibration = 100.00 141.42 100.00 141.42 100.00 141.42 100.00 141.42\n"
 	@"Turntable/Stick/Calibration = 100.00 141.42 100.00 141.42 100.00 141.42 100.00 141.42\n"
+    @"IMUIR/Enabled = True\n"
+    @"Extension = Nunchuk\n"
+    @"Extension/Attach MotionPlus = `Attached MotionPlus`\n"
 	@"Source = 1\n";
 	[content writeToFile:fileName
 	   atomically:NO
@@ -1044,7 +948,7 @@ s8 joyx[4], joyy[4];
 
 // Required ini file for the Button Manager GC is at 0-3 port
 -(void) writeGCIniFile {
-	NSString *fileName = [NSString stringWithFormat:@"%@/saves/Config/GCPadNew.ini",
+	NSString *fileName = [NSString stringWithFormat:@"%@/../DolphinData/Config/GCPadNew.ini",
 						  self.batterySavesPath];
 	NSString *content =
 	@"[GCPad1]\n"
@@ -1074,40 +978,10 @@ s8 joyx[4], joyy[4];
 	@"Rumble/Motor = `Rumble 700`\n"
 	@"Main Stick/Calibration = 100.00 141.42 100.00 141.42 100.00 141.42 100.00 141.42\n"
 	@"C-Stick/Calibration = 100.00 141.42 100.00 141.42 100.00 141.42 100.00 141.42\n"
-	@"Source = 1\n";
+    @"Source = 1\n";
 	[content writeToFile:fileName
 	   atomically:NO
 	   encoding:NSStringEncodingConversionAllowLossy
 	   error:nil];
 }
-
-# pragma mark - Input Wii
-//- (oneway void)didMoveWiiJoystickDirection:(OEWiiButton)button withValue:(CGFloat)value forPlayer:(NSUInteger)player
-//{
-//	if(_isInitialized)
-//	{
-//		dol_host->SetAxis(button, value, (int)player);
-//	}
-//}
-//
-//- (oneway void)didPushWiiButton:(OEWiiButton)button forPlayer:(NSUInteger)player
-//{
-//	if(_isInitialized)
-//	{
-//		if (button > OEWiiButtonCount) {
-//			dol_host->processSpecialKeys(button , (int)player);
-//		} else {
-//			dol_host->setButtonState(button, 1, (int)player);
-//		}
-//	}
-//}
-//
-//- (oneway void)didReleaseWiiButton:(OEWiiButton)button forPlayer:(NSUInteger)player
-//{
-//	if(_isInitialized && button != OEWiimoteSideways && button != OEWiimoteUpright)
-//	{
-//		dol_host->setButtonState(button, 0, (int)player);
-//	}
-//}
-
 @end

--- a/Cores/Dolphin/PVDolphinCore/Core/PVDolphinCore.h
+++ b/Cores/Dolphin/PVDolphinCore/Core/PVDolphinCore.h
@@ -38,6 +38,11 @@
 	BOOL isNTSC;
 	BOOL isBilinear;
 	BOOL isWii;
+    BOOL enableCheatCode;
+    UIView *m_view;
+    UIViewController *m_view_controller;
+    CAMetalLayer* m_metal_layer;
+    CAEAGLLayer *m_gl_layer;
 @public
 	dispatch_queue_t _callbackQueue;
 }
@@ -53,6 +58,7 @@
 @property (nonatomic, assign) int8_t msaa;
 @property (nonatomic, assign) bool ssaa;
 @property (nonatomic, assign) bool fastMemory;
+@property (nonatomic, assign) bool enableCheatCode;
 - (void) refreshScreenSize;
 - (void) startVM:(UIView *)view;
 - (void) setupControllers;

--- a/Cores/Dolphin/PVDolphinCore/Core/PVDolphinCore.mm
+++ b/Cores/Dolphin/PVDolphinCore/Core/PVDolphinCore.mm
@@ -74,6 +74,7 @@
 #include "VideoCommon/AsyncRequests.h"
 #include "VideoCommon/Fifo.h"
 #include "VideoCommon/RenderBase.h"
+#include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VideoBackendBase.h"
 #include "VideoCommon/VideoConfig.h"
 #include "VideoCommon/OnScreenDisplay.h"
@@ -88,21 +89,19 @@
 #define SAMPLERATE 48000
 #define SIZESOUNDBUFFER 48000 / 60 * 4
 
+static Common::Flag s_running{true};
+static Common::Flag s_shutdown_requested{false};
+static Common::Flag s_tried_graceful_shutdown{false};
+static Common::Event s_update_main_frame_event;
+static bool s_have_wm_user_stop = false;
+static bool s_game_metadata_is_valid = false;
+static std::mutex s_host_identity_lock;
+static bool _isOff = false;
 __weak PVDolphinCore *_current = 0;
-UIView *m_view = nullptr;
-CAMetalLayer* m_metal_layer = nullptr;
-CAEAGLLayer *m_gl_layer = nullptr;
-Common::Flag s_running{true};
-Common::Flag s_shutdown_requested{false};
-Common::Flag s_tried_graceful_shutdown{false};
-Common::Event s_update_main_frame_event;
-std::string user_dir;
-std::mutex s_host_identity_lock;
-bool s_have_wm_user_stop = false;
-bool s_game_metadata_is_valid = false;
 bool _isInitialized;
-bool MsgAlert(const char* caption, const char* text, bool yes_no, Common::MsgType style);
-void UpdateWiiPointer();
+std::string user_dir;
+static bool MsgAlert(const char* caption, const char* text, bool yes_no, Common::MsgType style);
+static void UpdateWiiPointer();
 
 #pragma mark - Private
 @interface PVDolphinCore() {
@@ -115,122 +114,122 @@ void UpdateWiiPointer();
 
 @implementation PVDolphinCore
 {
-	//DolHost *dol_host;
-	uint16_t *_soundBuffer;
-	bool _isWii;
-	float _frameInterval;
-	NSString *autoLoadStatefileName;
-	NSString *_dolphinCoreModule;
-	CGSize _dolphinCoreAspect;
-	CGSize _dolphinCoreScreen;
-	NSString *_romPath;
+    //DolHost *dol_host;
+    uint16_t *_soundBuffer;
+    bool _isWii;
+    float _frameInterval;
+    NSString *autoLoadStatefileName;
+    NSString *_dolphinCoreModule;
+    CGSize _dolphinCoreAspect;
+    CGSize _dolphinCoreScreen;
+    NSString *_romPath;
 }
 
 - (instancetype)init {
-	if (self = [super init]) {
-		_videoWidth  = 640;
-		_videoHeight = 480;
-		_videoBitDepth = 32; // ignored
-		videoDepthBitDepth = 0; // TODO
-		sampleRate = 44100;
-		isNTSC = YES;
-		dispatch_queue_attr_t queueAttributes = dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL, QOS_CLASS_USER_INTERACTIVE, 0);
-		_callbackQueue = dispatch_queue_create("org.provenance-emu.dolphin.CallbackHandlerQueue", queueAttributes);
-		//dol_host = DolHost::GetInstance();
-		[self parseOptions];
-	}
-	_current = self;
-	return self;
+    if (self = [super init]) {
+        _videoWidth  = 640;
+        _videoHeight = 480;
+        _videoBitDepth = 32; // ignored
+        videoDepthBitDepth = 0; // TODO
+        sampleRate = 44100;
+        isNTSC = YES;
+        dispatch_queue_attr_t queueAttributes = dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL, QOS_CLASS_USER_INTERACTIVE, 0);
+        _callbackQueue = dispatch_queue_create("org.provenance-emu.dolphin.CallbackHandlerQueue", queueAttributes);
+        //dol_host = DolHost::GetInstance();
+        [self parseOptions];
+    }
+    _current=self;
+    return self;
 }
 
 - (void)dealloc {
-	_current = nil;
+    _current = nil;
 }
 
 #pragma mark - PVEmulatorCore
 - (BOOL)loadFileAtPath:(NSString *)path error:(NSError**)error {
-	NSBundle *coreBundle = [NSBundle bundleForClass:[self class]];
-	const char *dataPath;
-	[self initControllBuffers];
-	NSString *configPath = self.saveStatesPath;
-	dataPath = [[coreBundle resourcePath] fileSystemRepresentation];
-	[[NSFileManager defaultManager] createDirectoryAtPath:configPath
-							  withIntermediateDirectories:YES
-											   attributes:nil
-													error:nil];
-	NSString *batterySavesDirectory = self.batterySavesPath;
-	[[NSFileManager defaultManager] createDirectoryAtPath:batterySavesDirectory
-							  withIntermediateDirectories:YES
-											   attributes:nil
-													error:NULL];
-	_romPath = [path copy];
-	if([[self systemIdentifier] isEqualToString:@"com.provenance.gamecube"])
-	{
-		_dolphinCoreModule = @"gc";
-		_isWii = false;
-		_frameInterval = 60;
-		_dolphinCoreAspect = CGSizeMake(4, 3);
-		_dolphinCoreScreen = CGSizeMake(640, 480);
-		_videoWidth=640;
-		_videoHeight=480;
-	}
-	else
-	{
-		_dolphinCoreModule = @"Wii";
-		_isWii = true;
-		_frameInterval = 60;
-		_dolphinCoreAspect = CGSizeMake(16,9);
-		_dolphinCoreScreen = CGSizeMake(832, 456);
-		_videoWidth=832;
-		_videoHeight=456;
-	}
-	//	dol_host->Init([[self supportDirectoryPath] fileSystemRepresentation], [path fileSystemRepresentation] );
-	[self parseOptions];
-	return YES;
+    NSBundle *coreBundle = [NSBundle bundleForClass:[self class]];
+    const char *dataPath;
+    [self initControllBuffers];
+    NSString *configPath = self.saveStatesPath;
+    dataPath = [[coreBundle resourcePath] fileSystemRepresentation];
+    [[NSFileManager defaultManager] createDirectoryAtPath:configPath
+                              withIntermediateDirectories:YES
+                                               attributes:nil
+                                                    error:nil];
+    NSString *batterySavesDirectory = self.batterySavesPath;
+    [[NSFileManager defaultManager] createDirectoryAtPath:batterySavesDirectory
+                              withIntermediateDirectories:YES
+                                               attributes:nil
+                                                    error:NULL];
+    _romPath = [path copy];
+    if([[self systemIdentifier] isEqualToString:@"com.provenance.gamecube"])
+    {
+        _dolphinCoreModule = @"gc";
+        _isWii = false;
+        _frameInterval = 60;
+        _dolphinCoreAspect = CGSizeMake(4, 3);
+        _dolphinCoreScreen = CGSizeMake(640, 480);
+        _videoWidth=640;
+        _videoHeight=480;
+    }
+    else
+    {
+        _dolphinCoreModule = @"Wii";
+        _isWii = true;
+        _frameInterval = 60;
+        _dolphinCoreAspect = CGSizeMake(16,9);
+        _dolphinCoreScreen = CGSizeMake(832, 456);
+        _videoWidth=832;
+        _videoHeight=456;
+    }
+    //	dol_host->Init([[self supportDirectoryPath] fileSystemRepresentation], [path fileSystemRepresentation] );
+    [self parseOptions];
+    return YES;
 }
 
 /* Config at dolphin-ios/Source/Core/Core/Config */
 - (void)setOptionValues {
-	[self parseOptions];
-
+    [self parseOptions];
+    
     // Resolution upscaling
-	Config::SetBase(Config::GFX_EFB_SCALE, self.resFactor);
-	Config::SetBase(Config::GFX_MAX_EFB_SCALE, 8); // 16 but dolphini uses 8
-
-	// Graphics renderer
-	if (self.gsPreference == 0) {
-		Config::SetBase(Config::MAIN_GFX_BACKEND, "Vulkan");
-		Config::SetBase(Config::MAIN_OSD_MESSAGES, true);
-	} else if (self.gsPreference == 1) {
-		Config::SetBase(Config::MAIN_GFX_BACKEND, "OGL");
-		Config::SetBase(Config::MAIN_OSD_MESSAGES, false);
-	}
+    Config::SetBase(Config::GFX_EFB_SCALE, self.resFactor);
+    Config::SetBase(Config::GFX_MAX_EFB_SCALE, 8); // 16 but dolphini uses 8
+    
+    // Graphics renderer
+    if (self.gsPreference == 0) {
+        Config::SetBase(Config::MAIN_GFX_BACKEND, "Vulkan");
+        Config::SetBase(Config::MAIN_OSD_MESSAGES, true);
+    } else if (self.gsPreference == 1) {
+        Config::SetBase(Config::MAIN_GFX_BACKEND, "OGL");
+        Config::SetBase(Config::MAIN_OSD_MESSAGES, false);
+    }
     VideoBackendBase::PopulateBackendInfoFromUI();
     
-	// CPU
-	if (self.cpuType == 0) {
-		SConfig::GetInstance().cpu_core = PowerPC::CPUCore::Interpreter;
-		SConfig::GetInstance().m_DSPEnableJIT = false;
-		SConfig::GetInstance().bJITOff = true;
-		SConfig::GetInstance().bJITLoadStoreOff=true;
-		SConfig::GetInstance().bJITLoadStoreFloatingOff=true;
-		SConfig::GetInstance().bJITLoadStorePairedOff=true;
-		SConfig::GetInstance().bJITFloatingPointOff=true;
-		SConfig::GetInstance().bJITIntegerOff=true;
-		SConfig::GetInstance().bJITPairedOff=true;
-		SConfig::GetInstance().bJITSystemRegistersOff=true;
-		SConfig::GetInstance().bJITBranchOff=true;
-		SConfig::GetInstance().bJITRegisterCacheOff=true;
-		Config::SetBase(Config::MAIN_JIT_FOLLOW_BRANCH, false);
-		Config::SetBase(Config::MAIN_DSP_JIT, false);
-	} else if (self.cpuType == 1) {
-		SConfig::GetInstance().cpu_core = PowerPC::CPUCore::CachedInterpreter;
-		SConfig::GetInstance().m_DSPEnableJIT = false;
-	} else if (self.cpuType == 1) {
+    // CPU
+    if (self.cpuType == 0) {
+        SConfig::GetInstance().cpu_core = PowerPC::CPUCore::Interpreter;
+        SConfig::GetInstance().m_DSPEnableJIT = false;
+        SConfig::GetInstance().bJITOff = true;
+        SConfig::GetInstance().bJITLoadStoreOff=true;
+        SConfig::GetInstance().bJITLoadStoreFloatingOff=true;
+        SConfig::GetInstance().bJITLoadStorePairedOff=true;
+        SConfig::GetInstance().bJITFloatingPointOff=true;
+        SConfig::GetInstance().bJITIntegerOff=true;
+        SConfig::GetInstance().bJITPairedOff=true;
+        SConfig::GetInstance().bJITSystemRegistersOff=true;
+        SConfig::GetInstance().bJITBranchOff=true;
+        SConfig::GetInstance().bJITRegisterCacheOff=true;
+        Config::SetBase(Config::MAIN_JIT_FOLLOW_BRANCH, false);
+        Config::SetBase(Config::MAIN_DSP_JIT, false);
+    } else if (self.cpuType == 1) {
+        SConfig::GetInstance().cpu_core = PowerPC::CPUCore::CachedInterpreter;
+        SConfig::GetInstance().m_DSPEnableJIT = false;
+    } else if (self.cpuType == 2) {
 #if defined(__x86_64__)
-        SConfig::GetInstance().cpu_core = PowerPC::CPUCore::JIT64;
+        Config::SetBase(Config::MAIN_CPU_CORE, PowerPC::CPUCore::JIT64);
 #else
-        SConfig::GetInstance().cpu_core = PowerPC::CPUCore::JITARM64;
+        Config::SetBase(Config::MAIN_CPU_CORE, PowerPC::CPUCore::JITARM64);
 #endif
         SConfig::GetInstance().m_DSPEnableJIT = true;
         SConfig::GetInstance().bJITOff = false;
@@ -247,13 +246,19 @@ void UpdateWiiPointer();
         Config::SetBase(Config::MAIN_DSP_JIT, true);
     }
     
-	// Filtering
-	Config::SetBase(Config::GFX_ENHANCE_FORCE_FILTERING, self.isBilinear);
-
-	// Fast Mem
-	SConfig::GetInstance().bFastmem = self.fastMemory;
-
-	// Anti Aliasing
+    SConfig::GetInstance().m_WiiKeyboard = false;
+    SConfig::GetInstance().m_WiiSDCard = true;
+    SConfig::GetInstance().bEnableMemcardSdWriting = true;
+    SConfig::GetInstance().bAutomaticStart = true;
+    SConfig::GetInstance().m_bt_passthrough_enabled = false;
+    
+    // Filtering
+    Config::SetBase(Config::GFX_ENHANCE_FORCE_FILTERING, self.isBilinear);
+    
+    // Fast Mem
+    SConfig::GetInstance().bFastmem = self.fastMemory;
+    
+    // Anti Aliasing
     if (self.gsPreference == 0) {
         Config::SetBase(Config::GFX_MSAA, self.msaa);
         Config::SetBase(Config::GFX_SSAA, self.ssaa);
@@ -261,186 +266,227 @@ void UpdateWiiPointer();
         Config::SetBase(Config::GFX_MSAA, 1);
         Config::SetBase(Config::GFX_SSAA, false);
     }
-
-	// Cheats
-    SConfig::GetInstance().bEnableCheats = true;
-
-	// CPU Overclock
-	Config::SetBase(Config::MAIN_CPU_THREAD, true);
-	SConfig::GetInstance().m_OCFactor = self.cpuOClock;
-	SConfig::GetInstance().m_OCEnable = true;
-
-	// CPU High Level / Low Level Emulation (Low Level is slower but better)
-	SConfig::GetInstance().bDSPHLE = true;
-	//Core::SetIsThrottlerTempDisabled(true);
-
-	// Wiimote
-	//SConfig::GetInstance().m_WiimoteContinuousScanning = true;
-	Config::SetBase(Config::SYSCONF_WIIMOTE_MOTOR, false);
-
-	// Wait for Shaders
-	Config::SetBase(Config::GFX_WAIT_FOR_SHADERS_BEFORE_STARTING, true);
-
-	// Must be set to false (will crash if set to other values)
-	SConfig::GetInstance().bMMU = false;
-	//SConfig::GetInstance().bDSPThread = false;
-	//Config::SetBase(Config::GFX_ENABLE_GPU_TEXTURE_DECODING, false);
-
-	// Sync
-	Config::SetBase(Config::MAIN_SYNC_ON_SKIP_IDLE, true);
-	Config::SetBase(Config::MAIN_SYNC_GPU, false);
-	Config::SetBase(Config::MAIN_SYNC_GPU_MAX_DISTANCE, 200000);
-	Config::SetBase(Config::MAIN_SYNC_GPU_MIN_DISTANCE, -200000);
-	Config::SetBase(Config::MAIN_SYNC_GPU_OVERCLOCK, 1.0);
-	Config::SetBase(Config::MAIN_FPRF, false);
-	Config::SetBase(Config::MAIN_ACCURATE_NANS, false);
-	Config::SetBase(Config::MAIN_TIMING_VARIANCE, 40);
-	Config::SetBase(Config::MAIN_SKIP_IPL, true);
-
-	//Audio
-	Config::SetBase(Config::MAIN_AUDIO_LATENCY, 22);
-
-	//Debug Settings
-	SConfig::GetInstance().bEnableDebugging = false;
-	SConfig::GetInstance().m_ShowFrameCount = false;
-
-	// Graphics Multithreading
-	//Config::SetBase(Config::GFX_BACKEND_MULTITHREADING, false);
-	//Config::SetBase(Config::GFX_SAVE_TEXTURE_CACHE_TO_STATE, false);
-	//Config::SetBase(Config::GFX_SHADER_COMPILATION_MODE, ShaderCompilationMode::Synchronous);
-	//Config::SetBase(Config::GFX_SHADER_COMPILER_THREADS, 1);
-	//Config::SetBase(Config::GFX_SHADER_PRECOMPILER_THREADS, 1);
-
-	// Social
-	Discord::SetDiscordPresenceEnabled(false);
-
-	// Alerts
-	Common::SetEnableAlert(false);
-
-	SConfig::GetInstance().SaveSettings();
+    
+    // Cheats
+    SConfig::GetInstance().bEnableCheats = self.enableCheatCode;
+    
+    // CPU Overclock
+    Config::SetBase(Config::MAIN_CPU_THREAD, true);
+    SConfig::GetInstance().m_OCFactor = self.cpuOClock;
+    SConfig::GetInstance().m_OCEnable = true;
+    
+    // CPU High Level / Low Level Emulation (Low Level is slower but better)
+    SConfig::GetInstance().bDSPHLE = true;
+    //Core::SetIsThrottlerTempDisabled(true);
+    
+    // Wiimote
+    //SConfig::GetInstance().m_WiimoteContinuousScanning = true;
+    Config::SetBase(Config::SYSCONF_WIIMOTE_MOTOR, false);
+    
+    // Wait for Shaders
+    //Config::SetBase(Config::GFX_WAIT_FOR_SHADERS_BEFORE_STARTING, true);
+    
+    // Must be set to false (will crash if set to other values)
+    SConfig::GetInstance().bMMU = false;
+    //SConfig::GetInstance().bDSPThread = false;
+    //Config::SetBase(Config::GFX_ENABLE_GPU_TEXTURE_DECODING, false);
+    
+    // Sync
+    Config::SetBase(Config::MAIN_SYNC_ON_SKIP_IDLE, true);
+    Config::SetBase(Config::MAIN_SYNC_GPU, false);
+    Config::SetBase(Config::MAIN_SYNC_GPU_MAX_DISTANCE, 200000);
+    Config::SetBase(Config::MAIN_SYNC_GPU_MIN_DISTANCE, -200000);
+    Config::SetBase(Config::MAIN_SYNC_GPU_OVERCLOCK, 1.0);
+    Config::SetBase(Config::MAIN_FPRF, false);
+    Config::SetBase(Config::MAIN_ACCURATE_NANS, false);
+    Config::SetBase(Config::MAIN_TIMING_VARIANCE, 40);
+    Config::SetBase(Config::MAIN_SKIP_IPL, true);
+    
+    //Audio
+    Config::SetBase(Config::MAIN_AUDIO_LATENCY, 20);
+    
+    //Debug Settings
+    SConfig::GetInstance().bEnableDebugging = false;
+    SConfig::GetInstance().m_ShowFrameCount = false;
+    
+    // Graphics Multithreading
+    //Config::SetBase(Config::GFX_BACKEND_MULTITHREADING, false);
+    //Config::SetBase(Config::GFX_SAVE_TEXTURE_CACHE_TO_STATE, false);
+    //Config::SetBase(Config::GFX_SHADER_COMPILATION_MODE, ShaderCompilationMode::Synchronous);
+    //Config::SetBase(Config::GFX_SHADER_COMPILER_THREADS, 1);
+    //Config::SetBase(Config::GFX_SHADER_PRECOMPILER_THREADS, 1);
+    
+    // Other
+    //Config::SetBase(Config::GFX_HACK_EFB_EMULATE_FORMAT_CHANGES, 1);
+    //Config::SetBase(Config::GFX_HACK_DEFER_EFB_COPIES, 0);
+    //Config::SetBase(Config::GFX_HACK_FORCE_LOGICOPS_FALLBACK, 1);
+    //Config::SetBase(Config::GFX_STEREO_CONVERGENCE, 613);
+    
+    // Social
+    Discord::SetDiscordPresenceEnabled(false);
+    
+    // Alerts
+    Common::SetEnableAlert(false);
+    
+    //SConfig::GetInstance().SaveSettings();
 }
 
 #pragma mark - Running
 - (void)setupEmulation {
-    NSString* saveDirectory = [self.batterySavesPath stringByAppendingPathComponent:@"/saves/"];
-	user_dir = std::string([saveDirectory UTF8String]);
+    NSError *error;
+    NSFileManager *fm = [[NSFileManager alloc] init];
+    NSString* saveDirectory = [self.batterySavesPath stringByAppendingPathComponent:@"../DolphinData" ];
+    // Copy Sys Bundle
+    NSString *sysPath = [[NSBundle bundleForClass:[PVDolphinCore class]] pathForResource:@"Sys" ofType:nil];
+    if (![fm fileExistsAtPath: saveDirectory]) {
+        if(![fm copyItemAtPath:sysPath toPath:saveDirectory error:&error]) {
+            NSLog(@"Error copying the sys files: %@", [error description]);
+        }
+        
+    }
+    // Copy Wii Files (needed to boot some games)
+    NSString *wiiPath = [[NSBundle bundleForClass:[PVDolphinCore class]] pathForResource:@"Sys/Wii/" ofType:nil];
+    NSString* wiiDestDirectory = [self.batterySavesPath stringByAppendingPathComponent:@"../DolphinData/Wii/" ];
+    for(NSString *file in wiiPath)
+    {
+        NSString *src= [wiiPath stringByAppendingString:file];
+        NSString *dst = [wiiDestDirectory stringByAppendingString:file];
+        if (![fm fileExistsAtPath: dst]) {
+            [fm copyItemAtPath:src toPath:dst error:nil];
+        }
+    }
+    // Copy gecko code handler from resource bundle
+    NSString *filePath = [[NSBundle bundleForClass:[PVDolphinCore class]] pathForResource:@"Sys/codehandler.bin" ofType:nil];
+    NSString *codeHandler = [saveDirectory stringByAppendingPathComponent:@"codehandler.bin"];
+    if (![fm fileExistsAtPath: codeHandler]) {
+        if(![fm copyItemAtPath:filePath toPath:codeHandler error:&error]) {
+            NSLog(@"Error copying the gecko handler: %@", [error description]);
+        }
+    }
+    user_dir = std::string([saveDirectory UTF8String]);
     Common::RegisterMsgAlertHandler(&MsgAlert);
     UICommon::SetUserDirectory(user_dir);
     UICommon::CreateDirectories();
-    // Copy gecko code handler from resource bundle
-    NSFileManager *fmngr = [[NSFileManager alloc] init];
-    NSString *filePath = [[NSBundle bundleForClass:[PVDolphinCore class]] pathForResource:@"Sys/codehandler.bin" ofType:nil];
-    NSError *error;
-    if(![fmngr copyItemAtPath:filePath toPath:[saveDirectory stringByAppendingPathComponent:@"codehandler.bin"] error:&error]) {
-        NSLog(@"Error copying the gecko handler: %@", [error description]);
-    }
-    // Init with files
-	UICommon::Init();
+    UICommon::Init();
     ILOG(@"User Directory set to '%s'\n", user_dir.c_str());
 }
 
 - (void)startVM:(UIView *)view {
     ILOG(@"Starting VM\n");
-	dispatch_async(dispatch_get_global_queue(0, 0), ^{
-		std::unique_lock<std::mutex> guard(s_host_identity_lock);
-		__block WindowSystemInfo wsi;
-		wsi.type = WindowSystemType::IPhoneOS;
-		wsi.display_connection = nullptr;
-		dispatch_sync(dispatch_get_main_queue(), ^{
-			wsi.render_surface = (__bridge void*)view.layer;
-		});
-		wsi.render_surface_scale = [UIScreen mainScreen].scale;
-		VideoBackendBase::ActivateBackend(Config::Get(Config::MAIN_GFX_BACKEND));
-		ILOG(@"Using GFX backend: %s\n", Config::Get(Config::MAIN_GFX_BACKEND).c_str());
-		std::string gamePath=std::string([_romPath UTF8String]);
-		std::vector<std::string> normalized_game_paths;
-		normalized_game_paths.push_back(gamePath);
-		[self setupControllers];
-		if (!BootManager::BootCore(BootParameters::GenerateFromFile(normalized_game_paths), wsi))
-		{
+    // Ensure core is stopped (otherwise game lags)
+    Core::Stop();
+    while (Core::GetState() != Core::State::Uninitialized) {
+       sleep(1);
+    }
+    dispatch_async(dispatch_get_global_queue(0, 0), ^{
+        std::unique_lock<std::mutex> guard(s_host_identity_lock);
+        __block WindowSystemInfo wsi;
+        wsi.type = WindowSystemType::IPhoneOS;
+        wsi.display_connection = nullptr;
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            wsi.render_surface = (__bridge void*)view.layer;
+        });
+        wsi.render_surface_scale = [UIScreen mainScreen].scale;
+        VideoBackendBase::ActivateBackend(Config::Get(Config::MAIN_GFX_BACKEND));
+        ILOG(@"Using GFX backend: %s\n", Config::Get(Config::MAIN_GFX_BACKEND).c_str());
+        std::string gamePath=std::string([_romPath UTF8String]);
+        std::vector<std::string> normalized_game_paths;
+        normalized_game_paths.push_back(gamePath);
+        [self setupControllers];
+        if (!BootManager::BootCore(BootParameters::GenerateFromFile(normalized_game_paths), wsi))
+        {
             ILOG(@"Could not boot %s\n", [_romPath UTF8String]);
-			return;
-		}
-		AudioCommon::SetSoundStreamRunning(true);
-		while (Core::GetState() == Core::State::Starting && !Core::IsRunning())
-		{
-			Common::SleepCurrentThread(100);
-		}
-		_isInitialized = true;
-        while (_isInitialized)
-		{
-			guard.unlock();
-			s_update_main_frame_event.Wait();
-			guard.lock();
-			Core::HostDispatchJobs();
-		}
+            return;
+        }
+        AudioCommon::SetSoundStreamRunning(true);
+        while (Core::GetState() == Core::State::Starting && !Core::IsRunning())
+        {
+            Common::SleepCurrentThread(100);
+        }
+        _isInitialized = true;
+        _isOff = false;
         ILOG(@"VM Started\n");
-	});
+        while (_isInitialized)
+        {
+            guard.unlock();
+            s_update_main_frame_event.Wait();
+            guard.lock();
+            Core::HostDispatchJobs();
+        }
+        _isOff=true;
+    });
 }
 
 - (void)startEmulation {
     // Skip Emulation Loop since the core has its own loop
     self.skipEmulationLoop = true;
-	[self setupEmulation];
-	[self setOptionValues];
-	[self setupView];
-	[super startEmulation];
-	//		[self.renderDelegate willRenderFrameOnAlternateThread];
-	//		dol_host->SetPresentationFBO((int)[[self.renderDelegate presentationFramebuffer] integerValue]);
-	//if(dol_host->LoadFileAtPath())
-	//_frameInterval = dol_host->GetFrameInterval();
-	//Disable the OE framelimiting
-	//	[self.renderDelegate suspendFPSLimiting];
-	//	if(!self.isRunning) {
-	//		[super startEmulation];
-	////        [NSThread detachNewThreadSelector:@selector(runReicastRenderThread) toTarget:self withObject:nil];
-	//	}
+    [self setupEmulation];
+    [self setOptionValues];
+    [self setupView];
+    [super startEmulation];
+    //		[self.renderDelegate willRenderFrameOnAlternateThread];
+    //		dol_host->SetPresentationFBO((int)[[self.renderDelegate presentationFramebuffer] integerValue]);
+    //if(dol_host->LoadFileAtPath())
+    //_frameInterval = dol_host->GetFrameInterval();
+    //Disable the OE framelimiting
+    //	[self.renderDelegate suspendFPSLimiting];
+    //	if(!self.isRunning) {
+    //		[super startEmulation];
+    ////        [NSThread detachNewThreadSelector:@selector(runReicastRenderThread) toTarget:self withObject:nil];
+    //	}
 }
 
 - (void)runReicastEmuThread {
-	@autoreleasepool
-	{
-		//[self reicastMain];
-		// Core returns
-		// Unlock rendering thread
-		//dispatch_semaphore_signal(coreWaitToEndFrameSemaphore);
-		[super stopEmulation];
-	}
+    @autoreleasepool
+    {
+        //[self reicastMain];
+        // Core returns
+        // Unlock rendering thread
+        //dispatch_semaphore_signal(coreWaitToEndFrameSemaphore);
+        [super stopEmulation];
+    }
 }
 
 - (void)setPauseEmulation:(BOOL)flag {
-	//dol_host->Pause(flag);
-	Core::State state = flag ? Core::State::Paused : Core::State::Running;
-	Core::SetState(state);
-	[super setPauseEmulation:flag];
+    //dol_host->Pause(flag);
+    Core::State state = flag ? Core::State::Paused : Core::State::Running;
+    Core::SetState(state);
+    [super setPauseEmulation:flag];
 }
 
 - (void)stopEmulation {
-	[super stopEmulation];
-	self->shouldStop = YES;
-	_isInitialized = false;
-	Core::SetState(Core::State::Running);
-	ProcessorInterface::PowerButton_Tap();
-	Core::Stop();
-	while (CPU::GetState() != CPU::State::PowerDown)
-		Common::SleepCurrentThread(1000);
-	Core::Shutdown();
-	s_host_identity_lock.unlock();
-	//dol_host->RequestStop();
-	//dispatch_semaphore_signal(mupenWaitToBeginFrameSemaphore);
-	//dispatch_semaphore_wait(coreWaitForExitSemaphore, DISPATCH_TIME_FOREVER);
-	//[self.frontBufferCondition lock];
-	//[self.frontBufferCondition signal];
-	//[self.frontBufferCondition unlock];
+    [super stopEmulation];
+    self->shouldStop = YES;
+    _isInitialized = false;
+    Core::SetState(Core::State::Running);
+    ProcessorInterface::PowerButton_Tap();
+    Core::Stop();
+    s_update_main_frame_event.Set();
+    while (CPU::GetState() != CPU::State::PowerDown ||
+           Core::GetState() != Core::State::Uninitialized ||
+           !_isOff) {
+        Common::SleepCurrentThread(100);
+    }
+    Core::Shutdown();
+    
+    VertexLoaderManager::Clear();
+    Fifo::Shutdown();
+    //g_video_backend->ShutdownShared();
+    s_host_identity_lock.unlock();
+    [m_view removeFromSuperview];
+    [m_view_controller dismissViewControllerAnimated:NO completion:nil];
+    m_gl_layer = nullptr;
+    m_metal_layer = nullptr;
+    m_view_controller = nullptr;
+    m_view=nullptr;
+    AudioCommon::ShutdownSoundStream();
+    g_renderer.release();
 }
+-(void)startHaptic { }
+-(void)stopHaptic { }
 
 - (void)resetEmulation {
 	ProcessorInterface::ResetButton_Tap();
-	//dol_host->Reset();
-	//dispatch_semaphore_signal(mupenWaitToBeginFrameSemaphore);
-	//[self.frontBufferCondition lock];
-	//[self.frontBufferCondition signal];
-	//[self.frontBufferCondition unlock];
 }
 
 - (void)refreshScreenSize {
@@ -459,6 +505,7 @@ void UpdateWiiPointer();
 													  videoHeight: self.videoHeight
 													  core: self];
 		m_metal_layer=(CAMetalLayer *)cgsh_view_controller.view.layer;
+        m_view_controller=(UIViewController *)cgsh_view_controller;
 		m_view=cgsh_view_controller.view;
         m_view.contentMode = UIViewContentModeScaleToFill;
         [gl_view_controller addChildViewController:cgsh_view_controller];
@@ -470,6 +517,7 @@ void UpdateWiiPointer();
 													  videoHeight: self.videoHeight
 													  core: self];
 		m_gl_layer=(CAEAGLLayer *)cgsh_view_controller.view.layer;
+        m_view_controller=(UIViewController *)cgsh_view_controller;
 		m_view=cgsh_view_controller.view;
 		m_view.contentMode = UIViewContentModeScaleToFill;
         [gl_view_controller addChildViewController:cgsh_view_controller];
@@ -487,6 +535,8 @@ void UpdateWiiPointer();
         gl_view_controller.view.autoresizesSubviews=true;
         gl_view_controller.view.clipsToBounds=true;
 		[gl_view_controller.view addSubview:m_view];
+        [m_view.widthAnchor constraintGreaterThanOrEqualToAnchor:gl_view_controller.view.widthAnchor].active=true;
+        [m_view.heightAnchor constraintGreaterThanOrEqualToAnchor:gl_view_controller.view.heightAnchor constant: 0].active=true;
 		[m_view.topAnchor constraintEqualToAnchor:gl_view_controller.view.topAnchor constant:0].active = true;
 		[m_view.leadingAnchor constraintEqualToAnchor:gl_view_controller.view.leadingAnchor constant:0].active = true;
 		[m_view.trailingAnchor constraintEqualToAnchor:gl_view_controller.view.trailingAnchor constant:0].active = true;

--- a/Cores/Dolphin/PVDolphinCore/Core/PVDolphinCore.swift
+++ b/Cores/Dolphin/PVDolphinCore/Core/PVDolphinCore.swift
@@ -37,6 +37,14 @@ extension PVDolphinCore: CoreOptional {
 			requiresRestart: true),
 		defaultValue: false)
 	}()
+    
+    static var enableCheatOption: CoreOption = {
+        .bool(.init(
+            title: "Enable Cheat Codes (Runs Slower)",
+            description: nil,
+            requiresRestart: true),
+        defaultValue: false)
+    }()
 
 	static var msaaOption: CoreOption = {
 		 .enumeration(.init(title: "Multi Surface Anti-Aliasing",
@@ -97,7 +105,7 @@ extension PVDolphinCore: CoreOptional {
 		let coreOptions: [CoreOption] = [
 			resolutionOption, gsOption, forceBilinearFilteringOption,
 			cpuOption, msaaOption, ssaaOption, cpuClockOption,
-			fastMemoryOption]
+			fastMemoryOption, enableCheatOption]
 		let coreGroup:CoreOption = .group(.init(title: "Dolphin! Core",
 												description: "Global options for Dolphin!"),
 										  subOptions: coreOptions)
@@ -122,6 +130,9 @@ extension PVDolphinCore: CoreOptional {
 	@objc var cpuClock: Int{
 		PVDolphinCore.valueForOption(PVDolphinCore.cpuClockOption).asInt ?? 0
 	}
+    @objc var enableCheatOption: Bool{
+        PVDolphinCore.valueForOption(PVDolphinCore.enableCheatOption).asBool
+    }
 	@objc var msaaOption: Int{
 		PVDolphinCore.valueForOption(PVDolphinCore.msaaOption).asInt ?? 0
 	}
@@ -141,6 +152,7 @@ extension PVDolphinCore: CoreOptional {
 		if self.msaa < 2 {
 			self.ssaa=false
 		}
+        self.enableCheatCode = enableCheatOption
 		self.fastMemory = fastMemoryOption
 		self.cpuOClock = NSNumber(value: cpuClock).int8Value
 	}

--- a/Cores/PPSSPP/PVPPSSPPCore/Core/PVPPSSPPCore+Video.mm
+++ b/Cores/PPSSPP/PVPPSSPPCore/Core/PVPPSSPPCore+Video.mm
@@ -46,7 +46,7 @@
 #include "Common/File/VFS/VFS.h"
 #include "Common/File/VFS/AssetReader.h"
 #include "Common/Data/Text/I18n.h"
-#include "Common/StringUtils.h""
+#include "Common/StringUtils.h"
 #include "Common/System/Display.h"
 #include "Common/System/NativeApp.h"
 #include "Common/System/System.h"
@@ -64,7 +64,7 @@
 #include "Common/GraphicsContext.h"
 
 #include "GPU/GPUState.h"
-#include "GPU/GPUInterface.h""
+#include "GPU/GPUInterface.h"
 
 #include "Core/Config.h"
 #include "Core/ConfigValues.h"
@@ -145,7 +145,7 @@ static bool threadStopped = false;
 	 dp_yres = pixel_yres * g_dpi_scale_y;
 	 pixel_in_dps_x = (float)pixel_xres / (float)dp_xres;
 	 pixel_in_dps_y = (float)pixel_yres / (float)dp_yres;
-	 [m_view setContentScaleFactor:self.gsPreference * scale];
+	 [m_view setContentScaleFactor:scale];
 	 // PSP native resize
 	 PSP_CoreParameter().pixelWidth = pixel_xres;
 	 PSP_CoreParameter().pixelHeight = pixel_yres;
@@ -217,7 +217,7 @@ static bool threadStopped = false;
         [m_view.widthAnchor constraintGreaterThanOrEqualToConstant:bounds.size.width].active=true;
         [m_view.heightAnchor constraintGreaterThanOrEqualToAnchor:gl_view_controller.view.heightAnchor constant: 0].active=true;;
         [m_view.topAnchor constraintEqualToAnchor:gl_view_controller.view.topAnchor constant:0].active = true;
-        [m_view.leadingAnchor constraintEqualToAnchor:gl_view_controller.view.superview.leadingAnchor constant:0].active = true;
+        [m_view.leadingAnchor constraintEqualToAnchor:gl_view_controller.view.leadingAnchor constant:0].active = true;
         [m_view.trailingAnchor constraintEqualToAnchor:gl_view_controller.view.trailingAnchor constant:0].active = true;
         [m_view.bottomAnchor constraintEqualToAnchor:gl_view_controller.view.bottomAnchor constant:0].active = true;
     }


### PR DESCRIPTION
### What does this PR do
   Dolphin requires Wii system directory files to launch some games, so dolphin core now copies over entire Data/Sys to DolphinData directory (shared by all dolphin core games) if it doesn't exist. The games run much faster with cheat code disabled, so this is added as an option. (by default cheat code is disabled) Also nunchuck axis are added to dpad input so on screen dpad sends input for both types of games. Minor scaling adjustment on PPSSPP so stretch mode fills the screen. Nunchuck extension's added to the controller ini file so that games that require nunchuck to be connected to the wiimote recognizes it as connected. Dolphin's speed is very sensitive to initialization / cleanup between launches so additional cleanup after / before launch is added to keep speed.


### Where should the reviewer start

### How should this be manually tested

### Any background context you want to provide

### What are the relevant tickets

### Screenshots (important for UI changes)

### Questions
