### PR TITLE
Fix search bar on iPadOS 26

### DIFF
--- a/PVUI/Sources/PVSwiftUI/SideMenu/SideMenuView.swift
+++ b/PVUI/Sources/PVSwiftUI/SideMenu/SideMenuView.swift
@@ -399,15 +399,16 @@ SideMenuView: SwiftUI.View {
         })
         .introspectViewController(customize: { vc in
             let image = UIImage(named: "provnavicon", in: PVUIBase.BundleLoader.myBundle, with: nil)
+            let menuIconTint = themeManager.currentPalette.menuIconTint
             if #available(iOS 26.0, *) {
                 let imageView = UIImageView(image: image)
+                imageView.contentMode = .scaleAspectFit
+                imageView.tintColor = menuIconTint
                 vc.navigationItem.titleView = imageView
                 vc.navigationItem.preferredSearchBarPlacement = .stacked
             } else {
-                let menuIconTint = themeManager.currentPalette.menuIconTint
-
                 if menuIconTint != .clear {
-                        image?.applyTintEffectWithColor(menuIconTint)
+                    image?.applyTintEffectWithColor(menuIconTint)
                 }
                 let provenanceLogo = UIBarButtonItem(image: image)
                 provenanceLogo.tintColor = themeManager.currentPalette.menuIconTint

--- a/PVUI/Sources/PVSwiftUI/SideMenu/SideMenuView.swift
+++ b/PVUI/Sources/PVSwiftUI/SideMenu/SideMenuView.swift
@@ -399,17 +399,22 @@ SideMenuView: SwiftUI.View {
         })
         .introspectViewController(customize: { vc in
             let image = UIImage(named: "provnavicon", in: PVUIBase.BundleLoader.myBundle, with: nil)
-            let menuIconTint = themeManager.currentPalette.menuIconTint
+            if #available(iOS 26.0, *) {
+                let imageView = UIImageView(image: image)
+                vc.navigationItem.titleView = imageView
+                vc.navigationItem.preferredSearchBarPlacement = .stacked
+            } else {
+                let menuIconTint = themeManager.currentPalette.menuIconTint
 
-            if menuIconTint != .clear {
-                    image?.applyTintEffectWithColor(menuIconTint)
+                if menuIconTint != .clear {
+                        image?.applyTintEffectWithColor(menuIconTint)
+                }
+                let provenanceLogo = UIBarButtonItem(image: image)
+                provenanceLogo.tintColor = themeManager.currentPalette.menuIconTint
+                vc.navigationItem.leftBarButtonItem = provenanceLogo
+                vc.navigationItem.leftBarButtonItem?.tintColor = menuIconTint
+                vc.navigationController?.navigationBar.tintColor = menuIconTint
             }
-            let provenanceLogo = UIBarButtonItem(image: image)
-            provenanceLogo.tintColor = themeManager.currentPalette.menuIconTint
-            vc.navigationItem.leftBarButtonItem = provenanceLogo
-            vc.navigationItem.leftBarButtonItem?.tintColor = menuIconTint
-            vc.navigationController?.navigationBar.tintColor = menuIconTint
-
         })
         .foregroundStyle(themeManager.currentPalette.menuIconTint.swiftUIColor)
 #endif


### PR DESCRIPTION
### **User description**
### What does this PR do
This adjusts the navigation bar item and search bar placement to fix iPadOS 26 layout issues.

### Any background context you want to provide
When built against the iOS 26 SDK, the search bar moves to the bottom on iOS but causes layout issues on iPadOS.

### Screenshots (important for UI changes)
| iPadOS Before | iPadOS After |
|---------|--------|
| <img width="223" height="62" alt="IMG_0091" src="https://github.com/user-attachments/assets/d0305255-5e6c-49b5-83e5-254caf9ed962" /><br><img width="223" height="60" alt="IMG_0092" src="https://github.com/user-attachments/assets/3f0a3a10-683d-4d9b-8661-00547683cbc9" /> | <img width="220" height="120" alt="IMG_0093" src="https://github.com/user-attachments/assets/b7e584ee-a18f-4eb3-b474-cffc83944c85" /> |

| macOS Before | macOS After |
|---------|--------|
| <img width="306" height="50" alt="Screenshot 2025-11-29 at 09 36 38" src="https://github.com/user-attachments/assets/ddd48408-8f78-4e32-a22d-e1b7005726e4" /><br><img width="305" height="49" alt="Screenshot 2025-11-29 at 09 36 10" src="https://github.com/user-attachments/assets/3086e386-5b23-4270-a7a3-42d9ed076d8b" />  | <img width="306" height="84" alt="Screenshot 2025-11-29 at 09 36 53" src="https://github.com/user-attachments/assets/20be9d3a-5e18-44be-ac0d-9fe432fa3a4b" /> |

| iOS Before | iOS After |
|---------|--------|
| <img width="393" height="93" alt="IMG_2115" src="https://github.com/user-attachments/assets/d2215f9d-63ec-4726-b311-d507f3bb93e0" /> | <img width="394" height="93" alt="IMG_2116" src="https://github.com/user-attachments/assets/160cbf0c-1e34-404c-9387-c76502864f50" /> |


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes search bar layout issues on iOS 26 SDK

- Implements platform-specific navigation bar handling

- Uses stacked search bar placement for iOS 26+

- Preserves legacy navigation bar styling for older versions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["iOS 26+ Detection"] --> B["Use titleView with imageView"]
  A --> C["Set stacked search bar placement"]
  D["Pre-iOS 26"] --> E["Apply tint to logo image"]
  D --> F["Set leftBarButtonItem with logo"]
  D --> G["Configure tint colors"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SideMenuView.swift</strong><dd><code>Add iOS 26 conditional navigation bar handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

PVUI/Sources/PVSwiftUI/SideMenu/SideMenuView.swift

<ul><li>Added iOS 26 availability check to conditionally handle navigation bar <br>setup<br> <li> For iOS 26+: uses <code>titleView</code> with <code>UIImageView</code> and sets <br><code>preferredSearchBarPlacement</code> to <code>.stacked</code><br> <li> For pre-iOS 26: preserves existing logic with tinted logo image and <br><code>leftBarButtonItem</code> configuration<br> <li> Refactored navigation bar customization into version-specific branches</ul>


</details>


  </td>
  <td><a href="https://github.com/Provenance-Emu/Provenance/pull/2435/files#diff-04a6aad8f1c0c91805efa0c940dd9869b62e23b8d0f568aa7cdc35da2453d84a">+15/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

