### PR TITLE
Update PVMetalViewController.swift - Fix Rotation misalignment.

### DIFF
--- a/PVUI/Sources/PVUIBase/PVGLViewController/PVMetalViewController.swift
+++ b/PVUI/Sources/PVUIBase/PVGLViewController/PVMetalViewController.swift
@@ -173,6 +173,19 @@ class PVMetalViewController : PVGPUViewController, PVRenderDelegate, MTKViewDele
         }
     }
 
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        
+        // Invalidate cached values to force recalculation of the viewport on rotation.
+        lastScreenBounds = .zero
+        lastBufferSize = .zero
+        lastNativeScaleEnabled = false
+
+        coordinator.animate(alongsideTransition: { _ in
+            self.view.setNeedsLayout()
+        })
+    }
+    
     override func loadView() {
         /// Create MTKView with initial frame from screen bounds
         let screenBounds = UIScreen.main.bounds


### PR DESCRIPTION
### **User description**
Currently when rotating the device on iOS the new screen placement is not correctly centered due to the cached state of some of the used vars. 

This update will invalidate the cached ScreenBounds, BufferSize. and NativeScaleEnabled when rotating so that the new draw state will be correctly centered.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed rotation misalignment issue in `PVMetalViewController`.

- Added `viewWillTransition` override to reset cached values.

- Ensured viewport recalculates correctly after device rotation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PVMetalViewController.swift</strong><dd><code>Handle rotation and reset cached values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

PVUI/Sources/PVUIBase/PVGLViewController/PVMetalViewController.swift

<li>Added <code>viewWillTransition</code> method to handle rotation.<br> <li> Reset cached values like <code>lastScreenBounds</code> and <code>lastBufferSize</code>.<br> <li> Triggered layout update during rotation transition.


</details>


  </td>
  <td><a href="https://github.com/Provenance-Emu/Provenance/pull/2400/files#diff-913a77f58bde06dda9c12060d6347efbd8f8783242ca6f249c07c477c0700134">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>