### PR TITLE
Fixes delete roms and a few other various menu actions

### DIFF
--- a/PVLibrary/Sources/PVLibrary/Configuration/PVEmulatorConfiguration.swift
+++ b/PVLibrary/Sources/PVLibrary/Configuration/PVEmulatorConfiguration.swift
@@ -320,10 +320,11 @@ public extension PVEmulatorConfiguration {
     }
 
     class func path(forGame game: PVGame) -> URL {
-        return URL.documentsiCloudOrLocalPath.appendingPathComponent(game.systemIdentifier).appendingPathComponent(game.file.url.lastPathComponent)
+        return
+        PVEmulatorConfiguration.romDirectory(forSystemIdentifier: game.systemIdentifier).appendingPathComponent(game.file.url.lastPathComponent)
     }
     class func path(forGame game: PVGame, url:URL) -> URL {
-        return URL.documentsiCloudOrLocalPath.appendingPathComponent(game.systemIdentifier).appendingPathComponent(url.lastPathComponent)
+        return PVEmulatorConfiguration.romDirectory(forSystemIdentifier: game.systemIdentifier).appendingPathComponent(url.lastPathComponent)
     }
 }
 


### PR DESCRIPTION
Any action relying on PVEmulatorCongifuration returning the correct path for a game would fail, because it was returning the wrong path.  We were computing the directory for the ROM incorrectly, so it was never being found.

### What does this PR do

Fixes the computation of the path for a give Game.  actions relying on that such as Delete and Move ROM should work properly now.  

### Where should the reviewer start

### How should this be manually tested

Test Delete Rom, move rom, etc.

### Any background context you want to provide

### What are the relevant tickets

### Screenshots (important for UI changes)

### Questions
