### PR TITLE
PPSSPP: Fix Game Freezing after 5 minutes, Save Adjustments / Joypad support

### DIFF
--- a/Cores/Mednafen/MednafenGameCore.h
+++ b/Cores/Mednafen/MednafenGameCore.h
@@ -50,30 +50,23 @@ typedef NS_ENUM(NSInteger, MednaSystem) {
 };
 
 #pragma mark - Input maps
-static int GBAMap[PVGBAButtonCount];
-static int GBMap[PVGBButtonCount];
-static int SNESMap[PVSNESButtonCount];
-static int NESMap[PVNESButtonCount];
-static int PCEMap[PVPCEButtonCount];
-static int PCFXMap[PVPCFXButtonCount];
-
-// Map OE button order to Mednafen button order
-
+static int PCEMap[] = { 4, 6, 7, 5, 0, 1, 8, 9, 10, 11, 3, 2, 12};
+static int PCFXMap[] = { 8, 10, 11, 9, 0, 1, 2, 3, 4, 5, 7, 6, 12};
+static int SNESMap[] = { 4, 5, 6, 7, 8, 0, 9, 1, 10, 11, 3, 2 };
+static int GBMap[] = { 6, 7, 5, 4, 0, 1, 3, 2 };
+static int GBAMap[] = { 6, 7, 5, 4, 0, 1, 9, 8, 3, 2};
+// ↑, ↓, ←, →, A, B, Start, Select
+static int NESMap[] = { 4, 5, 6, 7, 0, 1, 3, 2 };
 // Pause, B, 1, 2, ↓, ↑, ←, →
 static const int LynxMap[] = { 6, 7, 4, 5, 0, 1, 3, 2 };
-
-// ↑, ↓, ←, →, A, B, Start, Select
-//const int NESMap[PVNESButtonCount] = { 4, 5, 6, 7, 0, 1, 3, 2};
 
 // Select, [Triangle], [X], Start, R1, R2, left stick u, left stick left,
 static const int PSXMap[]  = { 4, 6, 7, 5, 12, 13, 14, 15, 10, 8, 1, 11, 9, 2, 3, 0, 16, 24, 23, 22, 21, 20, 19, 18, 17 };
 static const int VBMap[]   = { 9, 8, 7, 6, 4, 13, 12, 5, 3, 2, 0, 1, 10, 11 };
 static const int WSMap[]   = { 0, 2, 3, 1, 4, 6, 7, 5, 9, 10, 8, 11 };
 static const int NeoMap[]  = { 0, 1, 2, 3, 4, 5, 6};
-
 // SS Sega Saturn
-static int SSMap[PVSaturnButtonCount]; //   = { 4, 5, 6, 7, 10, 8, 9, 2, 1, 0, 15, 3, 11 };
-
+static int SSMap[] = { 4, 5, 6, 7, 10, 8, 9, 2, 1, 0, 15, 3, 11 };
 // SMS, GG and MD unused as of now. Mednafen support is not maintained
 static const int GenesisMap[] = { 5, 7, 11, 10, 0 ,1, 2, 3, 4, 6, 8, 9};
 

--- a/Cores/Mednafen/MednafenGameCore.mm
+++ b/Cores/Mednafen/MednafenGameCore.mm
@@ -833,8 +833,10 @@ static void emulation_run(BOOL skipFrame) {
         //            }
         //        }
     }
-    else
-    {
+    else if (self.systemType == MednaSystemGBA) {
+        // gba sets all of these in 1 variable, so setting the one we use
+        game->SetInput(0, "gamepad", (uint8_t *)inputBuffer[0]);
+    } else {
         game->SetInput(0, "gamepad", (uint8_t *)inputBuffer[0]);
         game->SetInput(1, "gamepad", (uint8_t *)inputBuffer[1]);
 //        game->SetInput(2, "gamepad", (uint8_t *)inputBuffer[2]);

--- a/Cores/PPSSPP/PVPPSSPP/Core.plist
+++ b/Cores/PPSSPP/PVPPSSPP/Core.plist
@@ -15,6 +15,6 @@
 	<key>PVProjectURL</key>
 	<string>https://github.com/hrydgard/ppsspp.git</string>
 	<key>PVProjectVersion</key>
-	<string>3.2.0b2 (186)</string>
+	<string>v1.13.2-2467</string>
 </dict>
 </plist>

--- a/Cores/PPSSPP/PVPPSSPPCore/Core/PVPPSSPPCore+Controls.mm
+++ b/Cores/PPSSPP/PVPPSSPPCore/Core/PVPPSSPPCore+Controls.mm
@@ -238,7 +238,7 @@ extern bool _isInitialized;
 }
 
 - (void)didMovePSPJoystickDirection:(PVPSPButton)button withValue:(CGFloat)value forPlayer:(NSInteger)player {
-	[self sendPSPButtonInput:(PVPSPButton)button isPressed:true withValue:value forPlayer:player];
+	[self sendPSPButtonInput:(PVPSPButton)button isPressed:value != 0 withValue:value forPlayer:player];
 }
 
 -(void)didMoveJoystick:(NSInteger)button withValue:(CGFloat)value forPlayer:(NSInteger)player {
@@ -293,15 +293,19 @@ extern bool _isInitialized;
 			[self gamepadEventOnPad:player button:NKCODE_BUTTON_12 action:(pressed?1:0)];
 			break;
 		case(PVPSPButtonLeftAnalogLeft):
-			[self gamepadMoveEventOnPad:player axis:JOYSTICK_AXIS_X value:CGFloat(value)];
+            value *= 3;
+			[self gamepadMoveEventOnPad:player axis:JOYSTICK_AXIS_X value:CGFloat(-value)];
 			break;
 		case(PVPSPButtonLeftAnalogRight):
+            value *= 3;
 			[self gamepadMoveEventOnPad:player axis:JOYSTICK_AXIS_X value:CGFloat(value)];
 			break;
 		case(PVPSPButtonLeftAnalogUp):
-			[self gamepadMoveEventOnPad:player axis:JOYSTICK_AXIS_Y value:CGFloat(value)];
+            value *= 3;
+			[self gamepadMoveEventOnPad:player axis:JOYSTICK_AXIS_Y value:CGFloat(-value)];
 			break;
 		case(PVPSPButtonLeftAnalogDown):
+            value *= 3;
 			[self gamepadMoveEventOnPad:player axis:JOYSTICK_AXIS_Y value:CGFloat(value)];
 			break;
 		case(PVPSPButtonLeft):

--- a/Cores/PPSSPP/PVPPSSPPCore/Core/PVPPSSPPCore+Video.mm
+++ b/Cores/PPSSPP/PVPPSSPPCore/Core/PVPPSSPPCore+Video.mm
@@ -256,8 +256,11 @@ static bool threadStopped = false;
 	dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
 		NativeInitGraphics(graphicsContext);
 		_isInitialized=true;
-		ELOG(@"Emulation thread starting\n");
-		UpdateUIState(UISTATE_INGAME);
+        UpdateUIState(UISTATE_INGAME);
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+            isPaused=false;
+        });
+        ELOG(@"Emulation thread starting\n");
 		while (threadEnabled) {
 			NativeUpdate();
 			NativeRender(graphicsContext);

--- a/Cores/PPSSPP/PVPPSSPPCore/Core/PVPPSSPPCore.mm
+++ b/Cores/PPSSPP/PVPPSSPPCore/Core/PVPPSSPPCore.mm
@@ -201,7 +201,7 @@
 	// Core Options
 	PSP_CoreParameter().fileToStart     = Path(std::string([_romPath UTF8String]));
 	PSP_CoreParameter().mountIso.clear();
-	PSP_CoreParameter().startBreak      = true;
+    PSP_CoreParameter().startBreak      = false;
 	PSP_CoreParameter().enableSound     = true;
 	PSP_CoreParameter().printfEmuLog    = true;
 	PSP_CoreParameter().headLess        = false;
@@ -234,14 +234,13 @@
 }
 
 - (void)setPauseEmulation:(BOOL)flag {
-    // Here we actually pause from 2nd time on
     ELOG(@"We are right now Paused: %d %d -> %d\n", isPaused, self.isEmulationPaused, flag);
-    [super setPauseEmulation:flag];
     if (flag == isPaused) return;
     if (flag != isPaused || flag != self.isEmulationPaused) {
         Core_EnableStepping(flag, "ui.lost_focus", 0);
         isPaused=flag;
 	}
+    [super setPauseEmulation:flag];
 }
 
 - (void)stopEmulation {

--- a/Cores/PPSSPP/PVPPSSPPCore/Core/VulkanGraphicsContext.h
+++ b/Cores/PPSSPP/PVPPSSPPCore/Core/VulkanGraphicsContext.h
@@ -1,55 +1,207 @@
 //
 //  VulkanGraphicsContext.h
 //  PVPPSSPP
-//  Copyright © 2022 Provenance Emu. All rights reserved.
+//  Copyright (c) 2012- PPSSPP Project.
 //
+
+#import "PVPPSSPPCore.h"
+#import "PVPPSSPPCore+Controls.h"
+#import "PVPPSSPPCore+Audio.h"
+#import "PVPPSSPPCore+Video.h"
+#import <PVPPSSPP/PVPPSSPP-Swift.h>
+#import <Foundation/Foundation.h>
+#import <PVSupport/PVSupport.h>
+#import <PVSupport/PVLogging.h>
+
+/* PPSSPP Includes */
+#include <vector>
+#include <string>
+#include <cstring>
+
+#include "Common/System/Display.h"
+#include "Common/System/NativeApp.h"
+#include "Common/System/System.h"
+#include "Common/GPU/Vulkan/VulkanContext.h"
+#include "Common/GPU/Vulkan/VulkanDebug.h"
+#include "Common/GPU/Vulkan/VulkanLoader.h"
+#include "Common/GPU/Vulkan/VulkanRenderManager.h"
+#include "Common/GPU/thin3d.h"
+#include "Common/GPU/thin3d_create.h"
+#include "Common/Data/Text/Parsers.h"
+#include "Common/VR/PPSSPPVR.h"
+#include "Common/Log.h"
+#include "Core/Config.h"
+#include "Core/ConfigValues.h"
+#include "Core/System.h"
+#if !PPSSPP_PLATFORM(WINDOWS) && !PPSSPP_PLATFORM(SWITCH)
+#include <dlfcn.h>
+#endif
 
 #ifndef VulkanGraphicsContext_h
 #define VulkanGraphicsContext_h
 
+typedef void *VulkanLibraryHandle;
+static VulkanLibraryHandle vulkanLibrary;
+#define LOAD_GLOBAL_FUNC(x) x = (PFN_ ## x)dlsym(vulkanLibrary, #x); if (!x) { ELOG(@"Missing (global): %s", #x);}
+
 class VulkanGraphicsContext : public GraphicsContext {
 public:
 	VulkanGraphicsContext() {
-		CheckGLExtensions();
-		draw_ = Draw::T3DCreateGLContext();
-		renderManager_ = (GLRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
-		renderManager_->SetInflightFrames(g_Config.iInflightFrames);
-		SetGPUBackend(GPUBackend::OPENGL);
-		g_Config.iGPUBackend = (int)GPUBackend::OPENGL;
-		bool success = draw_->CreatePresets();
-		_assert_msg_(success, "Failed to compile preset shaders");
 	}
+
 	~VulkanGraphicsContext() {
-		delete draw_;
+        delete g_Vulkan;
+        g_Vulkan = nullptr;
 	}
+
+	VulkanGraphicsContext(CAMetalLayer* layer, const char* vulkan_path) {
+		bool success = false;
+		ELOG(@"Init");
+		init_glslang();
+		ELOG(@"Creating Vulkan context");
+		Version gitVer(PPSSPP_GIT_VERSION);
+		if (!this->VulkanLoad(vulkan_path)) {
+			ELOG(@"Failed to load Vulkan driver library");
+			return;
+		}
+		if (!g_Vulkan) {
+			g_Vulkan = new VulkanContext();
+		}
+		VulkanContext::CreateInfo info{};
+		info.app_name = "PPSSPP";
+		info.app_ver = gitVer.ToInteger();
+		info.flags = this->flags;
+		VkResult res = g_Vulkan->CreateInstance(info);
+		if (res != VK_SUCCESS) {
+			ELOG(@"Failed to create vulkan context: %s", g_Vulkan->InitError().c_str());
+			VulkanSetAvailable(false);
+			delete g_Vulkan;
+			g_Vulkan = nullptr;
+			return;
+		}
+		int physicalDevice = g_Vulkan->GetBestPhysicalDevice();
+		if (physicalDevice < 0) {
+			ELOG(@"No usable Vulkan device found.");
+			g_Vulkan->DestroyInstance();
+			delete g_Vulkan;
+			g_Vulkan = nullptr;
+			return;
+		}
+		g_Vulkan->ChooseDevice(physicalDevice);
+		ELOG(@"Creating Vulkan device");
+		if (g_Vulkan->CreateDevice() != VK_SUCCESS) {
+			ELOG(@"Failed to create vulkan device: %s", g_Vulkan->InitError().c_str());
+			g_Vulkan->DestroyInstance();
+			delete g_Vulkan;
+			g_Vulkan = nullptr;
+			return;
+		}
+		ELOG(@"Vulkan device created!");
+		g_Config.iGPUBackend = (int)GPUBackend::VULKAN;
+		SetGPUBackend(GPUBackend::VULKAN);
+		if (!g_Vulkan) {
+			ELOG(@"InitFromRenderThread: No Vulkan context");
+			return;
+		}
+		res = g_Vulkan->InitSurface(WINDOWSYSTEM_METAL_EXT, (__bridge void *)layer, nullptr);
+		if (res != VK_SUCCESS) {
+			ELOG(@"g_Vulkan->InitSurface failed: '%s'", VulkanResultToString(res));
+			return;
+		}
+		if (g_Vulkan->InitSwapchain()) {
+			draw_ = Draw::T3DCreateVulkanContext(g_Vulkan);
+			SetGPUBackend(GPUBackend::VULKAN);
+			success = draw_->CreatePresets();  // Doesn't fail, we ship the compiler.
+			_assert_msg_(success, "Failed to compile preset shaders");
+			draw_->HandleEvent(Draw::Event::GOT_BACKBUFFER, g_Vulkan->GetBackbufferWidth(), g_Vulkan->GetBackbufferHeight());
+			VulkanRenderManager *renderManager = (VulkanRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
+			renderManager->SetInflightFrames(g_Config.iInflightFrames);
+			success = renderManager->HasBackbuffers();
+		} else {
+			success = false;
+		}
+		ELOG(@"Vulkan Init completed, %s", success ? "successfully" : "but failed");
+		if (!success) {
+			g_Vulkan->DestroySwapchain();
+			g_Vulkan->DestroySurface();
+			g_Vulkan->DestroyDevice();
+			g_Vulkan->DestroyInstance();
+		}
+	}
+
 	Draw::DrawContext *GetDrawContext() override {
 		return draw_;
 	}
 
-	void SwapInterval(int interval) override {}
-	void SwapBuffers() override {}
-	void Resize() override {}
-	void Shutdown() override {}
-
-	void ThreadStart() override {
-		renderManager_->ThreadStart(draw_);
+	void Shutdown() override {
+        ELOG(@"Shutdown");
+        draw_->HandleEvent(Draw::Event::LOST_BACKBUFFER, g_Vulkan->GetBackbufferWidth(), g_Vulkan->GetBackbufferHeight());
+        delete draw_;
+        draw_ = nullptr;
+        g_Vulkan->WaitUntilQueueIdle();
+        g_Vulkan->PerformPendingDeletes();
+        g_Vulkan->DestroySwapchain();
+        g_Vulkan->DestroySurface();
+        ELOG(@"Done with ShutdownFromRenderThread");
+		ELOG(@"Calling NativeShutdownGraphics");
+		g_Vulkan->DestroyDevice();
+		g_Vulkan->DestroyInstance();
+		// We keep the g_Vulkan context around to avoid invalidating a ton of pointers around the app.
+		finalize_glslang();
+		ELOG(@"Shutdown completed");
 	}
 
-	bool ThreadFrame() override {
-		return renderManager_->ThreadFrame();
+	void SwapBuffers() override {
 	}
 
-	void ThreadEnd() override {
-		renderManager_->ThreadEnd();
+	void Resize() override {
+		ELOG(@"Resize begin (oldsize: %dx%d)", g_Vulkan->GetBackbufferWidth(), g_Vulkan->GetBackbufferHeight());
+		draw_->HandleEvent(Draw::Event::LOST_BACKBUFFER, g_Vulkan->GetBackbufferWidth(), g_Vulkan->GetBackbufferHeight());
+		g_Vulkan->DestroySwapchain();
+		g_Vulkan->DestroySurface();
+		g_Vulkan->UpdateFlags(this->flags);
+		g_Vulkan->ReinitSurface();
+		g_Vulkan->InitSwapchain();
+		draw_->HandleEvent(Draw::Event::GOT_BACKBUFFER, g_Vulkan->GetBackbufferWidth(), g_Vulkan->GetBackbufferHeight());
+		ELOG(@"Resize end (final size: %dx%d)", g_Vulkan->GetBackbufferWidth(), g_Vulkan->GetBackbufferHeight());
 	}
 
-	void StopThread() override {
-		renderManager_->WaitUntilQueueIdle();
-		renderManager_->StopThread();
+	void SwapInterval(int interval) override {
 	}
 
+	void *GetAPIContext() override {
+		return g_Vulkan;
+	}
+
+	bool Initialized() {
+		return draw_ != nullptr;
+	}
+    
+    bool VulkanLoad(const char* path) {
+        void *lib = dlopen(path, RTLD_NOW | RTLD_LOCAL);
+        if (lib) {
+            ELOG(@"%s: Library loaded\n", path);
+        } else {
+            ELOG(@"Faield path %s: Library not loaded\n", path);
+        }
+        vulkanLibrary = lib;
+        LOAD_GLOBAL_FUNC(vkCreateInstance);
+        LOAD_GLOBAL_FUNC(vkGetInstanceProcAddr);
+        LOAD_GLOBAL_FUNC(vkGetDeviceProcAddr);
+        LOAD_GLOBAL_FUNC(vkEnumerateInstanceVersion);
+        LOAD_GLOBAL_FUNC(vkEnumerateInstanceExtensionProperties);
+        LOAD_GLOBAL_FUNC(vkEnumerateInstanceLayerProperties);
+        if (vkCreateInstance && vkGetInstanceProcAddr && vkGetDeviceProcAddr && vkEnumerateInstanceExtensionProperties && vkEnumerateInstanceLayerProperties) {
+            ELOG(@"VulkanLoad: Base functions loaded.");
+            return true;
+        } else {
+            ELOG(@"VulkanLoad: Failed to load Vulkan base functions.");
+            return false;
+        }
+    }
 private:
-	Draw::DrawContext *draw_;
-	GLRenderManager *renderManager_;
+	VulkanContext *g_Vulkan = nullptr;
+	Draw::DrawContext *draw_ = nullptr;
+	uint32_t flags = VULKAN_FLAG_PRESENT_MAILBOX | VULKAN_FLAG_PRESENT_FIFO_RELAXED;
 };
 #endif /* VulkanGraphicsContext_h */

--- a/PVLibrary/PVLibrary/Resources/systems.plist
+++ b/PVLibrary/PVLibrary/Resources/systems.plist
@@ -92,43 +92,25 @@
 				<key>PVControlSize</key>
 				<string>{180,180}</string>
 			</dict>
+			<dict>                  
+                                <key>PVControlType</key>
+                                <string>PVJoyPad</string>
+                                <key>PVControlSize</key>
+                                <string>{150,150}</string>
+                        </dict>
+                        <dict>
+                                <key>PVControlType</key>
+                                <string>PVSelectButton</string>
+                                <key>PVControlTitle</key>
+                                <string>Select</string>
+                                <key>PVControlSize</key>
+                                <string>{60,42}</string>
+                        </dict>
 			<dict>
 				<key>PVControlType</key>
 				<string>PVStartButton</string>
 				<key>PVControlTitle</key>
 				<string>Start</string>
-				<key>PVControlSize</key>
-				<string>{60,42}</string>
-			</dict>
-			<dict>
-				<key>PVControlType</key>
-				<string>PVSelectButton</string>
-				<key>PVControlTitle</key>
-				<string>Select</string>
-				<key>PVControlSize</key>
-				<string>{60,42}</string>
-			</dict>
-			<dict>
-				<key>PVControlType</key>
-				<string>PVLeftShoulderButton</string>
-				<key>PVControlTitle</key>
-				<string>L1</string>
-				<key>PVControlSize</key>
-				<string>{60,42}</string>
-			</dict>
-			<dict>
-				<key>PVControlType</key>
-				<string>PVLeftShoulderButton</string>
-				<key>PVControlTitle</key>
-				<string>L2</string>
-				<key>PVControlSize</key>
-				<string>{60,42}</string>
-			</dict>
-			<dict>
-				<key>PVControlType</key>
-				<string>PVLeftAnalogButton</string>
-				<key>PVControlTitle</key>
-				<string>L3</string>
 				<key>PVControlSize</key>
 				<string>{60,42}</string>
 			</dict>
@@ -156,6 +138,30 @@
 				<key>PVControlSize</key>
 				<string>{60,42}</string>
 			</dict>
+                        <dict>
+                                <key>PVControlType</key>
+                                <string>PVLeftShoulderButton</string>
+                                <key>PVControlTitle</key>
+                                <string>L1</string>
+                                <key>PVControlSize</key>
+                                <string>{60,42}</string>
+                        </dict>
+                        <dict>
+                                <key>PVControlType</key>
+                                <string>PVLeftShoulderButton</string>
+                                <key>PVControlTitle</key>
+                                <string>L2</string>
+                                <key>PVControlSize</key>
+                                <string>{60,42}</string>
+                        </dict>
+                        <dict>
+                                <key>PVControlType</key>
+                                <string>PVLeftAnalogButton</string>
+                                <key>PVControlTitle</key>
+                                <string>L3</string>
+                                <key>PVControlSize</key>
+                                <string>{60,42}</string>
+                        </dict>
 		</array>
 	</dict>
 	<dict>
@@ -882,6 +888,30 @@
 				<key>PVControlSize</key>
 				<string>{60,42}</string>
 			</dict>
+                        <dict>
+                                <key>PVControlType</key>
+                                <string>PVRightShoulderButton</string>
+                                <key>PVControlTitle</key>
+                                <string>R1</string>
+                                <key>PVControlSize</key>
+                                <string>{60,42}</string>
+                        </dict>
+                        <dict>
+                                <key>PVControlType</key>
+                                <string>PVRightShoulderButton</string>
+                                <key>PVControlTitle</key>
+                                <string>R2</string>
+                                <key>PVControlSize</key>
+                                <string>{60,42}</string>
+                        </dict>
+                        <dict>
+                                <key>PVControlType</key>
+                                <string>PVRightAnalogButton</string>
+                                <key>PVControlTitle</key>
+                                <string>R3</string>
+                                <key>PVControlSize</key>
+                                <string>{60,42}</string>
+                        </dict>
 			<dict>
 				<key>PVControlType</key>
 				<string>PVLeftShoulderButton</string>
@@ -903,30 +933,6 @@
 				<string>PVLeftAnalogButton</string>
 				<key>PVControlTitle</key>
 				<string>L3</string>
-				<key>PVControlSize</key>
-				<string>{60,42}</string>
-			</dict>
-			<dict>
-				<key>PVControlType</key>
-				<string>PVRightShoulderButton</string>
-				<key>PVControlTitle</key>
-				<string>R1</string>
-				<key>PVControlSize</key>
-				<string>{60,42}</string>
-			</dict>
-			<dict>
-				<key>PVControlType</key>
-				<string>PVRightShoulderButton</string>
-				<key>PVControlTitle</key>
-				<string>R2</string>
-				<key>PVControlSize</key>
-				<string>{60,42}</string>
-			</dict>
-			<dict>
-				<key>PVControlType</key>
-				<string>PVRightAnalogButton</string>
-				<key>PVControlTitle</key>
-				<string>R3</string>
 				<key>PVControlSize</key>
 				<string>{60,42}</string>
 			</dict>

--- a/Provenance/Controller/Systems/PVPSPControllerViewController.swift
+++ b/Provenance/Controller/Systems/PVPSPControllerViewController.swift
@@ -20,9 +20,14 @@ private extension JSButton {
 
 final class PVPSPControllerViewController: PVControllerViewController<PVPSPSystemResponderClient> {
     override func layoutViews() {
-        leftAnalogButton?.buttonTag = .l3
         rightAnalogButton?.buttonTag = .r3
-
+        rightShoulderButton?.buttonTag = .r1
+        rightShoulderButton2?.buttonTag = .r2
+        leftShoulderButton2?.buttonTag = .l2
+        leftShoulderButton?.buttonTag = .l1
+        leftAnalogButton?.buttonTag = .l3
+        selectButton?.buttonTag = .select
+        startButton?.buttonTag = .start
         buttonGroup?.subviews.forEach {
             guard let button = $0 as? JSButton, let text = button.titleLabel.text else {
                 return
@@ -37,15 +42,40 @@ final class PVPSPControllerViewController: PVControllerViewController<PVPSPSyste
                 button.buttonTag = .triangle
             }
         }
-
-        leftShoulderButton?.buttonTag = .l1
-        rightShoulderButton?.buttonTag = .r1
-        leftShoulderButton2?.buttonTag = .l2
-        rightShoulderButton2?.buttonTag = .r2
-        selectButton?.buttonTag = .select
-        startButton?.buttonTag = .start
+    }
+    
+    override func prelayoutSettings() {
+        alwaysRightAlign = true
+        alwaysJoypadOverDpad = false
     }
 
+    override func dPad(_ dPad: JSDPad, joystick value: JoystickValue) {
+        var up:CGFloat = value.y < 0.5 ? CGFloat(1 - (value.y * 2)) : 0.0
+        var down:CGFloat = value.y > 0.5 ? CGFloat((value.y - 0.5) * 2) : 0.0
+        var left:CGFloat = value.x < 0.5 ? CGFloat(1 - (value.x * 2)) : 0.0
+        var right:CGFloat = value.x > 0.5 ? CGFloat((value.x - 0.5) * 2) : 0.0
+
+        up = min(up, 1.0)
+        down = min(down, 1.0)
+        left = min(left, 1.0)
+        right = min(right, 1.0)
+
+        up = max(up, 0.0)
+        down = max(down, 0.0)
+        left = max(left, 0.0)
+        right = max(right, 0.0)
+
+        // print("x: \(value.x) , y: \(value.y), up:\(up), down:\(down), left:\(left), right:\(right), ")
+        emulatorCore.didMoveJoystick(.leftAnalogUp, withValue: up, forPlayer: 0)
+        if down != 0 {
+            emulatorCore.didMoveJoystick(.leftAnalogDown, withValue: down, forPlayer: 0)
+        }
+        emulatorCore.didMoveJoystick(.leftAnalogLeft, withValue: left, forPlayer: 0)
+        if right != 0 {
+            emulatorCore.didMoveJoystick(.leftAnalogRight, withValue: right, forPlayer: 0)
+        }
+    }
+    
     override func dPad(_: JSDPad, didPress direction: JSDPadDirection) {
         emulatorCore.didRelease(.up, forPlayer: 0)
         emulatorCore.didRelease(.down, forPlayer: 0)

--- a/Provenance/Controller/Systems/PVPSXControllerViewController.swift
+++ b/Provenance/Controller/Systems/PVPSXControllerViewController.swift
@@ -47,6 +47,10 @@ final class PVPSXControllerViewController: PVControllerViewController<PVPSXSyste
         selectButton?.buttonTag = .select
         startButton?.buttonTag = .start
     }
+    
+    override func prelayoutSettings() {
+        alwaysRightAlign = true
+    }
 
     override func dPad(_ dPad: JSDPad, joystick value: JoystickValue) {
         var up:CGFloat = value.y < 0.5 ? CGFloat(1 - (value.y * 2)) : 0.0

--- a/Provenance/Emulator/PVEmulatorVC/PVEmulatorViewController+Saves.swift
+++ b/Provenance/Emulator/PVEmulatorVC/PVEmulatorViewController+Saves.swift
@@ -194,6 +194,9 @@ extension PVEmulatorViewController {
         }
 
         // Create a function to use later
+        let loadOk = {
+        }
+
         let loadSave = {
             try! realm.write {
                 state.lastOpened = Date()
@@ -217,12 +220,13 @@ extension PVEmulatorViewController {
         }
 
         if core.projectVersion != state.createdWithCoreVersion {
+            loadSave()
             let message =
                 """
                 Save state created with version \(state.createdWithCoreVersion ?? "nil") but current \(core.projectName) core is version \(core.projectVersion).
                 Save file may not load. Create a new save state to avoid this warning in the future.
                 """
-            presentWarning(message, completion: loadSave)
+            presentWarning(message, completion: loadOk)
         } else {
             loadSave()
         }


### PR DESCRIPTION
### What does this PR do
   Modifies PPSSPP save such that lags / freezes caused by waiting for save to return during the game won't happen. The saves will take place in the background, with synchronous saving happening only when the game is paused.

   Adds joypad support to PPSSPP to support games that require both. 

   Adds generic internal flag to layout views to support Playstation / PPSSPP and other cores that might use joypad. Adjusted load to load save regardless of core version (version dialogue doesn't show on the ppsspp core, so the change will make the save load regardless)

   Adds some adjustments to Mednafen to make on screen input work

### Where should the reviewer start

### How should this be manually tested

### Any background context you want to provide

### What are the relevant tickets

### Screenshots (important for UI changes)

### Questions
