### PR TITLE
Check if app group container is readable

### DIFF
--- a/PVLibrary/Sources/PVLibrary/Database/Realm Database/RomDatabase.swift
+++ b/PVLibrary/Sources/PVLibrary/Database/Realm Database/RomDatabase.swift
@@ -40,13 +40,13 @@ public final class RealmConfiguration {
         guard !PVAppGroupId.isEmpty, let container = RealmConfiguration.appGroupContainer else {
             return false
         }
-        let path = container.path
         let fm = FileManager.default
-        if fm.isReadableFile(atPath: path) {
-            return true
-        } else {
+        var isDir: ObjCBool = false
+        let path = container.path
+        guard fm.fileExists(atPath: path, isDirectory: &isDir), isDir.boolValue else {
             return false
         }
+        return true
 #endif
     }
 

--- a/PVLibrary/Sources/PVLibrary/Database/Realm Database/RomDatabase.swift
+++ b/PVLibrary/Sources/PVLibrary/Database/Realm Database/RomDatabase.swift
@@ -37,7 +37,16 @@ public final class RealmConfiguration {
 #if targetEnvironment(macCatalyst)
         return false
 #else
-        return !PVAppGroupId.isEmpty && RealmConfiguration.appGroupContainer != nil
+        guard !PVAppGroupId.isEmpty, let container = RealmConfiguration.appGroupContainer else {
+            return false
+        }
+        let path = container.path
+        let fm = FileManager.default
+        if fm.isReadableFile(atPath: path) {
+            return true
+        } else {
+            return false
+        }
 #endif
     }
 


### PR DESCRIPTION
### **User description**
### What does this PR do
This enables sideloading of the iPad version on macOS.

It is possible to install the IPA using iOS App Signer with the `embedded.mobileprovision` provisioning profile. The issue is that app groups are not available with the free plan, so changing the `APP_GROUP_IDENTIFIER` doesn't work because `com.apple.security.application-groups` entitlements are not possible.

### Where should the reviewer start

### How should this be manually tested

### Any background context you want to provide

### What are the relevant tickets

### Screenshots (important for UI changes)
![Screenshot 2025-08-26 at 19 47 24](https://github.com/user-attachments/assets/451151ec-395b-45d5-8ef0-4144c496ced6)

### Questions


___

### **PR Type**
Bug fix


___

### **Description**
- Add file readability check for app group containers

- Improve app group support detection on iOS

- Fix sideloading compatibility for iPad apps on macOS


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["App Group Check"] --> B["Container Exists?"]
  B --> C["File Readable?"]
  C --> D["Return Support Status"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RomDatabase.swift</strong><dd><code>Enhanced app group container validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

PVLibrary/Sources/PVLibrary/Database/Realm Database/RomDatabase.swift

<ul><li>Replace simple null check with file readability verification<br> <li> Add <code>FileManager.isReadableFile(atPath:)</code> check for app group container<br> <li> Improve robustness of <code>supportsAppGroups</code> property detection</ul>


</details>


  </td>
  <td><a href="https://github.com/Provenance-Emu/Provenance/pull/2420/files#diff-0cbc5e3fca1e1eee554290c7f7b233351587936ac30e3bdb346b3f66873c2c79">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

