### PR TITLE
Fix conflict UI issues

### DIFF
--- a/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
+++ b/Provenance/Game Library/UI/Game Library/CollectionViewController/PVGameLibraryViewController.swift
@@ -589,7 +589,9 @@ final class PVGameLibraryViewController: GCEventViewController, UITextFieldDeleg
             .subscribe(onNext: { hasConflicts in
                 self.updateConflictsButton(hasConflicts)
                 if hasConflicts {
-                    self.showConflictsAlert()
+                    DispatchQueue.main.async {
+                        self.showConflictsAlert()
+                    }
                 }
             })
             .disposed(by: disposeBag)

--- a/Provenance/Game Library/UI/PVConflictViewController.swift
+++ b/Provenance/Game Library/UI/PVConflictViewController.swift
@@ -33,13 +33,10 @@ final class PVConflictViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        #if os(tvOS)
-            splitViewController?.title = "Solve Conflicts"
-        #else
+        title = "Solve Conflicts"
+        #if !os(tvOS)
             let currentTableview = tableView!
             tableView = UITableView(frame: currentTableview.frame, style: currentTableview.style)
-
-            title = "Solve Conflicts"
             tableView.separatorColor = UIColor.clear
         #endif
 

--- a/Provenance/Game Library/UI/PVConflictViewController.swift
+++ b/Provenance/Game Library/UI/PVConflictViewController.swift
@@ -84,12 +84,7 @@ final class PVConflictViewController: UITableViewController {
                     }
                 })
                 .bind(onNext: { conflict, indexPath in
-                    // Delete file
-                    do {
-                        try FileManager.default.removeItem(at: conflict.path)
-                    } catch {
-                        ELOG(error.localizedDescription)
-                    }
+                    self.conflictsController.deleteConflict(path: conflict.path)
                     self.tableView.reloadData()
                 })
             .disposed(by: disposeBag)

--- a/Provenance/Game Library/UI/PVConflictViewController.swift
+++ b/Provenance/Game Library/UI/PVConflictViewController.swift
@@ -49,7 +49,7 @@ final class PVConflictViewController: UITableViewController {
         let rows = conflictsController.conflicts
             .map({ conflicts -> [Row] in
                 if conflicts.isEmpty {
-                    return [.empty(title: ""), .empty(title: ""), .empty(title: "No Conflicts…")]
+                    return [.empty(title: "No Conflicts…")]
                 } else {
                     return conflicts.map { .conflict($0) }
                 }

--- a/Provenance/Game Library/UI/PVConflictViewController.swift
+++ b/Provenance/Game Library/UI/PVConflictViewController.swift
@@ -65,6 +65,7 @@ final class PVConflictViewController: UITableViewController {
                 cell.textLabel?.text = title
                 cell.textLabel?.textAlignment = .center
                 cell.accessoryType = .none
+                cell.isUserInteractionEnabled = false
             }
         }
         .disposed(by: disposeBag)
@@ -141,18 +142,6 @@ final class PVConflictViewController: UITableViewController {
     @objc func dismissMe() {
         dismiss(animated: true) { () -> Void in }
     }
-
-    #if os(tvOS)
-        override func tableView(_ tableView: UITableView, canFocusRowAt indexPath: IndexPath) -> Bool {
-            let row: Row = try! tableView.rx.model(at: indexPath)
-            switch row {
-            case .conflict:
-                return true
-            case .empty:
-                return false
-            }
-        }
-    #endif
 }
 
 extension PVConflictViewController {


### PR DESCRIPTION
### What does this PR do
Fixes the missing title on tvOS, removes superfluous empty cells on iOS, and fixes the status bar UI when the initial conflict alert is presented. tvOS empty cell selection has also been fixed along with removing conflicts.

Before and after:
<img src="https://github.com/Provenance-Emu/Provenance/assets/2276355/2c8c9fba-7416-4c0a-918e-1d7b88776fca" width="45%"> <img src="https://github.com/Provenance-Emu/Provenance/assets/2276355/6c970f84-465f-45db-985d-542cb0e3839c" width="45%">
