### PR TITLE
Fix dependency graph issue

### DIFF
--- a/Provenance.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Provenance.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/exyte/ActivityIndicatorView.git",
         "state": {
           "branch": null,
-          "revision": "9970fd0bb7a05dad0b6566ae1f56937716686b24",
-          "version": "1.1.1"
+          "revision": "36140867802ae4a1d2b11490bcbbefe058001d14",
+          "version": "1.2.1"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/exyte/AnimatedGradient.git",
         "state": {
           "branch": null,
-          "revision": "70f5d34bc553483936e86eca3984b6e12302ead2",
-          "version": "1.0.0"
+          "revision": "c0e19120abda483a61058721c6c7d65c82c4ebe9",
+          "version": "1.0.1"
         }
       },
       {
@@ -105,8 +105,8 @@
         "repositoryURL": "https://github.com/exyte/FloatingButton.git",
         "state": {
           "branch": null,
-          "revision": "cf77c2f124df1423d90a9a1985e9b9ccfa4b9b3e",
-          "version": "1.3.0"
+          "revision": "c1e3e6a641ef5bacbcbc2b2c80db54793f75f974",
+          "version": "1.4.0"
         }
       },
       {
@@ -402,8 +402,8 @@
         "repositoryURL": "https://github.com/apple/swift-atomics.git",
         "state": {
           "branch": null,
-          "revision": "cd142fd2f64be2100422d658e7411e39489da985",
-          "version": "1.2.0"
+          "revision": "b601256eab081c0f92f059e12818ac1d4f178ff7",
+          "version": "1.3.0"
         }
       },
       {
@@ -420,8 +420,8 @@
         "repositoryURL": "https://github.com/apple/swift-collections.git",
         "state": {
           "branch": null,
-          "revision": "c1805596154bb3a265fd91b8ac0c4433b4348fb0",
-          "version": "1.2.0"
+          "revision": "8c0c0a8b49e080e54e5e328cc552821ff07cd341",
+          "version": "1.2.1"
         }
       },
       {
@@ -447,8 +447,8 @@
         "repositoryURL": "https://github.com/apple/swift-openapi-runtime",
         "state": {
           "branch": null,
-          "revision": "81c309c7b43cd56b2d2b90ca0170f17ff3d0c433",
-          "version": "1.8.1"
+          "revision": "8f33cc5dfe81169fb167da73584b9c72c3e8bc23",
+          "version": "1.8.2"
         }
       },
       {


### PR DESCRIPTION
### **User description**
This fixes the following error:
```
error: Could not compute dependency graph: unable to load transferred PIF: The workspace contains multiple references with the same GUID 'PACKAGE:1QP6TY725H25J86HOT863Q7VAKFY6BCBA::MAINGROUP'
```


___

### **PR Type**
Other


___

### **Description**
- Update Swift Package Manager dependencies to latest versions

- Fix dependency graph GUID conflict error

- Upgrade 6 packages including ActivityIndicatorView, FloatingButton, and swift-atomics


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Package.resolved"] --> B["Updated Dependencies"]
  B --> C["Fixed GUID Conflict"]
  C --> D["Resolved Dependency Graph"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Package.resolved</strong><dd><code>Swift Package dependency version updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Provenance.xcworkspace/xcshareddata/swiftpm/Package.resolved

<ul><li>Updated ActivityIndicatorView from 1.1.1 to 1.2.1<br> <li> Updated AnimatedGradient from 1.0.0 to 1.0.1<br> <li> Updated FloatingButton from 1.3.0 to 1.4.0<br> <li> Updated swift-atomics from 1.2.0 to 1.3.0<br> <li> Updated swift-collections from 1.2.0 to 1.2.1<br> <li> Updated swift-openapi-runtime from 1.8.1 to 1.8.2</ul>


</details>


  </td>
  <td><a href="https://github.com/Provenance-Emu/Provenance/pull/2426/files#diff-b9edff4c9639a47c8c19252054e61c4ee1406d8eef5a8f5fe542918cb3857589">+12/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

