### PR TITLE
Fix save position after orientation change on iOS

### DIFF
--- a/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController+CollectionView.swift
+++ b/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController+CollectionView.swift
@@ -37,9 +37,9 @@ extension PVGameLibraryViewController: UICollectionViewDelegateFlowLayout {
     #if os(iOS)
         private func ios_collectionView(_ collectionView: UICollectionView, layout _: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
             var height: CGFloat = PVSettingsModel.shared.showGameTitles ? 144 : 100
-            let viewWidth = transitioningToSize?.width ?? collectionView.bounds.size.width
-            let itemsPerRow: CGFloat = viewWidth > 800 ? 6 : 3
 
+            let viewWidth = collectionView.bounds.size.width
+            let itemsPerRow: CGFloat = viewWidth > 700 ? 6 : 3
             var width: CGFloat = (viewWidth / itemsPerRow) - (minimumInteritemSpacing * itemsPerRow * 0.67)
 
             let item: Section.Item = try! collectionView.rx.model(at: indexPath)

--- a/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController+CollectionView.swift
+++ b/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController+CollectionView.swift
@@ -60,7 +60,7 @@ extension PVGameLibraryViewController: UICollectionViewDelegateFlowLayout {
     #if os(tvOS)
         private func tvos_collectionView(_ collectionView: UICollectionView, layout _: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
             let item: Section.Item = try! collectionView.rx.model(at: indexPath)
-            let viewWidth = transitioningToSize?.width ?? collectionView.bounds.size.width
+            let viewWidth = collectionView.bounds.size.width
             switch item {
             case .saves:
                 // TODO: Multirow?

--- a/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
+++ b/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
@@ -744,17 +744,6 @@ final class PVGameLibraryViewController: GCEventViewController, UITextFieldDeleg
 
     fileprivate lazy var officialBundleID: Bool = Bundle.main.bundleIdentifier!.contains("org.provenance-emu.")
 
-    var transitioningToSize: CGSize?
-    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        super.viewWillTransition(to: size, with: coordinator)
-
-        transitioningToSize = size
-        collectionView?.collectionViewLayout.invalidateLayout()
-        coordinator.notifyWhenInteractionChanges { [weak self] _ in
-            self?.transitioningToSize = nil
-        }
-    }
-
     #if os(iOS) && !targetEnvironment(macCatalyst)
         override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
             return .all


### PR DESCRIPTION
### What does this PR do
The landscape orientation on iOS has horizontal space on either side, this results in the value from `viewWillTransition` being wider than the collection view.

Using the `collectionView.bounds.size.width` instead solves the problem, this value is the same as the value from `viewWillTransition` on iPadOS.

Before and after:
<img width="1006" alt="Screenshot 2023-09-24 at 16 53 34" src="https://github.com/Provenance-Emu/Provenance/assets/2276355/d2dcf09f-4986-4ad4-8dba-1fea26c2eb85">
<img width="1006" alt="Screenshot 2023-09-24 at 16 54 33" src="https://github.com/Provenance-Emu/Provenance/assets/2276355/28e6dbd7-9f7b-400d-8bf0-a0e353ad560d">
