### PR TITLE
Mednafen PSX & Save States Crashing + Game Importer Setup

### DIFF
--- a/Cores/Mednafen/Sources/MednafenGameCoreOptions/MednafenGameCoreOptions.swift
+++ b/Cores/Mednafen/Sources/MednafenGameCoreOptions/MednafenGameCoreOptions.swift
@@ -186,7 +186,7 @@ public final class MednafenGameCoreOptions: NSObject, CoreOptions, CoreOptional 
         .bool(.init(
             title: "Cache CD in memory",
             description: "Reads the entire CD image(s) into memory at startup(which will cause a small delay). Can help obviate emulation hiccups due to emulated CD access. May cause more harm than good on low memory systems.",
-            requiresRestart: true), defaultValue: false)
+            requiresRestart: true), defaultValue: true)
     }
 
     // MARK: PCE

--- a/PVUI/Sources/PVUIBase/GameLaunching/GameLaunchingViewController.swift
+++ b/PVUI/Sources/PVUIBase/GameLaunching/GameLaunchingViewController.swift
@@ -35,7 +35,7 @@ public protocol GameLaunchingViewController: AnyObject {
 }
 
 extension GameLaunchingViewController {
-    func openSaveState(withID objectId: String) async {
+    @MainActor func openSaveState(withID objectId: String) async {
         let realm = RomDatabase.sharedInstance
         if let object = realm.object(ofType: PVSaveState.self, wherePrimaryKeyEquals: objectId) {
             @ThreadSafe var threadObject = object
@@ -210,6 +210,7 @@ extension GameLaunchingViewController where Self: UIViewController {
         }
     }
 
+    @MainActor
     public
     func openSaveState(_ saveState: PVSaveState) async {
         

--- a/Provenance/PVAppDelegate.swift
+++ b/Provenance/PVAppDelegate.swift
@@ -211,6 +211,10 @@ final class PVAppDelegate: UIResponder, GameLaunchingAppDelegate {
         #endif
         
         Task.detached { @MainActor in
+            let database = RomDatabase.sharedInstance
+            await gameImporter.initSystems()
+            database.reloadCache()
+            
             let libraryUpdatesController = await PVGameLibraryUpdatesController(gameImporter: gameImporter)
 #if os(iOS) || os(macOS)
             libraryUpdatesController.addImportedGames(to: CSSearchableIndex.default(), database: RomDatabase.sharedInstance).disposed(by: self.disposeBag)
@@ -219,12 +223,6 @@ final class PVAppDelegate: UIResponder, GameLaunchingAppDelegate {
             // Handle refreshing library
             self._initUI(libraryUpdatesController: libraryUpdatesController, gameImporter: gameImporter, gameLibrary: gameLibrary)
             self.window!.makeKeyAndVisible()
-        }
-
-        Task.detached { @MainActor in
-            let database = RomDatabase.sharedInstance
-            database.refresh()
-            database.reloadCache()
         }
     }
     


### PR DESCRIPTION
### **User description**
### What does this PR do
1.  Fix Mednafen PSX - currently it's required to set cd.image_memcache to true so this sets the default value of the core option to true (could also just remove for now)
2.  Fixes Save state loading for mednafen by forcing relevant functions accessing Realm to MainActor
3.  Forgot to add some important sequencing on App Delegate that ensures proper set up of directories and caches on first load

### Where should the reviewer start

### How should this be manually tested

### Any background context you want to provide

### What are the relevant tickets

### Screenshots (important for UI changes)

### Questions


___

### **PR Type**
enhancement, bug_fix


___

### **Description**
- Changed the default value of the `cd.image_memcache_option` to `true` in the Mednafen core options to improve emulation performance.
- Fixed save state loading issues by ensuring relevant functions are executed on the `MainActor`.
- Enhanced the app delegate setup by initializing systems and reloading the cache in a single task, removing redundant database refresh calls.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MednafenGameCoreOptions.swift</strong><dd><code>Set default CD cache option to true in Mednafen.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Cores/Mednafen/Sources/MednafenGameCoreOptions/MednafenGameCoreOptions.swift

- Changed default value of `cd.image_memcache_option` to `true`.



</details>


  </td>
  <td><a href="https://github.com/Provenance-Emu/Provenance/pull/2355/files#diff-76727ef1ae126c91bbb3690e067dd1e26e61f56caf8d0b3132354d6e7398c180">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>PVAppDelegate.swift</strong><dd><code>Improve app delegate setup for database and systems.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Provenance/PVAppDelegate.swift

<li>Added initialization of systems and cache reload in <code>Task.detached</code>.<br> <li> Removed redundant database refresh task.<br>


</details>


  </td>
  <td><a href="https://github.com/Provenance-Emu/Provenance/pull/2355/files#diff-241b9506fe6f4f47d23a0821a6308486ea7320e5315e47d1dbfdf7c33ca84767">+4/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GameLaunchingViewController.swift</strong><dd><code>Ensure save state functions run on MainActor.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

PVUI/Sources/PVUIBase/GameLaunching/GameLaunchingViewController.swift

- Added `@MainActor` attribute to `openSaveState` methods.



</details>


  </td>
  <td><a href="https://github.com/Provenance-Emu/Provenance/pull/2355/files#diff-4e541a771d983b9ea11382c45d83a5b774e04722cbf0d7988568100c26fcf330">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information