### PR TITLE
Fix slider cell detail text

### DIFF
--- a/Provenance/Emulator/CoreOptionsViewController.swift
+++ b/Provenance/Emulator/CoreOptionsViewController.swift
@@ -54,6 +54,7 @@ final class CoreOptionsViewController: QuickTableViewController {
         super.viewDidLoad()
         generateTableViewViewModels()
         tableView.reloadData()
+        tableView.layoutIfNeeded()
     }
 
     func generateTableViewViewModels() {

--- a/Provenance/Settings/Cells/SliderCell.swift
+++ b/Provenance/Settings/Cells/SliderCell.swift
@@ -111,30 +111,34 @@ extension QuickTableViewController: SliderCellDelegate {
 				#endif
                 slider.setValue(row.value, animated: false)
             }
+            
+            guard let textLabel = textLabel else {
+                return
+            }
+
+            textLabel.translatesAutoresizingMaskIntoConstraints = false
+            textLabel.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor).isActive = true
+
+            slider.translatesAutoresizingMaskIntoConstraints = false
+            slider.leadingAnchor.constraint(equalTo: textLabel.trailingAnchor, constant: 20).isActive = true
+            slider.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor).isActive = true
+
+            if let detailTextLabel = detailTextLabel {
+                detailTextLabel.translatesAutoresizingMaskIntoConstraints = false
+                contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: 69).isActive = true
+                detailTextLabel.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor).isActive = true
+                detailTextLabel.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor).isActive = true
+                detailTextLabel.topAnchor.constraint(equalTo: topAnchor, constant: 32).isActive = true
+                detailTextLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: 0).isActive = true
+                textLabel.topAnchor.constraint(equalTo: topAnchor, constant: 12).isActive = true
+                slider.topAnchor.constraint(equalTo: textLabel.topAnchor, constant: -5).isActive = true
+            } else {
+                contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: 44).isActive = true
+                textLabel.topAnchor.constraint(equalTo: topAnchor, constant: 0).isActive = true
+                textLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: 0).isActive = true
+                slider.centerYAnchor.constraint(equalTo: centerYAnchor, constant: 0).isActive = true
+            }
         }
-
-    open override func layoutSubviews() {
-        super.layoutSubviews()
-        guard let textLabel = textLabel else {
-            return
-        }
-
-        contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: 44).isActive = true
-
-        textLabel.translatesAutoresizingMaskIntoConstraints = false
-        if (contentView.bounds.height == 44.5) {
-            textLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 16).isActive = true
-        } else {
-            textLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 20).isActive = true
-        }
-        textLabel.topAnchor.constraint(equalTo: self.topAnchor, constant: 0).isActive = true
-        textLabel.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: 0).isActive = true
-
-        slider.translatesAutoresizingMaskIntoConstraints = false
-        slider.leadingAnchor.constraint(equalTo: textLabel.trailingAnchor, constant: 20).isActive = true
-        slider.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -20).isActive = true
-        slider.centerYAnchor.constraint(equalTo: self.centerYAnchor, constant: 0).isActive = true
-    }
 
         // MARK: - Private
 

--- a/Provenance/Settings/Custom Rows/SliderRow.swift
+++ b/Provenance/Settings/Custom Rows/SliderRow.swift
@@ -69,10 +69,10 @@ open class SliderRow<T>: SliderRowCompatible, Equatable where T: SliderCell {
 
     // MARK: - Row
 
-    /// The title is disabled in `SliderRow`.
+    /// The text of the row.
     public let text: String
 
-    /// The subtitle is disabled in `SliderRow`.
+    /// The detail text of the row.
     public let detailText: DetailText?
 
     /// A closure that will be invoked when the `switchValue` is changed.
@@ -83,12 +83,16 @@ open class SliderRow<T>: SliderRowCompatible, Equatable where T: SliderCell {
     /// The type of the table view cell to display the row.
     public let cellType: UITableViewCell.Type = T.self
 
-    /// The reuse identifier of the table view cell to display the row. The default value is **SliderCell**.
-    public let cellReuseIdentifier: String = "SliderCell" // T.reuseIdentifier
-
-    /// The cell style is `.default`.
-    public let cellStyle: UITableViewCell.CellStyle = .default
-
+    /// Returns the reuse identifier of the table view cell to display the row.
+    public var cellReuseIdentifier: String {
+      return T.reuseIdentifier + (detailText?.style.stringValue ?? "")
+    }
+    
+    /// Returns the table view cell style for the specified detail text.
+    public var cellStyle: UITableViewCell.CellStyle {
+      return detailText?.style ?? .default
+    }
+    
     /// The minimum value icon of the slider.
     public var icon: Icon? {
         return nil
@@ -110,6 +114,7 @@ open class SliderRow<T>: SliderRowCompatible, Equatable where T: SliderCell {
     public static func == (lhs: SliderRow, rhs: SliderRow) -> Bool {
         return
             lhs.text == rhs.text &&
+            lhs.detailText == rhs.detailText &&
             lhs.value == rhs.value &&
             lhs.icon == rhs.icon
     }


### PR DESCRIPTION
### What does this PR do

Displays the detail text that is often available.

Before and after:
<img width="45%" alt="Screenshot 2023-10-02 at 19 04 50" src="https://github.com/Provenance-Emu/Provenance/assets/2276355/d597f6b6-4c4b-4643-8453-dd32648909a1"> <img width="45%" alt="Screenshot 2023-10-02 at 19 05 24" src="https://github.com/Provenance-Emu/Provenance/assets/2276355/0d7eab40-9486-48ba-b172-96e7455d6b46">
