### PR TITLE
Prevent table row selection persisting

### DIFF
--- a/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
+++ b/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
@@ -1747,6 +1747,7 @@ extension PVGameLibraryViewController: UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: false)
         if indexPath.section == 0 {
             currentSort.onNext(SortOptions.optionForRow(UInt(indexPath.row)))
             // dont call reloadSections or we will loose focus on tvOS


### PR DESCRIPTION
### What does this PR do
Changing game library display or sort options now deselects the row after selection so the checkmark can be seen.
