### PR TITLE
Sets 'requiresRestart: false' instead of 'true' for some emuThree core options

### DIFF
--- a/Cores/emuThree/PVEmuThreeCore/Core/PVEmuThreeCoreOptions.swift
+++ b/Cores/emuThree/PVEmuThreeCore/Core/PVEmuThreeCoreOptions.swift
@@ -6,8 +6,8 @@ import PVCoreBridge
     
     static var resolutionOption: CoreOption {
         .enumeration(.init(title: "Resolution Upscaling",
-                           description: "(Requires Restart)",
-                           requiresRestart: true),
+                           description: nil,
+                           requiresRestart: false),
                      values: [
                         .init(title: "1X", description: "1X", value: 1),
                         .init(title: "2X", description: "2X", value: 2),
@@ -32,9 +32,9 @@ import PVCoreBridge
     }
     
     static var cpuClockOption: CoreOption {
-        .enumeration(.init(title: "CPU Clock",
-                           description: "(Requires Restart) Underclocking can increase performance but may cause the game to freeze. Overclocking may reduce in game lag but also might cause freezes",
-                           requiresRestart: true),
+        .enumeration(.init(title: "CPU Clock Speed",
+                           description: "Underclocking can increase performance but may cause the game to freeze. Overclocking may reduce in game lag but also might cause freezes",
+                           requiresRestart: false),
                      values: [
                         .init(title: "10%", description: "10%", value: 10),
                         .init(title: "20%", description: "20%", value: 20),
@@ -65,7 +65,7 @@ import PVCoreBridge
         .bool(.init(
             title: "Enable Logging",
             description: "May affect performance",
-            requiresRestart: true),
+            requiresRestart: false),
               defaultValue: false)
     }
     
@@ -73,7 +73,7 @@ import PVCoreBridge
         .bool(.init(
             title: "Enable New 3DS",
             description: nil,
-            requiresRestart: true),
+            requiresRestart: false),
               defaultValue: true)
     }
     
@@ -91,7 +91,7 @@ import PVCoreBridge
         .bool(.init(
             title: "Enable Async Shader Compilation",
             description: nil,
-            requiresRestart: true),
+            requiresRestart: false),
               defaultValue: false)
     }
     
@@ -127,8 +127,8 @@ import PVCoreBridge
     static var enableShaderAccurateMulOption: CoreOption {
         .bool(.init(
             title: "Enable Shader Accurate Mul",
-            description: nil,
-            requiresRestart: true),
+            description: "Some games require this to be enabled to render properly, but slightly reduces performance",
+            requiresRestart: false),
               defaultValue: true)
     }
     


### PR DESCRIPTION
### **User description**
### What does this PR do
I noticed that most options that have 'requiresRestart: true' do not actually apply on restart. These changes should (in theory) fix resolution upscaling not updating, cpu clock not updating, as well as some other core options. On Citra, most settings do not require a restart anyway, except for JIT.

I also added a description for Shader Accurate Mul.
### Where should the reviewer start

### How should this be manually tested
This needs to be tested as I cannot build emuThree for myself. Resolution upscaling and cpu clock speed are the most important ones to check if they update while in game. Other options that I set requiresRestart to false are logging, new 3ds, async shader comp, and shader accurate mul.

### Any background context you want to provide

### What are the relevant tickets

### Screenshots (important for UI changes)

### Questions


___

### **PR Type**
Enhancement


___

### **Description**
- Changed `requiresRestart` to `false` for several core options.

- Updated descriptions for `CPU Clock Speed` and `Shader Accurate Mul`.

- Improved user experience by reducing unnecessary restart requirements.

- Enhanced clarity of core option descriptions.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PVEmuThreeCoreOptions.swift</strong><dd><code>Updated core options to avoid restarts and improve descriptions</code></dd></summary>
<hr>

Cores/emuThree/PVEmuThreeCore/Core/PVEmuThreeCoreOptions.swift

<li>Changed <code>requiresRestart</code> to <code>false</code> for multiple core options.<br> <li> Updated description for <code>CPU Clock Speed</code> option.<br> <li> Added description for <code>Shader Accurate Mul</code> option.<br> <li> Improved user experience by reducing restart requirements.


</details>


  </td>
  <td><a href="https://github.com/Provenance-Emu/Provenance/pull/2379/files#diff-e270a7d38c857743929278e6f035bca300bb67b1afc85ee66615d68ad302edc1">+10/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information