### PR TITLE
Oslog linux support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,11 +200,16 @@ tvos: | update developer_tvos
 open:
 	open Provenance.xcworkspace
 
-## Generate libretro cheat database from libretro-database repo
+## Generate libretro cheat database if missing (for builds/tests)
+ensure-cheatdb:
+	@PVLookup/Scripts/generate_cheatdb_if_needed.sh
+
+## Force-regenerate libretro cheat database from libretro-database repo
 ## Uses MD5 cross-referencing from DAT files for ROM hash lookup support.
 update-cheatdb:
 	$(info Generating libretro cheat database…)
 	rm -rf /tmp/libretro-database
+	rm -f PVLookup/Sources/LibretroCheatDB/Resources/libretro_cheats.sqlite.zip
 	git clone --depth=1 https://github.com/libretro/libretro-database.git /tmp/libretro-database
 	python3 Scripts/generate_cheatdb.py /tmp/libretro-database/cht/ \
 		--dat-dir /tmp/libretro-database \

--- a/PVAudio/Package.resolved
+++ b/PVAudio/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b60709f2200e328ae1032baa03236d4f985786a7670f7db8b4389cdbeb1c51b6",
+  "originHash" : "ced8b41c4330a8b1ff734da0665e50063625a48084cfeae231012d76aaf352dd",
   "pins" : [
     {
       "identity" : "swift-atomics",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
         "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "bbd81b6725ae874c69e9b8c8804d462356b55523",
+        "version" : "1.10.1"
       }
     }
   ],

--- a/PVAudio/Package.swift
+++ b/PVAudio/Package.swift
@@ -2,6 +2,12 @@
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 import PackageDescription
 
+#if os(Linux)
+let privacyResource: [Resource] = []
+#else
+let privacyResource: [Resource] = [.copy("PrivacyInfo.xcprivacy")]
+#endif
+
 let package = Package(
     name: "PVAudio",
     platforms: [
@@ -29,7 +35,6 @@ let package = Package(
     dependencies: [
         .package(name: "PVLogging", path: "../PVLogging/"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.0"),
-
     ],
 
     // MARK: - Targets
@@ -45,7 +50,7 @@ let package = Package(
                 "CARingBuffer",
                 "PVLogging"
             ],
-            resources: [.copy("PrivacyInfo.xcprivacy")]
+            resources: privacyResource
         ),
         // MARK: - RingBuffer Protocol
         .target(
@@ -53,11 +58,8 @@ let package = Package(
             dependencies: [
                 "PVLogging"
             ],
-            resources: [.copy("PrivacyInfo.xcprivacy")]
+            resources: privacyResource
         ),
-        // -----------------------------------------
-        // MARK: - RingBuffer Implementations
-        //==========================================
         // MARK: - PVRingBuffer
         .target(
             name: "PVRingBuffer",
@@ -65,10 +67,9 @@ let package = Package(
                 "RingBuffer",
                 "PVLogging",
                 .product(name: "Atomics", package: "swift-atomics")
-
             ],
             path: "Sources/Ring Buffers/PVRingBuffer",
-            resources: [.copy("PrivacyInfo.xcprivacy")]
+            resources: privacyResource
         ),
         // MARK: - AppleRingBuffer
         .target(
@@ -78,7 +79,7 @@ let package = Package(
                 "PVLogging"
             ],
             path: "Sources/Ring Buffers/AppleRingBuffer",
-            resources: [.copy("PrivacyInfo.xcprivacy")]
+            resources: privacyResource
         ),
         // MARK: - OERingBuffer
         .target(
@@ -88,7 +89,7 @@ let package = Package(
                 "PVLogging"
             ],
             path: "Sources/Ring Buffers/OERingBuffer",
-            resources: [.copy("PrivacyInfo.xcprivacy")]
+            resources: privacyResource
         ),
         // MARK: - CARingBuffer
         .target(
@@ -98,9 +99,8 @@ let package = Package(
                 "PVLogging"
             ],
             path: "Sources/Ring Buffers/CARingBuffer",
-            resources: [.copy("PrivacyInfo.xcprivacy")]
+            resources: privacyResource
         ),
-        // -----------------------------------------
         // MARK: - Tests
         .testTarget(
             name: "PVAudioTests",

--- a/PVAudio/Sources/RingBuffer/RingBufferProtocol.swift
+++ b/PVAudio/Sources/RingBuffer/RingBufferProtocol.swift
@@ -9,7 +9,10 @@ import Foundation
 
 public typealias RingBufferSize = Int
 
-@objc public protocol RingBufferProtocol {
+#if canImport(ObjectiveC)
+@objc
+#endif
+public protocol RingBufferProtocol {
 
     init?(withLength: RingBufferSize)
 
@@ -20,7 +23,6 @@ public typealias RingBufferSize = Int
     @discardableResult func read(_ buffer: UnsafeMutableRawPointer, preferredSize: RingBufferSize) -> RingBufferSize
 
     func reset()
-//    func set(length: RingBufferSize)
 
-    @objc var availableBytes: RingBufferSize { get }
+    var availableBytes: RingBufferSize { get }
 }

--- a/PVCheevos/Sources/PVCheevos/Network/RetroNetworkClient.swift
+++ b/PVCheevos/Sources/PVCheevos/Network/RetroNetworkClient.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// Network client for RetroAchievements API communication
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, *)

--- a/PVCheevos/Sources/PVCheevos/Network/URLSessionProtocol.swift
+++ b/PVCheevos/Sources/PVCheevos/Network/URLSessionProtocol.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// Protocol for URLSession to enable dependency injection and testing
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, *)
@@ -7,5 +10,24 @@ public protocol URLSessionProtocol: Sendable {
 }
 
 /// Extension to make URLSession conform to the protocol
+#if os(Linux)
+extension URLSession: URLSessionProtocol {
+    public func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        try await withCheckedThrowingContinuation { continuation in
+            let task = self.dataTask(with: request) { data, response, error in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else if let data = data, let response = response {
+                    continuation.resume(returning: (data, response))
+                } else {
+                    continuation.resume(throwing: URLError(.unknown))
+                }
+            }
+            task.resume()
+        }
+    }
+}
+#else
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, *)
 extension URLSession: URLSessionProtocol {}
+#endif

--- a/PVCheevos/Sources/PVCheevos/PVCheevos.swift
+++ b/PVCheevos/Sources/PVCheevos/PVCheevos.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// Main entry point for the PVCheevos library
 /// Provides convenient access to RetroAchievements API functionality

--- a/PVCheevos/Sources/PVCheevos/RetroAchievementsClient.swift
+++ b/PVCheevos/Sources/PVCheevos/RetroAchievementsClient.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// Main client for accessing the RetroAchievements API
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, *)

--- a/PVCheevos/Tests/PVCheevosTests/PVCheevosTests.swift
+++ b/PVCheevos/Tests/PVCheevosTests/PVCheevosTests.swift
@@ -1,5 +1,8 @@
 import Testing
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 @testable import PVCheevos
 
 /// Thread-safe response queue for multi-request mock sequences
@@ -34,8 +37,8 @@ class MockURLSession: URLSessionProtocol, @unchecked Sendable {
             let response = HTTPURLResponse(
                 url: request.url!,
                 statusCode: next.statusCode,
-                httpVersion: nil,
-                headerFields: nil
+                httpVersion: nil as String?,
+                headerFields: nil as [String: String]?
             )!
             return (next.data, response)
         }
@@ -44,8 +47,8 @@ class MockURLSession: URLSessionProtocol, @unchecked Sendable {
         let response = mockResponse ?? HTTPURLResponse(
             url: request.url!,
             statusCode: 200,
-            httpVersion: nil,
-            headerFields: nil
+            httpVersion: nil as String?,
+            headerFields: nil as [String: String]?
         )!
 
         return (data, response)
@@ -56,8 +59,8 @@ class MockURLSession: URLSessionProtocol, @unchecked Sendable {
         self.mockResponse = HTTPURLResponse(
             url: URL(string: "https://example.com")!,
             statusCode: statusCode,
-            httpVersion: nil,
-            headerFields: nil
+            httpVersion: nil as String?,
+            headerFields: nil as [String: String]?
         )
     }
 

--- a/PVCoreAudio/Legacy/OtherEngines/OEGameAudio.swift
+++ b/PVCoreAudio/Legacy/OtherEngines/OEGameAudio.swift
@@ -24,12 +24,16 @@
 
 import Foundation
 import AVFoundation
+#if canImport(OSLog)
 @_implementationOnly import os.log
+#endif
 import OpenEmuBase.OEGameCore
 
+#if canImport(OSLog)
 extension OSLog {
     static let audio = OSLog(subsystem: "org.openemu.OpenEmuKit", category: "GameAudio")
 }
+#endif
 
 @available(macOS, deprecated: 10.15, obsoleted: 11.0)
 final public class GameAudio: GameAudioProtocol {
@@ -104,8 +108,10 @@ final public class GameAudio: GameAudioProtocol {
         do {
             try engine.start()
         } catch {
+            #if canImport(os)
             os_log(.error, log: .audio, "Unable to start AVAudioEngine: %{public}s",
                    error.localizedDescription)
+            #endif
         }
     }
     
@@ -116,7 +122,9 @@ final public class GameAudio: GameAudioProtocol {
             .addObserver(forName: .AVAudioEngineConfigurationChange, object: engine, queue: .main) { [weak self] _ in
                 guard let self = self else { return }
                 
+                #if canImport(os)
                 os_log(.info, log: .audio, "AVAudioEngine configuration change")
+                #endif
                 self.setOutputDeviceID(self.outputDeviceID)
             }
     }
@@ -189,8 +197,10 @@ final public class GameAudio: GameAudioProtocol {
         do {
             try bus.setFormat(renderFormat)
         } catch {
+            #if canImport(os)
             os_log(.error, log: .audio, "Unable to set input bus render format %{public}s: %{public}s",
                    renderFormat.description, error.localizedDescription)
+            #endif
             return
         }
         
@@ -232,7 +242,9 @@ final public class GameAudio: GameAudioProtocol {
         if newOutputDeviceID == 0 {
             id = defaultAudioOutputDeviceID
             isDefaultOutputDevice = true
+            #if canImport(os)
             os_log(.info, log: .audio, "Using default audio device %d", id)
+            #endif
         } else {
             id = newOutputDeviceID
             isDefaultOutputDevice = false
@@ -243,8 +255,10 @@ final public class GameAudio: GameAudioProtocol {
         do {
             try engine.outputNode.auAudioUnit.setDeviceID(id)
         } catch {
+            #if canImport(os)
             os_log(.error, log: .audio, "Unable to set output device ID %d: %{public}s",
                    id, error.localizedDescription)
+            #endif
         }
         
         connectNodes()

--- a/PVCoreAudio/Legacy/OtherEngines/OEGameAudio2.swift
+++ b/PVCoreAudio/Legacy/OtherEngines/OEGameAudio2.swift
@@ -24,11 +24,15 @@
 
 import Foundation
 import AVFoundation
-@_implementationOnly import os
+#if canImport(OSLog)
+@_implementationOnly import OSLog
+#endif
 import OpenEmuBase.OEGameCore
 
+#if canImport(OSLog)
 @available(macOS 11.0, iOS 14.0, *)
 private var log = Logger(subsystem: "org.openemu.OpenEmuKit", category: "GameAudio2")
+#endif
 
 @available(macOS 11.0, iOS 14.0, *)
 final public class GameAudio2: GameAudioProtocol {
@@ -101,7 +105,9 @@ final public class GameAudio2: GameAudioProtocol {
         do {
             try engine.start()
         } catch {
+            #if canImport(OSLog)
             log.error("Unable to start AVAudioEngine: \(error.localizedDescription, privacy: .public)")
+            #endif
         }
     }
     
@@ -188,7 +194,9 @@ final public class GameAudio2: GameAudioProtocol {
             .addObserver(forName: .AVAudioEngineConfigurationChange, object: engine, queue: .main) { [weak self] _ in
                 guard let self = self else { return }
                 
+                #if canImport(OSLog)
                 log.debug("AVAudioEngine configuration change")
+                #endif
                 self.setOutputDeviceID(self.outputDeviceID)
             }
     }
@@ -215,7 +223,9 @@ final public class GameAudio2: GameAudioProtocol {
         if newOutputDeviceID == 0 {
             id = defaultAudioOutputDeviceID
             isDefaultOutputDevice = true
+            #if canImport(OSLog)
             log.debug("Using default audio device \(id)")
+            #endif
         } else {
             id = newOutputDeviceID
             isDefaultOutputDevice = false
@@ -226,7 +236,9 @@ final public class GameAudio2: GameAudioProtocol {
         do {
             try engine.outputNode.auAudioUnit.setDeviceID(id)
         } catch {
+            #if canImport(OSLog)
             log.error("Unable to set output device ID \(id): \(error.localizedDescription, privacy: .public)")
+            #endif
         }
         
         connectNodes()

--- a/PVCoreAudio/Sources/PVCoreAudio/Utilities/PVMuteSwitchMonitor.swift
+++ b/PVCoreAudio/Sources/PVCoreAudio/Utilities/PVMuteSwitchMonitor.swift
@@ -1,5 +1,8 @@
 import Foundation
-import os.log
+import PVLogging
+#if canImport(os)
+import os
+#endif
 import notify
 //import NotifyWrapper
 
@@ -30,7 +33,11 @@ public final class PVMuteSwitchMonitor {
                 self.isMuted = (state == 0)
                 muteHandler(self.isMuted)
             } else {
+                #if canImport(os)
                 os_log("Failed to get mute state. Error: %d", log: .default, type: .error, result)
+                #else
+                ELOG("Failed to get mute state. Error: \(result)")
+                #endif
             }
         }
 
@@ -52,7 +59,11 @@ public final class PVMuteSwitchMonitor {
         if status == NOTIFY_STATUS_OK {
             updateMutedState()
         } else {
+            #if canImport(os)
             os_log("Failed to register for mute switch notifications. Error: %d", log: .default, type: .error, status)
+            #else
+            ELOG("Failed to register for mute switch notifications. Error: \(status)")
+            #endif
         }
     }
 

--- a/PVHashing/Package.resolved
+++ b/PVHashing/Package.resolved
@@ -1,13 +1,31 @@
 {
-  "originHash" : "e8a5becb36b471775f1971c2482a5bc8bb499ca781ea8f146c6c921102e1fbbd",
+  "originHash" : "ae5fd80cce1bb259e749b25cb946dac1a60bc715d056afa909f5146818ac19be",
   "pins" : [
     {
-      "identity" : "checksum",
+      "identity" : "swift-asn1",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/JoeMatt/Checksum.git",
+      "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "11bf55d6ec0e4dbfff2bcd99b6b12c5ce5d57b91",
-        "version" : "1.1.1"
+        "revision" : "810496cf121e525d660cd0ea89a758740476b85f",
+        "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
+        "version" : "3.15.1"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "bbd81b6725ae874c69e9b8c8804d462356b55523",
+        "version" : "1.10.1"
       }
     }
   ],

--- a/PVHashing/Package.swift
+++ b/PVHashing/Package.swift
@@ -2,6 +2,18 @@
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 import PackageDescription
 
+#if os(Linux)
+let checksumDep: [Package.Dependency] = []
+let checksumTarget: [Target.Dependency] = []
+#else
+let checksumDep: [Package.Dependency] = [
+    .package(url: "https://github.com/JoeMatt/Checksum.git", from: "1.1.1"),
+]
+let checksumTarget: [Target.Dependency] = [
+    "Checksum",
+]
+#endif
+
 let package = Package(
     name: "PVHashing",
     platforms: [
@@ -20,13 +32,15 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../PVLogging"),
-//        .package(url: "https://github.com/rnine/Checksum.git", from: "1.0.2")
-        .package(url: "https://github.com/JoeMatt/Checksum.git", from: "1.1.1")
-    ],
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0"),
+    ] + checksumDep,
     targets: [
         .target(
             name: "PVHashing",
-            dependencies: [ "Checksum", "PVLogging" ]
+            dependencies: [
+                "PVLogging",
+                .product(name: "Crypto", package: "swift-crypto"),
+            ] + checksumTarget
         ),
 
         // MARK: SwiftPM tests

--- a/PVHashing/Sources/PVHashing/FileHashing+Async.swift
+++ b/PVHashing/Sources/PVHashing/FileHashing+Async.swift
@@ -1,4 +1,8 @@
+#if canImport(CryptoKit)
 import CryptoKit
+#else
+import Crypto
+#endif
 import Foundation
 import PVLogging
 

--- a/PVHashing/Sources/PVHashing/NSData+Hashing.swift
+++ b/PVHashing/Sources/PVHashing/NSData+Hashing.swift
@@ -1,7 +1,13 @@
+#if canImport(CryptoKit)
 import CryptoKit
+#else
+import Crypto
+#endif
 import Foundation
 
+#if canImport(ObjectiveC)
 @objc
+#endif
 public extension NSData {
     var md5: String {
         let computed = Insecure.MD5.hash(data: self)

--- a/PVHashing/Sources/PVHashing/NSFileManager+Hashing.swift
+++ b/PVHashing/Sources/PVHashing/NSFileManager+Hashing.swift
@@ -1,8 +1,16 @@
+#if canImport(CryptoKit)
+import CryptoKit
+#else
+import Crypto
+#endif
+#if canImport(Checksum)
 import Checksum
+#endif
 import Foundation
 import PVLogging
-import CryptoKit
+#if canImport(Combine)
 import Combine
+#endif
 
 /// Notification names for file access errors and coordination
 public extension Notification.Name {
@@ -22,11 +30,11 @@ extension FileManager: MD5Provider {
             return md5Hash
         } catch {
             ELOG("An error occurred: \(error)\nFile: \(url)")
-            
+
             // Post notification for file access error
             let nsError = error as NSError
             let errorType = determineErrorType(nsError)
-            
+
             Task { @MainActor in
                 NotificationCenter.default.post(
                     name: .fileAccessError,
@@ -40,13 +48,14 @@ extension FileManager: MD5Provider {
                     ]
                 )
             }
-            
+
             return nil
         }
         #endif
     }
 }
 
+#if canImport(Combine)
 /// Asynchronously reads a local file and calculates the MD5 checksum.
 /// - Parameters:
 ///   - fileURL: The URL of the file.
@@ -64,7 +73,7 @@ func calculateMD5(of fileURL: URL, startingAt offset: UInt64 = 0) -> AnyPublishe
             // If retryable, introduce a delay before retrying
             return Fail(error: error) // Emit the error to trigger retry
                 .delay(for: .seconds(1), scheduler: DispatchQueue.global()) // Wait 1 second
-                .eraseToAnyPublisher() 
+                .eraseToAnyPublisher()
         } else {
             // If not retryable, fail immediately
             return Fail(error: error).eraseToAnyPublisher()
@@ -80,7 +89,7 @@ private func calculateMD5Attempt(fileURL: URL, offset: UInt64, promise: @escapin
         do {
             let fileHandle = try FileHandle(forReadingFrom: fileURL)
             defer { fileHandle.closeFile() }
-            
+
             if offset > 0 {
                 // Recommended way for macOS 10.15.4+ and iOS 13.4+
                 if #available(macOS 10.15.4, iOS 13.4, tvOS 13.4, *) {
@@ -90,10 +99,10 @@ private func calculateMD5Attempt(fileURL: URL, offset: UInt64, promise: @escapin
                     fileHandle.seek(toFileOffset: offset)
                 }
             }
-            
+
             var hasher = Insecure.MD5()
             let bufferSize: Int = 1024 * 1024 // 1 MB
-            
+
             while true {
                 // Autorelease pool for efficient memory management during read loop
                 let data = try autoreleasepool { () -> Data? in
@@ -104,16 +113,16 @@ private func calculateMD5Attempt(fileURL: URL, offset: UInt64, promise: @escapin
                         return fileHandle.readData(ofLength: bufferSize)
                     }
                 }
-                
+
                 guard let chunk = data, !chunk.isEmpty else {
                     break // End of file
                 }
                 hasher.update(data: chunk)
             }
-            
+
             let result = hasher.finalize()
             let hashString = result.map { String(format: "%02x", $0) }.joined().uppercased()
-            
+
             promise(.success(hashString))
         } catch {
             VLOG("calculateMD5Attempt failed for \(fileURL.lastPathComponent): \(error.localizedDescription)")
@@ -157,7 +166,7 @@ func calculateMD5Synchronously(of fileURL: URL, startingAt offset: UInt64 = 0) t
         // Throw a generic error or a more specific one if possible
         throw NSError(domain: "PVHashingErrorDomain", code: 1, userInfo: [NSLocalizedDescriptionKey: "MD5 calculation produced an empty hash."])
     }
-    
+
     return md5Hash.uppercased()
 }
 
@@ -178,6 +187,26 @@ public extension URL {
     }
 }
 
+#else
+
+/// Direct synchronous MD5 calculation without Combine (used on Linux)
+func calculateMD5Synchronously(of fileURL: URL, startingAt offset: UInt64 = 0) throws -> String {
+    return try _computeMD5(of: fileURL, startingAt: offset)
+}
+
+public extension URL {
+    /// Asynchronously computes the MD5 hash of the file using Swift structured concurrency.
+    func md5Async(startingAt offset: UInt64 = 0) async throws -> String {
+        try await calculateMD5Async(of: self, startingAt: offset)
+    }
+
+    /// Streams progress events and the final MD5 hash via `AsyncThrowingStream`.
+    func md5Stream(startingAt offset: UInt64 = 0) -> AsyncThrowingStream<MD5HashingEvent, Error> {
+        calculateMD5Stream(of: self, startingAt: offset)
+    }
+}
+#endif
+
 // MARK: - Error Handling Helpers
 
 /// Determine the type of error for better user feedback
@@ -186,23 +215,23 @@ func determineErrorType(_ error: NSError) -> String {
     if error.domain == NSPOSIXErrorDomain && error.code == 60 {
         return "timeout"
     }
-    
+
     // Check for file access errors
     if error.domain == NSCocoaErrorDomain && error.code == 256 {
         return "access_denied"
     }
-    
+
     // Check for iCloud-related errors
-    if error.domain == NSCocoaErrorDomain && 
+    if error.domain == NSCocoaErrorDomain &&
        (error.userInfo[NSUnderlyingErrorKey] as? NSError)?.domain == NSPOSIXErrorDomain {
         return "icloud_access"
     }
-    
+
     // Check for NSFileProviderInternalErrorDomain errors (iCloud file provider errors)
     if error.domain == "NSFileProviderInternalErrorDomain" {
         return "file_provider_error"
     }
-    
+
     return "unknown"
 }
 
@@ -212,7 +241,7 @@ func isRetryableError(_ error: NSError) -> Bool {
     if error.domain == NSPOSIXErrorDomain && error.code == 60 {
         return true
     }
-    
+
     // Some file access errors might be temporary
     if error.domain == NSCocoaErrorDomain && error.code == 256 {
         // Check if it's a temporary file system issue
@@ -221,6 +250,6 @@ func isRetryableError(_ error: NSError) -> Bool {
             return true
         }
     }
-    
+
     return false
 }

--- a/PVHashing/Sources/PVHashing/NSString+Hashing.swift
+++ b/PVHashing/Sources/PVHashing/NSString+Hashing.swift
@@ -1,4 +1,8 @@
+#if canImport(CryptoKit)
 import CryptoKit
+#else
+import Crypto
+#endif
 import Foundation
 
 public extension String {

--- a/PVHashing/Tests/PVHashingTests/NSFileManager+HashingTests.swift
+++ b/PVHashing/Tests/PVHashingTests/NSFileManager+HashingTests.swift
@@ -6,6 +6,9 @@
 //
 
 import XCTest
+#if canImport(Combine)
+import Combine
+#endif
 @testable import PVHashing
 
 class ChecksumTests: XCTestCase {
@@ -32,6 +35,7 @@ class ChecksumTests: XCTestCase {
         let content = try! String(contentsOf: url)
     }
 
+    #if canImport(Combine)
     func testCalculateMD5Asynchronously() throws {
         let expectation = XCTestExpectation(description: "Calculate MD5 asynchronously")
 
@@ -50,6 +54,7 @@ class ChecksumTests: XCTestCase {
 
         wait(for: [expectation], timeout: 5.0)
     }
+    #endif
 
     func testCalculateMD5Synchronously() {
         // This hash corresponds to "Hello, world!" with MD5

--- a/PVLibrary/Sources/PVLibrary/Cloud Sync/iCloud/CloudSyncLogManager.swift
+++ b/PVLibrary/Sources/PVLibrary/Cloud Sync/iCloud/CloudSyncLogManager.swift
@@ -10,7 +10,9 @@ import Foundation
 import PVLogging
 import Combine
 import CloudKit
-import os.log
+#if canImport(OSLog)
+import OSLog
+#endif
 
 /// Log level for cloud sync operations
 public enum CloudLogLevel: String, Codable {

--- a/PVLibrary/Sources/SwiftCloudDrive/FileMonitor.swift
+++ b/PVLibrary/Sources/SwiftCloudDrive/FileMonitor.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import os
+import PVLogging
 
 /// Monitors changes to files using file presenter. Used to notifiy of changes
 /// from remote devices.
@@ -61,7 +61,7 @@ final class FileMonitor: NSObject, NSFilePresenter, @unchecked Sendable {
             }
             informOfChange(at: version.url)
         } catch {
-            os_log("Failed to handle cloud metadata")
+            ELOG("Failed to handle cloud metadata")
         }
     }
     

--- a/PVLibrary/Sources/SwiftCloudDrive/MetadataMonitor.swift
+++ b/PVLibrary/Sources/SwiftCloudDrive/MetadataMonitor.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import os
+import PVLogging
 
 /// Monitors changes to the metadata, to trigger downloads of new files or updates.
 final class MetadataMonitor: @unchecked Sendable {
@@ -58,7 +58,7 @@ final class MetadataMonitor: @unchecked Sendable {
             do {
                 try fileManager.startDownloadingUbiquitousItem(at: url)
             } catch {
-                os_log("Failed to start downloading file")
+                ELOG("Failed to start downloading file")
             }
         }
     }

--- a/PVLogging/Package.resolved
+++ b/PVLogging/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "6f07e53c51f65f9e443e478f770ef1613170c8d6fd03cbaf1ca4b89d1728101d",
+  "pins" : [
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "bbd81b6725ae874c69e9b8c8804d462356b55523",
+        "version" : "1.10.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/PVLogging/Package.swift
+++ b/PVLogging/Package.swift
@@ -2,6 +2,26 @@
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 import PackageDescription
 
+#if os(Linux)
+let extraProducts: [Product] = []
+let extraTargets: [Target] = []
+#else
+let extraProducts: [Product] = [
+    .library(
+        name: "PVLoggingObjC",
+        targets: ["PVLogging", "PVLoggingObjC"]),
+]
+let extraTargets: [Target] = [
+    .target(
+        name: "PVLoggingObjC",
+        dependencies: [
+            "PVLogging"
+        ],
+        publicHeadersPath: "include/"
+    ),
+]
+#endif
+
 let package = Package(
     name: "PVLogging",
     platforms: [
@@ -13,68 +33,28 @@ let package = Package(
         .visionOS(.v1)
     ],
     products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "PVLogging",
-            targets: ["PVLogging", "PVLoggingObjC"]),
+            targets: ["PVLogging"]),
         .library(
             name: "PVLogging-Dynamic",
             type: .dynamic,
-            targets: ["PVLogging", "PVLoggingObjC"]),
+            targets: ["PVLogging"]),
         .library(
             name: "PVLogging-Static",
             type: .static,
-            targets: ["PVLogging", "PVLoggingObjC"]),
-    ],
+            targets: ["PVLogging"]),
+    ] + extraProducts,
     dependencies: [
-        // Dependencies declare other packages that this package depends on.
-//        .package(
-//            url: "https://github.com/CocoaLumberjack/CocoaLumberjack",
-//            .upToNextMajor(from: "3.8.0")),
-//        .package(url: "https://github.com/fpillet/NSLogger", branch: "master")
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.6.0"),
     ],
     targets: [
         .target(
-            name: "PVLoggingObjC",
-            dependencies: [
-                "PVLogging"
-//                .product(name: "CocoaLumberjack", package: "CocoaLumberjack"),
-//                .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack"),
-//                .product(name: "CocoaLumberjackSwiftLogBackend", package: "CocoaLumberjack"),
-//                "NSLogger"
-            ],
-            publicHeadersPath: "include/"
-        ),
-
-        .target(
             name: "PVLogging",
             dependencies: [
-//                .product(name: "CocoaLumberjack", package: "CocoaLumberjack"),
-//                .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack"),
-//                .product(name: "CocoaLumberjackSwiftLogBackend", package: "CocoaLumberjack"),
-//                "NSLogger"
+                .product(name: "Logging", package: "swift-log"),
             ],
             resources: [.copy("PrivacyInfo.xcprivacy")]
-//            publicHeadersPath: "include/"
-            //            ,
-            //            cSettings: [
-            //                .headerSearchPath("."),
-            //                .headerSearchPath("include"),
-            //                .headerSearchPath("include/PVLogging"),
-            //            ]
-            // This breaks ObjC Cocoalumberjack to Swift bindings for option types
-            //                swiftSettings: [
-            //                    .unsafeFlags([
-            //                        "-Xfrontend", "-enable-cxx-interop",
-            //                        //                    "-Xfrontend", "-validate-tbd-against-ir=none",
-            //                        //                    "-I", "Sources/CXX/include",
-            //                        //                    "-I", "\(sdkRoot)/usr/include",
-            //                        //                    "-I", "\(cPath)",
-            //                        //                    "-lc++",
-            //                        //                    "-Xfrontend", "-disable-implicit-concurrency-module-import",
-            //                        //                    "-Xcc", "-nostdinc++"
-            //                    ])
-            //                ]
         ),
 
         // MARK: SwiftPM tests
@@ -82,7 +62,7 @@ let package = Package(
             name: "PVLoggingTests",
             dependencies: ["PVLogging"],
             path: "Tests")
-    ],
+    ] + extraTargets,
     swiftLanguageModes: [.v5, .v6],
     cLanguageStandard: .gnu17,
     cxxLanguageStandard: .gnucxx20

--- a/PVLogging/Package.swift
+++ b/PVLogging/Package.swift
@@ -3,9 +3,11 @@
 import PackageDescription
 
 #if os(Linux)
+let loggingProductTargets: [String] = ["PVLogging"]
 let extraProducts: [Product] = []
 let extraTargets: [Target] = []
 #else
+let loggingProductTargets: [String] = ["PVLogging", "PVLoggingObjC"]
 let extraProducts: [Product] = [
     .library(
         name: "PVLoggingObjC",
@@ -35,15 +37,15 @@ let package = Package(
     products: [
         .library(
             name: "PVLogging",
-            targets: ["PVLogging"]),
+            targets: loggingProductTargets),
         .library(
             name: "PVLogging-Dynamic",
             type: .dynamic,
-            targets: ["PVLogging"]),
+            targets: loggingProductTargets),
         .library(
             name: "PVLogging-Static",
             type: .static,
-            targets: ["PVLogging"]),
+            targets: loggingProductTargets),
     ] + extraProducts,
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git", from: "1.6.0"),

--- a/PVLogging/Sources/PVLogging/Models/LevelString.swift
+++ b/PVLogging/Sources/PVLogging/Models/LevelString.swift
@@ -7,7 +7,9 @@
 
 import Foundation
 
+#if canImport(ObjectiveC)
 @objc
+#endif
 public enum LevelString: Int {
     case U
     case Error

--- a/PVLogging/Sources/PVLogging/Models/PVLogLevel.swift
+++ b/PVLogging/Sources/PVLogging/Models/PVLogLevel.swift
@@ -7,7 +7,9 @@
 
 import Foundation
 
+#if canImport(ObjectiveC)
 @objc
+#endif
 public enum PVLogLevel: Int, CaseIterable, Sendable {
     case U
     case Error

--- a/PVLogging/Sources/PVLogging/PVLogEntry.swift
+++ b/PVLogging/Sources/PVLogging/PVLogEntry.swift
@@ -10,7 +10,9 @@ nonisolated(unsafe) internal var __PVLogEntryIndexCounter:UInt = 0
 // Used to calculate offsets
 internal let __PVLoggingStartupTime: Date = Date()
 
+#if canImport(ObjectiveC)
 @objc
+#endif
 public final class PVLogEntry: NSObject {
     public let time: Date
     public let entryIndex: UInt
@@ -31,7 +33,9 @@ public final class PVLogEntry: NSObject {
         }
     }
     
+    #if canImport(ObjectiveC)
     @objc
+    #endif
     public convenience init(message: String) {
         self.init()
         self.text = message

--- a/PVLogging/Sources/PVLogging/PVLogFunctions.swift
+++ b/PVLogging/Sources/PVLogging/PVLogFunctions.swift
@@ -5,7 +5,14 @@
 //  Created by Joseph Mattiello on 1/17/23.
 //
 
+import Foundation
+import Logging
+
+#if canImport(OSLog)
 import OSLog
+
+/// On Apple platforms, PVLogCategory is os.Logger
+public typealias PVLogCategory = os.Logger
 
 extension os.Logger: Sendable {
     /// Using your bundle identifier is a great way to ensure a unique identifier.
@@ -34,6 +41,46 @@ extension os.Logger: Sendable {
     public static let general = Logger(subsystem: subsystem, category: "general")
 }
 
+#else
+
+/// Cross-platform logging category backed by swift-log
+public struct PVLogCategory: Sendable {
+    /// The underlying swift-log Logger instance
+    public let logger: Logging.Logger
+    /// Category name for display
+    public let categoryName: String
+
+    public init(subsystem: String, category: String) {
+        var logger = Logging.Logger(label: "\(subsystem).\(category)")
+        logger.logLevel = .trace
+        self.logger = logger
+        self.categoryName = category
+    }
+
+    /// Logs the view cycles like a view that appeared.
+    public static let viewCycle = PVLogCategory(subsystem: "provenance", category: "viewcycle")
+
+    /// All logs related to tracking and analytics.
+    public static let statistics = PVLogCategory(subsystem: "provenance", category: "statistics")
+
+    /// All logs related to networking.
+    public static let networking = PVLogCategory(subsystem: "provenance", category: "network")
+
+    /// All logs related to video processing and rendering.
+    public static let video = PVLogCategory(subsystem: "provenance", category: "video")
+
+    /// All logs related to audio processing and rendering.
+    public static let audio = PVLogCategory(subsystem: "provenance", category: "audio")
+
+    /// All logs related to libraries and databases.
+    public static let database = PVLogCategory(subsystem: "provenance", category: "database")
+
+    /// General logs
+    /// - Note: This is the default logger.
+    public static let general = PVLogCategory(subsystem: "provenance", category: "general")
+}
+#endif
+
 /// current Date/Time stamp using the ISO-8601 format and the device's time zone
 public var currentDatTimeStamp: String {
     let formatter = ISO8601DateFormatter()
@@ -43,8 +90,8 @@ public var currentDatTimeStamp: String {
 
 @inlinable
 public func log(_ message: @autoclosure () -> String,
-                level: OSLogType = .debug,
-                category: Logger = .general,
+                level: LogLevel = .debug,
+                category: PVLogCategory = .general,
                 file: String = #file,
                 function: String = #function,
                 line: Int = #line) {
@@ -57,30 +104,45 @@ public func log(_ message: @autoclosure () -> String,
         emoji = "ℹ️"
     case .error:
         emoji = "❌"
-    case .fault:
-        emoji = "💥"
-    default:
+    case .warning:
+        emoji = "⚠️"
+    case .verbose:
         emoji = "🔬"
     }
     let logMessage = "\(emoji) \(currentDatTimeStamp) \(fileName):\(line) - \(function): \(message())"
 
+    #if canImport(OSLog)
     switch level {
-    case .debug:
+    case .debug, .verbose:
         category.debug("\(logMessage, privacy: .public)")
     case .info:
         category.info("\(logMessage, privacy: .public)")
+    case .warning:
+        category.log(level: .default, "\(logMessage, privacy: .public)")
     case .error:
         category.error("\(logMessage, privacy: .public)")
-    case .fault:
-        category.fault("\(logMessage, privacy: .public)")
-    default:
-        category.log(level: level, "\(logMessage, privacy: .public)")
     }
+    #else
+    let swiftLogLevel: Logging.Logger.Level
+    switch level {
+    case .verbose:
+        swiftLogLevel = .trace
+    case .debug:
+        swiftLogLevel = .debug
+    case .info:
+        swiftLogLevel = .info
+    case .warning:
+        swiftLogLevel = .warning
+    case .error:
+        swiftLogLevel = .error
+    }
+    category.logger.log(level: swiftLogLevel, "\(logMessage)")
+    #endif
 }
 
 // Update convenience functions to include emojis
 @inlinable
-public func DLOG(_ message: @autoclosure () -> String, category: Logger = .general, file: String = #file, function: String = #function, line: Int = #line) {
+public func DLOG(_ message: @autoclosure () -> String, category: PVLogCategory = .general, file: String = #file, function: String = #function, line: Int = #line) {
     #if DEBUG
     let msg = message()
     log(msg, level: .debug, category: category, file: file, function: function, line: line)
@@ -89,29 +151,29 @@ public func DLOG(_ message: @autoclosure () -> String, category: Logger = .gener
 }
 
 @inlinable
-public func ILOG(_ message: @autoclosure () -> String, category: Logger = .general, file: String = #file, function: String = #function, line: Int = #line) {
+public func ILOG(_ message: @autoclosure () -> String, category: PVLogCategory = .general, file: String = #file, function: String = #function, line: Int = #line) {
     let msg = message()
     log(msg, level: .info, category: category, file: file, function: function, line: line)
     PVLogPublisher.shared.info(msg, category: category, file: file, function: function, line: line)
 }
 
 @inlinable
-public func ELOG(_ message: @autoclosure () -> String, category: Logger = .general, file: String = #file, function: String = #function, line: Int = #line) {
+public func ELOG(_ message: @autoclosure () -> String, category: PVLogCategory = .general, file: String = #file, function: String = #function, line: Int = #line) {
     let msg = message()
     log(msg, level: .error, category: category, file: file, function: function, line: line)
     PVLogPublisher.shared.error(msg, category: category, file: file, function: function, line: line)
 }
 
 @inlinable
-public func WLOG(_ message: @autoclosure () -> String, category: Logger = .general, file: String = #file, function: String = #function, line: Int = #line) {
+public func WLOG(_ message: @autoclosure () -> String, category: PVLogCategory = .general, file: String = #file, function: String = #function, line: Int = #line) {
     let msg = message()
     let warningPrefix = "⚠️"
-    log(warningPrefix + " " + msg, level: .info, category: category, file: file, function: function, line: line)
+    log(warningPrefix + " " + msg, level: .warning, category: category, file: file, function: function, line: line)
     PVLogPublisher.shared.warning(msg, category: category, file: file, function: function, line: line)
 }
 
 @inlinable
-public func VLOG(_ message: @autoclosure () -> String, category: Logger = .general, file: String = #file, function: String = #function, line: Int = #line) {
+public func VLOG(_ message: @autoclosure () -> String, category: PVLogCategory = .general, file: String = #file, function: String = #function, line: Int = #line) {
     #if DEBUG
     let msg = message()
     log(msg, level: .debug, category: category, file: file, function: function, line: line)
@@ -119,30 +181,32 @@ public func VLOG(_ message: @autoclosure () -> String, category: Logger = .gener
     #endif
 }
 
+#if canImport(ObjectiveC)
 @objc
 public final class PVLoggingObjC: NSObject {
     @objc
     public static func Vlog(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
         VLOG(message, file: file, function: function, line: line)
     }
-    
+
     @objc
     public static func Dlog(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
         DLOG(message, file: file, function: function, line: line)
     }
-    
+
     @objc
     public static func Ilog(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
         ILOG(message, file: file, function: function, line: line)
     }
-    
+
     @objc
     public  static func Elog(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
         ELOG(message, file: file, function: function, line: line)
     }
-    
+
     @objc
     public static func Wlog(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
         WLOG(message, file: file, function: function, line: line)
     }
 }
+#endif

--- a/PVLogging/Sources/PVLogging/PVLogFunctions.swift
+++ b/PVLogging/Sources/PVLogging/PVLogFunctions.swift
@@ -176,7 +176,7 @@ public func WLOG(_ message: @autoclosure () -> String, category: PVLogCategory =
 public func VLOG(_ message: @autoclosure () -> String, category: PVLogCategory = .general, file: String = #file, function: String = #function, line: Int = #line) {
     #if DEBUG
     let msg = message()
-    log(msg, level: .debug, category: category, file: file, function: function, line: line)
+    log(msg, level: .verbose, category: category, file: file, function: function, line: line)
     PVLogPublisher.shared.verbose(msg, category: category, file: file, function: function, line: line)
     #endif
 }

--- a/PVLogging/Sources/PVLogging/PVLogFunctionsExtension.swift
+++ b/PVLogging/Sources/PVLogging/PVLogFunctionsExtension.swift
@@ -15,7 +15,7 @@ public func VLOG(_ message: @autoclosure () -> String,
                  function: String = #function,
                  line: Int = #line) {
     let msg = message()
-    log(msg, level: .debug, category: .general, file: file, function: function, line: line)
+    log(msg, level: .verbose, category: .general, file: file, function: function, line: line)
 
     // Also send to the publisher
     PVLogPublisher.shared.verbose(msg, file: file, function: function, line: line)

--- a/PVLogging/Sources/PVLogging/PVLogFunctionsExtension.swift
+++ b/PVLogging/Sources/PVLogging/PVLogFunctionsExtension.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import OSLog
 
 /// Extension to connect the existing log functions with the new PVLogPublisher
 @inlinable
@@ -17,7 +16,7 @@ public func VLOG(_ message: @autoclosure () -> String,
                  line: Int = #line) {
     let msg = message()
     log(msg, level: .debug, category: .general, file: file, function: function, line: line)
-    
+
     // Also send to the publisher
     PVLogPublisher.shared.verbose(msg, file: file, function: function, line: line)
 }
@@ -30,7 +29,7 @@ public func DLOG(_ message: @autoclosure () -> String,
                  line: Int = #line) {
     let msg = message()
     log(msg, level: .debug, category: .general, file: file, function: function, line: line)
-    
+
     // Also send to the publisher
     PVLogPublisher.shared.debug(msg, file: file, function: function, line: line)
 }
@@ -48,7 +47,7 @@ public func ILOG(_ message: @autoclosure () -> String,
                  line: Int = #line) {
     let msg = message()
     log(msg, level: .info, category: .general, file: file, function: function, line: line)
-    
+
     // Also send to the publisher
     PVLogPublisher.shared.info(msg, file: file, function: function, line: line)
 }
@@ -59,8 +58,8 @@ public func WLOG(_ message: @autoclosure () -> String,
                  function: String = #function,
                  line: Int = #line) {
     let msg = message()
-    log(msg, level: .error, category: .general, file: file, function: function, line: line)
-    
+    log(msg, level: .warning, category: .general, file: file, function: function, line: line)
+
     // Also send to the publisher
     PVLogPublisher.shared.warning(msg, file: file, function: function, line: line)
 }
@@ -71,8 +70,8 @@ public func ELOG(_ message: @autoclosure () -> String,
                  function: String = #function,
                  line: Int = #line) {
     let msg = message()
-    log(msg, level: .fault, category: .general, file: file, function: function, line: line)
-    
+    log(msg, level: .error, category: .general, file: file, function: function, line: line)
+
     // Also send to the publisher
     PVLogPublisher.shared.error(msg, file: file, function: function, line: line)
 }

--- a/PVLogging/Sources/PVLogging/PVLogPublisher.swift
+++ b/PVLogging/Sources/PVLogging/PVLogPublisher.swift
@@ -10,6 +10,9 @@ import Foundation
 #if canImport(Combine)
 import Combine
 #endif
+#if canImport(OSLog)
+import OSLog
+#endif
 
 /// A modern Combine-based publisher for PVLogging
 public final class PVLogPublisher: @unchecked Sendable {

--- a/PVLogging/Sources/PVLogging/PVLogPublisher.swift
+++ b/PVLogging/Sources/PVLogging/PVLogPublisher.swift
@@ -7,48 +7,47 @@
 //
 
 import Foundation
+#if canImport(Combine)
 import Combine
-import OSLog
+#endif
 
 /// A modern Combine-based publisher for PVLogging
-public final class PVLogPublisher {
+public final class PVLogPublisher: @unchecked Sendable {
     // MARK: - Singleton
-    
+
     // MARK: - Private Properties
-    
+
     /// Serial queue for thread-safe access to logs
     private let logsQueue = DispatchQueue(label: "com.provenance.logging.storage", qos: .utility)
-    
+
     /// In-memory cache of recent logs
     private var recentLogs: [LogEntry] = []
-    
+
     /// Maximum number of logs to keep in memory
     private let maxLogCount = 2000
-    
+
     /// Shared instance
     nonisolated(unsafe)
     public static let shared = PVLogPublisher()
-    
+
     // MARK: - Properties
-    
+
+    #if canImport(Combine)
     /// Subject that publishes log entries
     private let logSubject = PassthroughSubject<LogEntry, Never>()
-    
+
     /// Publisher for log entries
     public var logPublisher: AnyPublisher<LogEntry, Never> {
         logSubject.eraseToAnyPublisher()
     }
-    
-    // No storage property needed with this approach
-    
+    #endif
+
     // MARK: - Initialization
-    
-    private init() {
-        // Set up any initial configuration
-    }
-    
+
+    private init() {}
+
     // MARK: - Public Methods
-    
+
     /// Log a message with the specified level
     /// - Parameters:
     ///   - message: The message to log
@@ -60,17 +59,15 @@ public final class PVLogPublisher {
     public func log(
         _ message: String,
         level: LogLevel,
-        category: Logger = .general,
+        category: PVLogCategory = .general,
         file: String = #file,
         function: String = #function,
         line: Int = #line
     ) {
         let fileName = URL(fileURLWithPath: file).lastPathComponent
-        
-        // Extract category name from the Logger
+
         let categoryName = getCategoryName(from: category)
-        
-        // Create the log entry
+
         let entry = LogEntry(
             message: message,
             level: level,
@@ -80,24 +77,20 @@ public final class PVLogPublisher {
             function: function,
             line: line
         )
-        
-        // Publish the log entry immediately
+
+        #if canImport(Combine)
         logSubject.send(entry)
-        
-        // Store the log entry asynchronously on a serial queue
+        #endif
+
         logsQueue.async { [weak self, entry] in
             guard let self = self else { return }
-            
-            // Add to recent logs
             self.recentLogs.append(entry)
-            
-            // Trim if needed
             if self.recentLogs.count > self.maxLogCount {
                 self.recentLogs = Array(self.recentLogs.suffix(self.maxLogCount))
             }
         }
-        
-        // Also log to system console
+
+        #if canImport(OSLog)
         let osLogType: OSLogType
         switch level {
         case .verbose:
@@ -107,19 +100,18 @@ public final class PVLogPublisher {
         case .info:
             osLogType = .info
         case .warning:
-            osLogType = .error
+            osLogType = .default
         case .error:
             osLogType = .fault
         }
-        
         category.log(level: osLogType, "\(fileName):\(function):\(line) - \(message)")
+        #endif
     }
-    
+
     /// Get recent logs, optionally filtered by level
     /// - Parameter level: Optional minimum log level to filter by
     /// - Returns: Array of log entries
     public func getRecentLogs(minLevel: LogLevel? = nil) -> [LogEntry] {
-        // Use the serial queue to safely access logs
         return logsQueue.sync { [self] in
             if let minLevel = minLevel {
                 return recentLogs.filter { $0.level.rawValue >= minLevel.rawValue }
@@ -128,27 +120,28 @@ public final class PVLogPublisher {
             }
         }
     }
-    
+
     /// Clear all cached logs
     public func clearLogs() {
         logsQueue.async { [weak self] in
             self?.recentLogs.removeAll()
         }
     }
-    
-    /// Extract category name from Logger
-    private func getCategoryName(from logger: Logger) -> String {
-        // Since Logger is a struct and we can't access its category directly,
-        // we'll use a string representation to determine the category
-        let loggerDescription = String(describing: logger)
-        
+
+    /// Extract category name from PVLogCategory
+    private func getCategoryName(from category: PVLogCategory) -> String {
+        #if canImport(OSLog)
+        let loggerDescription = String(describing: category)
         if loggerDescription.contains("viewcycle") { return "viewcycle" }
         if loggerDescription.contains("statistics") { return "statistics" }
         if loggerDescription.contains("network") { return "network" }
         if loggerDescription.contains("video") { return "video" }
         if loggerDescription.contains("audio") { return "audio" }
         if loggerDescription.contains("database") { return "database" }
-        return "general" // Default category
+        return "general"
+        #else
+        return category.categoryName
+        #endif
     }
 }
 
@@ -158,45 +151,45 @@ public final class PVLogPublisher {
 public struct LogEntry: Identifiable, Equatable, Sendable {
     /// Unique identifier
     public let id = UUID()
-    
+
     /// Log message
     public let message: String
-    
+
     /// Log level
     public let level: LogLevel
-    
+
     /// Log category
     public let category: String
-    
+
     /// Timestamp when the log was created
     public let timestamp: Date
-    
+
     /// Source file
     public let file: String
-    
+
     /// Source function
     public let function: String
-    
+
     /// Source line number
     public let line: Int
-    
+
     /// Formatted timestamp string
     public var formattedTimestamp: String {
         let formatter = DateFormatter()
         formatter.dateFormat = "HH:mm:ss.SSS"
         return formatter.string(from: timestamp)
     }
-    
+
     /// Short description for display
     public var shortDescription: String {
         "[\(level.shortName)] \(message)"
     }
-    
+
     /// Full description including source information
     public var fullDescription: String {
         "[\(formattedTimestamp)] [\(level.shortName)] [\(category)] \(file):\(function):\(line) - \(message)"
     }
-    
+
     public static func == (lhs: LogEntry, rhs: LogEntry) -> Bool {
         lhs.id == rhs.id
     }
@@ -211,7 +204,7 @@ public enum LogLevel: Int, Comparable, Sendable {
     case info = 2
     case warning = 3
     case error = 4
-    
+
     /// Short name for display
     public var shortName: String {
         switch self {
@@ -227,7 +220,7 @@ public enum LogLevel: Int, Comparable, Sendable {
             return "E"
         }
     }
-    
+
     /// Full name for display
     public var name: String {
         switch self {
@@ -243,7 +236,7 @@ public enum LogLevel: Int, Comparable, Sendable {
             return "Error"
         }
     }
-    
+
     /// Color for display
     public var color: String {
         switch self {
@@ -259,7 +252,7 @@ public enum LogLevel: Int, Comparable, Sendable {
             return "red"
         }
     }
-    
+
     public static func < (lhs: LogLevel, rhs: LogLevel) -> Bool {
         lhs.rawValue < rhs.rawValue
     }
@@ -272,51 +265,51 @@ public extension PVLogPublisher {
     /// Log a verbose message
     func verbose(
         _ message: String,
-        category: Logger = .general,
+        category: PVLogCategory = .general,
         file: String = #file,
         function: String = #function,
         line: Int = #line
     ) {
         log(message, level: .verbose, category: category, file: file, function: function, line: line)
     }
-    
+
     /// Log a debug message
     func debug(
         _ message: String,
-        category: Logger = .general,
+        category: PVLogCategory = .general,
         file: String = #file,
         function: String = #function,
         line: Int = #line
     ) {
         log(message, level: .debug, category: category, file: file, function: function, line: line)
     }
-    
+
     /// Log an info message
     func info(
         _ message: String,
-        category: Logger = .general,
+        category: PVLogCategory = .general,
         file: String = #file,
         function: String = #function,
         line: Int = #line
     ) {
         log(message, level: .info, category: category, file: file, function: function, line: line)
     }
-    
+
     /// Log a warning message
     func warning(
         _ message: String,
-        category: Logger = .general,
+        category: PVLogCategory = .general,
         file: String = #file,
         function: String = #function,
         line: Int = #line
     ) {
         log(message, level: .warning, category: category, file: file, function: function, line: line)
     }
-    
+
     /// Log an error message
     func error(
         _ message: String,
-        category: Logger = .general,
+        category: PVLogCategory = .general,
         file: String = #file,
         function: String = #function,
         line: Int = #line

--- a/PVLogging/Sources/PVLogging/PVLogPublisher.swift
+++ b/PVLogging/Sources/PVLogging/PVLogPublisher.swift
@@ -176,11 +176,21 @@ public struct LogEntry: Identifiable, Equatable, Sendable {
     /// Source line number
     public let line: Int
 
-    /// Formatted timestamp string
-    public var formattedTimestamp: String {
+    /// Shared date formatter for timestamps
+    private static let timestampFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "HH:mm:ss.SSS"
-        return formatter.string(from: timestamp)
+        return formatter
+    }()
+
+    /// Serial queue to ensure thread-safe formatter access
+    private static let timestampFormatterQueue = DispatchQueue(label: "com.provenance.logging.timestampFormatter")
+
+    /// Formatted timestamp string
+    public var formattedTimestamp: String {
+        return Self.timestampFormatterQueue.sync {
+            Self.timestampFormatter.string(from: timestamp)
+        }
     }
 
     /// Short description for display

--- a/PVLogging/Sources/PVLogging/PVLogging.swift
+++ b/PVLogging/Sources/PVLogging/PVLogging.swift
@@ -5,8 +5,9 @@
 //
 
 import Foundation
+#if canImport(System)
 import System
-import os
+#endif
 
 //@_exported import PVLoggingObjC
 
@@ -14,14 +15,18 @@ let LOGGING_STACK_SIZE = 1024
 let ISO_TIMEZONE_UTC_FORMAT: String = "Z"
 let ISO_TIMEZONE_OFFSET_FORMAT: String = "%+02d%02d"
 
+#if canImport(ObjectiveC)
 @objcMembers
+#endif
 public final class PVLogging: NSObject {
+    #if canImport(ObjectiveC)
     @objc(sharedInstance)
+    #endif
     nonisolated(unsafe) public static let shared = PVLogging()
 
     public var entity: PVLoggingEntity?
     public let startupTime: Date = Date()
-    
+
     public private(set) var history = [PVLogEntry]()
     private var listeners = Array<any PVLoggingEventProtocol>()
 
@@ -83,27 +88,9 @@ public final class PVLogging: NSObject {
         PVLogging.shared.notifyListeners()
     }
 
-    @available(iOS 14.0, tvOS 14.0, *)
-    private static let logger = Logger(
-        subsystem: Bundle.main.bundleIdentifier!, category: "App")
-
     fileprivate func log(_ entry: PVLogEntry) {
         // TODO: Add array of "loggers" for os_log, nslogger
         // and iterate through them
-//        if #available(iOS 14.0, tvOS 14.0, *) {
-//            switch entry.level {
-//            case .Debug:
-//                Self.logger.log(level: .debug, .init(stringLiteral: entry.string))
-//            case .Error:
-//                Self.logger.log(level: .error, .init(stringLiteral: entry.string))
-//            case .Warn:
-//                Self.logger.log(level: .error, .init(stringLiteral: entry.string))
-//            case .U:
-//                Self.logger.log(level: .fault, .init(stringLiteral: entry.string))
-//            case .Info:
-//                Self.logger.log(level: .info, .init(stringLiteral: entry.string))
-//            }
-//        }
     }
 
 
@@ -115,20 +102,9 @@ public final class PVLogging: NSObject {
     public func logFileInfos() -> [Any]? {
         return entity?.logFileInfos
     }
-    //
-    //    public func logFileData() -> Data? {
-    //        return entity?.logFileData()
-    //    }
-    //
-    //    public func logFileDataAsString() -> String? {
-    //        return entity?.logFileDataAsString()
-    //    }
-    //
-    //    public func logFileDataAsAttributedString() -> NSAttributedString? {
-    //        return entity?.logFileDataAsAttributedString()
-    //    }
 
     // MARK: - Listeners
+    #if canImport(ObjectiveC)
     @objc(registerListener:)
     public func register(listener: any PVLoggingEventProtocol) {
         listeners.insert(listener, at: 0)
@@ -138,6 +114,14 @@ public final class PVLogging: NSObject {
     public func remove(listener: any PVLoggingEventProtocol) {
         //        listeners.removeAll(where: {$0 == listener})
     }
+    #else
+    public func register(listener: any PVLoggingEventProtocol) {
+        listeners.insert(listener, at: 0)
+    }
+
+    public func remove(listener: any PVLoggingEventProtocol) {
+    }
+    #endif
 
     /**
      *  Notify listerners of log updates
@@ -208,6 +192,7 @@ public final class PVLogging: NSObject {
         return ""
     }
 
+    #if !os(Linux)
     public static func logNSURLCacheUsage() {
         let defaultCache = URLCache.shared
         let defaultCacheSizeMemory = defaultCache.memoryCapacity
@@ -218,19 +203,5 @@ public final class PVLogging: NSObject {
         let usedDiskCache = defaultCache.currentDiskUsage / 1024 / 1024
         ILOG("URLCache: Memory: \(defaultCacheSizeMemoryMB)MB, Disk: \(defaultCacheSizeDiskMB)MB\nUsed Memory: \(usedCachedMemory)MB, Used Disk: \(usedDiskCache)MB")
     }
+    #endif
 }
-//
-//@_cdecl("PVLog")
-//public func PVLog(level: DDLogLevel, flag: DDLogFlag, file: String, function: String?, line: UInt, message: String) {
-//    let logMessage = DDLogMessage(message: message,
-//                                  level: level,
-//                                  flag: flag,
-//                                  context: 0,
-//                                  file: file,
-//                                  function: function,
-//                                  line: line,
-//                                  tag: nil,
-//                                  timestamp: Date())
-//    let asynchronous: Bool = level == .error
-//    DDLog.sharedInstance.log(asynchronous: asynchronous, message: logMessage)
-//}

--- a/PVLogging/Sources/PVLogging/Protocols/PVLoggingEntity.swift
+++ b/PVLogging/Sources/PVLogging/Protocols/PVLoggingEntity.swift
@@ -7,7 +7,9 @@
 
 import Foundation
 
+#if canImport(ObjectiveC)
 @objc
+#endif
 public protocol PVLoggingEntity {
     /**
      *  Obtain paths of any file logs

--- a/PVLogging/Sources/PVLogging/Protocols/PVLoggingEventProtocol.swift
+++ b/PVLogging/Sources/PVLogging/Protocols/PVLoggingEventProtocol.swift
@@ -7,10 +7,16 @@
 
 import Foundation
 
+#if canImport(ObjectiveC)
 @objc
 public protocol PVLoggingEventProtocol: AnyObject {
     func updateHistory(sender: PVLogging)
 }
+#else
+public protocol PVLoggingEventProtocol: AnyObject {
+    func updateHistory(sender: PVLogging)
+}
+#endif
 
 //@nonobjc
 //extension PVLoggingEventProtocol: Equatable, Hashable { }

--- a/PVLogging/Tests/PVLoggingTests.swift
+++ b/PVLogging/Tests/PVLoggingTests.swift
@@ -394,9 +394,11 @@ struct PVLogPublisherTests {
         #expect(logs.contains(where: { $0.message == "error convenience" && $0.level == .error }))
     }
 
+    #if canImport(Combine)
     @Test("logPublisher property is accessible")
     func logPublisherAccessible() {
         // Verify the property is accessible and the type is correct
         _ = PVLogPublisher.shared.logPublisher
     }
+    #endif
 }

--- a/PVLookup/Package.resolved
+++ b/PVLookup/Package.resolved
@@ -1,22 +1,13 @@
 {
-  "originHash" : "6ff46a339ed9c93ecba2da78fdfbaecd23f15422d0e51fc707dce94933de3389",
+  "originHash" : "b5c62efc980a518de3bb46d644c7353fded4c467fdb04d12580e09261c6739ff",
   "pins" : [
     {
-      "identity" : "checksum",
+      "identity" : "csqlite",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/JoeMatt/Checksum.git",
+      "location" : "https://github.com/stephencelis/CSQLite.git",
       "state" : {
-        "revision" : "11bf55d6ec0e4dbfff2bcd99b6b12c5ce5d57b91",
-        "version" : "1.1.1"
-      }
-    },
-    {
-      "identity" : "defaults",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/sindresorhus/Defaults.git",
-      "state" : {
-        "revision" : "cc938ecf0bed848dc80a9726ac5455104e3f9dae",
-        "version" : "9.0.2"
+        "revision" : "9106e983d5e3d5149ee35281ec089484b0def018",
+        "version" : "0.0.3"
       }
     },
     {
@@ -38,6 +29,24 @@
       }
     },
     {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "810496cf121e525d660cd0ea89a758740476b85f",
+        "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
+        "version" : "3.15.1"
+      }
+    },
+    {
       "identity" : "swift-http-types",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-http-types",
@@ -47,21 +56,21 @@
       }
     },
     {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "bbd81b6725ae874c69e9b8c8804d462356b55523",
+        "version" : "1.10.1"
+      }
+    },
+    {
       "identity" : "swift-openapi-runtime",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-openapi-runtime",
       "state" : {
         "revision" : "5e119a3d52dde0229312ed586be99c666c6b6f64",
         "version" : "1.7.0"
-      }
-    },
-    {
-      "identity" : "swift-syntax",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-syntax",
-      "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
       }
     },
     {
@@ -78,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/weichsel/ZIPFoundation.git",
       "state" : {
-        "revision" : "02b6abe5f6eef7e3cbd5f247c5cc24e246efcfe0",
-        "version" : "0.9.19"
+        "revision" : "22787ffb59de99e5dc1fbfe80b19c97a904ad48d",
+        "version" : "0.9.20"
       }
     }
   ],

--- a/PVLookup/Package.swift
+++ b/PVLookup/Package.swift
@@ -37,6 +37,7 @@ let package = Package(
         .package(path: "../PVLogging"),
         .package(path: "../PVPrimitives"),
         .package(url: "https://github.com/Provenance-Emu/SwiftGenPlugin.git", branch: "develop"),
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0"),
 
         ///
         /// Database
@@ -102,6 +103,7 @@ let package = Package(
                 "PVSQLiteDatabase",
                 .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
 //                .product(name: "OpenAPIAsyncHTTPClient", package: "swift-openapi-async-http-client"),
+                .product(name: "Crypto", package: "swift-crypto"),
                 "PVLookupTypes",
                 "ROMMetadataProvider",
                 "PVPrimitives"

--- a/PVLookup/Scripts/generate_cheatdb_if_needed.sh
+++ b/PVLookup/Scripts/generate_cheatdb_if_needed.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# generate_cheatdb_if_needed.sh
+#
+# Generates the libretro_cheats.sqlite.zip database if it doesn't exist.
+# Used as a pre-build / pre-test step so PVLookup tests can run on CI
+# (including Linux runners) without committing the ~MB database to git.
+#
+# Usage:
+#   ./PVLookup/Scripts/generate_cheatdb_if_needed.sh
+#
+# Requires: python3, git
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+RESOURCE_DIR="$REPO_ROOT/PVLookup/Sources/LibretroCheatDB/Resources"
+ZIP_FILE="$RESOURCE_DIR/libretro_cheats.sqlite.zip"
+GENERATOR="$REPO_ROOT/Scripts/generate_cheatdb.py"
+
+if [ -f "$ZIP_FILE" ] && [ "$(stat -c%s "$ZIP_FILE" 2>/dev/null || stat -f%z "$ZIP_FILE" 2>/dev/null)" -gt 1000 ]; then
+    echo "libretro_cheats.sqlite.zip exists and appears valid, skipping generation."
+    exit 0
+fi
+
+echo "libretro_cheats.sqlite.zip is missing or empty — generating..."
+
+if ! command -v python3 &>/dev/null; then
+    echo "Error: python3 is required but not found" >&2
+    exit 1
+fi
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "Cloning libretro-database (shallow)..."
+git clone --depth=1 --quiet https://github.com/libretro/libretro-database.git "$TMPDIR/libretro-database"
+
+echo "Running generate_cheatdb.py..."
+python3 "$GENERATOR" "$TMPDIR/libretro-database/cht/" \
+    --dat-dir "$TMPDIR/libretro-database" \
+    --output "$RESOURCE_DIR/libretro_cheats.sqlite"
+
+echo "Done — $(du -h "$ZIP_FILE" | cut -f1) generated."

--- a/PVLookup/Sources/LibretroCheatDB/Resources/.gitignore
+++ b/PVLookup/Sources/LibretroCheatDB/Resources/.gitignore
@@ -1,0 +1,2 @@
+libretro_cheats.sqlite.zip
+libretro_cheats.sqlite

--- a/PVLookup/Sources/TheGamesDB/TheGamesDB.swift
+++ b/PVLookup/Sources/TheGamesDB/TheGamesDB.swift
@@ -11,7 +11,11 @@ import PVLookupTypes
 import PVSystems
 import PVLogging
 import PVSQLiteDatabase
+#if canImport(CryptoKit)
 import CryptoKit
+#else
+import Crypto
+#endif
 import ROMMetadataProvider
 
 public final class TheGamesDB: ArtworkLookupService, ROMMetadataProvider, @unchecked Sendable {

--- a/PVLookup/Sources/libretrodb/LibretroArtwork.swift
+++ b/PVLookup/Sources/libretrodb/LibretroArtwork.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import PVSystems
 import PVLookupTypes
 import PVSQLiteDatabase
@@ -9,11 +12,19 @@ public struct LibretroArtwork {
     private static let baseURL = "https://thumbnails.libretro.com"
 
     /// Cache for URL validation results
+    #if canImport(Darwin)
     private static let urlCache = URLCache(
-        memoryCapacity: 10 * 1024 * 1024,  // 10MB memory cache
-        diskCapacity: 50 * 1024 * 1024,    // 50MB disk cache
+        memoryCapacity: 10 * 1024 * 1024,
+        diskCapacity: 50 * 1024 * 1024,
         directory: nil
     )
+    #else
+    private static let urlCache = URLCache(
+        memoryCapacity: 10 * 1024 * 1024,
+        diskCapacity: 50 * 1024 * 1024,
+        diskPath: nil
+    )
+    #endif
 
     /// Cache duration for URL validation results
     private static let cacheDuration: TimeInterval = 3600 // 1 hour

--- a/PVPlists/Package.resolved
+++ b/PVPlists/Package.resolved
@@ -1,31 +1,31 @@
 {
-  "originHash" : "d6643277b7cd4a57167d01c1370e24cdedcbb74963964cdb029b1c3ea909f2b0",
+  "originHash" : "e7574216de9f7170f7bb4ff5612a4479067bbda2d0377b4a4c387959e25e8d3a",
   "pins" : [
     {
-      "identity" : "checksum",
+      "identity" : "swift-asn1",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/JoeMatt/Checksum.git",
+      "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "11bf55d6ec0e4dbfff2bcd99b6b12c5ce5d57b91",
-        "version" : "1.1.1"
+        "revision" : "810496cf121e525d660cd0ea89a758740476b85f",
+        "version" : "1.5.1"
       }
     },
     {
-      "identity" : "defaults",
+      "identity" : "swift-crypto",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/sindresorhus/Defaults.git",
+      "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "752bcb9eb2e110fa9d82826c99857b0e9a76fb1d"
+        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
+        "version" : "3.15.1"
       }
     },
     {
-      "identity" : "swift-syntax",
+      "identity" : "swift-log",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-syntax",
+      "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
-        "version" : "602.0.0"
+        "revision" : "bbd81b6725ae874c69e9b8c8804d462356b55523",
+        "version" : "1.10.1"
       }
     }
   ],

--- a/PVPlists/Sources/PVPlists/Core_plist/EmulatorCoreInfoPlist.swift
+++ b/PVPlists/Sources/PVPlists/Core_plist/EmulatorCoreInfoPlist.swift
@@ -9,8 +9,10 @@ import Foundation
 import PVLogging
 import PVPrimitives
 
+#if canImport(ObjectiveC)
 @objc
 @objcMembers
+#endif
 public final class EmulatorCoreInfoPlist: NSObject, Sendable {
     public let identifier: String
     public let principleClass: String

--- a/PVPlists/Sources/PVPlists/Core_plist/EmulatorCoreInfoPlistProvider.swift
+++ b/PVPlists/Sources/PVPlists/Core_plist/EmulatorCoreInfoPlistProvider.swift
@@ -8,7 +8,10 @@
 import Foundation
 import PVPrimitives
 
-@objc public protocol EmulatorCoreInfoPlistProvider {
+#if canImport(ObjectiveC)
+@objc
+#endif
+public protocol EmulatorCoreInfoPlistProvider {
     static var corePlist: EmulatorCoreInfoPlist { get }
     static var resourceBundle: Bundle { get }
 }

--- a/PVPrimitives/Package.resolved
+++ b/PVPrimitives/Package.resolved
@@ -1,22 +1,31 @@
 {
-  "originHash" : "b76966cd156c7209b73e8afb2e7e066e4dd41103541b896645bb833031a0bab2",
+  "originHash" : "0fcca3f593e22edc5db8672912e32cb9c4f3394701cfb2dcf406e0dd6b903b0c",
   "pins" : [
     {
-      "identity" : "checksum",
+      "identity" : "swift-asn1",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/JoeMatt/Checksum.git",
+      "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "11bf55d6ec0e4dbfff2bcd99b6b12c5ce5d57b91",
-        "version" : "1.1.1"
+        "revision" : "810496cf121e525d660cd0ea89a758740476b85f",
+        "version" : "1.5.1"
       }
     },
     {
-      "identity" : "defaults",
+      "identity" : "swift-crypto",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/sindresorhus/Defaults.git",
+      "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "4c009d5c2496e7aa126e922c94dd3d6ae049efa2"
+        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
+        "version" : "3.15.1"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "bbd81b6725ae874c69e9b8c8804d462356b55523",
+        "version" : "1.10.1"
       }
     }
   ],

--- a/PVPrimitives/Sources/PVPrimitives/Game.swift
+++ b/PVPrimitives/Sources/PVPrimitives/Game.swift
@@ -113,6 +113,7 @@ extension Game: Equatable {
     }
 }
 
+#if canImport(CoreTransferable)
 import CoreTransferable
 import UniformTypeIdentifiers
 @available(iOS 16.0, macOS 13, tvOS 16.0, watchOS 9.0, *)
@@ -121,3 +122,4 @@ extension Game: Transferable {
         CodableRepresentation(contentType: .rom)
     }
 }
+#endif

--- a/PVPrimitives/Sources/PVPrimitives/Protocols/FileInfoProvider.swift
+++ b/PVPrimitives/Sources/PVPrimitives/Protocols/FileInfoProvider.swift
@@ -98,8 +98,8 @@ public extension LocalFileInfoProvider {
         let fileSize: UInt64
 
         if let attr = try? FileManager.default.attributesOfItem(atPath: url.path),
-           let size = attr[.size] as? UInt64 {
-            fileSize = size
+           let sizeValue = attr[.size] {
+            fileSize = (sizeValue as? NSNumber)?.uint64Value ?? 0
         } else {
             fileSize = 0
         }

--- a/PVPrimitives/Sources/PVPrimitives/Protocols/FileInfoProvider.swift
+++ b/PVPrimitives/Sources/PVPrimitives/Protocols/FileInfoProvider.swift
@@ -97,8 +97,9 @@ public extension LocalFileInfoProvider {
         guard let url = url else { return 0 }
         let fileSize: UInt64
 
-        if let attr = try? FileManager.default.attributesOfItem(atPath: url.path) as NSDictionary {
-            fileSize = attr.fileSize()
+        if let attr = try? FileManager.default.attributesOfItem(atPath: url.path),
+           let size = attr[.size] as? UInt64 {
+            fileSize = size
         } else {
             fileSize = 0
         }

--- a/PVPrimitives/Sources/PVPrimitives/Protocols/SystemProtocol.swift
+++ b/PVPrimitives/Sources/PVPrimitives/Protocols/SystemProtocol.swift
@@ -8,7 +8,11 @@
 
 import Foundation
 
+#if canImport(Combine)
 public typealias _SystemProtocol = SystemProtocol & Identifiable & ObservableObject & Hashable
+#else
+public typealias _SystemProtocol = SystemProtocol & Identifiable & Hashable
+#endif
 public typealias AnySystem = any _SystemProtocol
 
 public protocol SystemProtocol : Hashable {

--- a/PVPrimitives/Sources/PVPrimitives/Util/Cache.swift
+++ b/PVPrimitives/Sources/PVPrimitives/Util/Cache.swift
@@ -59,7 +59,10 @@ open class Cache<KeyType: Hashable & Sendable, ObjectType> {
         NotificationCenter.default.removeObserver(self)
     }
 
-    @objc private func onLowMemory() {
+    #if canImport(ObjectiveC)
+    @objc
+    #endif
+    private func onLowMemory() {
         removeAllObjects()
     }
 

--- a/PVPrimitives/Sources/PVPrimitives/Util/UTI.swift
+++ b/PVPrimitives/Sources/PVPrimitives/Util/UTI.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if canImport(CoreServices)
 import CoreServices
+#endif
 
 public extension UTI {
     // General ROM types
@@ -182,6 +184,7 @@ public extension UTType {
 }
 #endif
 
+#if canImport(CoreServices)
 /// Instances of the UTI class represent a specific Universal Type Identifier, e.g. kUTTypeMPEG4.
 public final class UTI: RawRepresentable, Equatable {
     /**
@@ -491,9 +494,69 @@ public final class UTI: RawRepresentable, Equatable {
         return UTTypeIsDynamic(rawCFValue)
     }
 }
+#else
+/// Minimal UTI implementation for platforms without CoreServices (e.g. Linux).
+public final class UTI: RawRepresentable, Equatable {
+    public enum TagClass: String {
+        case fileExtension = "public.filename-extension"
+        case mimeType = "public.mime-type"
+        #if os(macOS)
+        case pbType = "com.apple.nspboard-type"
+        case osType = "com.apple.ostype"
+        #endif
+    }
+
+    public typealias RawValue = String
+    public let rawValue: String
+
+    public required init(rawValue: UTI.RawValue) {
+        self.rawValue = rawValue
+    }
+
+    public convenience init(withTagClass tagClass: TagClass, value: String, conformingTo conforming: UTI? = nil) {
+        self.init(rawValue: "public.data")
+    }
+
+    public convenience init(withExtension fileExtension: String, conformingTo conforming: UTI? = nil) {
+        self.init(withTagClass: .fileExtension, value: fileExtension, conformingTo: conforming)
+    }
+
+    public convenience init(withMimeType mimeType: String, conformingTo conforming: UTI? = nil) {
+        self.init(withTagClass: .mimeType, value: mimeType, conformingTo: conforming)
+    }
+
+    #if os(macOS)
+    public convenience init(withPBType pbType: String, conformingTo conforming: UTI? = nil) {
+        self.init(withTagClass: .pbType, value: pbType, conformingTo: conforming)
+    }
+    public convenience init(withOSType osType: String, conformingTo conforming: UTI? = nil) {
+        self.init(withTagClass: .osType, value: osType, conformingTo: conforming)
+    }
+    #endif
+
+    public func tag(with tagClass: TagClass) -> String? { nil }
+    public var fileExtension: String? { tag(with: .fileExtension) }
+    public var mimeType: String? { tag(with: .mimeType) }
+
+    #if os(macOS)
+    public var pbType: String? { tag(with: .pbType) }
+    public var osType: String? { tag(with: .osType) }
+    #endif
+
+    public func tags(with tagClass: TagClass) -> [String] { [] }
+    public static func utis(for tag: TagClass, value: String, conformingTo conforming: UTI? = nil) -> [UTI] { [] }
+    public func conforms(to otherUTI: UTI) -> Bool { rawValue == otherUTI.rawValue }
+    public static func == (lhs: UTI, rhs: UTI) -> Bool { lhs.rawValue == rhs.rawValue }
+    public var description: String? { nil }
+    public var declaration: [AnyHashable: Any]? { nil }
+    public var declaringBundleURL: URL? { nil }
+    public var isDynamic: Bool { false }
+}
+#endif
 
 // MARK: System defined UTIs
 
+#if canImport(UniformTypeIdentifiers)
 public extension UTI {
     nonisolated(unsafe) static let _3DContent = UTI(rawValue: UTType.threeDContent.identifier as String)
     nonisolated(unsafe) static let aliasFile = UTI(rawValue: UTType.aliasFile.identifier as String)
@@ -613,6 +676,7 @@ public extension UTI {
     nonisolated(unsafe) static let xpcService = UTI(rawValue: UTType.xpcService.identifier as String)
     nonisolated(unsafe) static let zipArchive = UTI(rawValue: UTType.zip.identifier as String)
 }
+#endif
 
 #if os(OSX)
 

--- a/PVPrimitives/Sources/PVSystems/PVGameBoxArtAspectRatio.swift
+++ b/PVPrimitives/Sources/PVSystems/PVGameBoxArtAspectRatio.swift
@@ -5,7 +5,11 @@
 //  Created by Joseph Mattiello on 9/5/24.
 //
 
+#if canImport(CoreGraphics)
 import CoreGraphics
+#else
+public typealias CGFloat = Double
+#endif
 
 public enum PVGameBoxArtAspectRatio: CGFloat {
     case square = 1.0
@@ -27,6 +31,6 @@ public enum PVGameBoxArtAspectRatio: CGFloat {
     case ggUSA = 0.7201
     case ggJAPAN = 0.86
     case Sega32XUSA = 0.7194636596
-    
+
     public static var jaguar: PVGameBoxArtAspectRatio { .tall }
 }

--- a/PVSettings/Package.resolved
+++ b/PVSettings/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e3a4d82710d4e460a4710688302d243e0964bb3c1374c7a50d566c7b23daacff",
+  "originHash" : "8939e406575665190f783a39233e10659394717b306769be2eb94a04dd2d85be",
   "pins" : [
     {
       "identity" : "defaults",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "cc938ecf0bed848dc80a9726ac5455104e3f9dae",
         "version" : "9.0.2"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "bbd81b6725ae874c69e9b8c8804d462356b55523",
+        "version" : "1.10.1"
       }
     },
     {

--- a/PVSupport/Package.resolved
+++ b/PVSupport/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "b5a0b42fbd4b5319d0cc085ec410c12ef0bec19502ffb08a03119c463e75c36f",
+  "originHash" : "6696f41f473bb6d2cf775ae8767a83cd8dc6896263eb605fc482f76fa2bf7e35",
   "pins" : [
     {
-      "identity" : "swiftgenplugin",
+      "identity" : "swift-log",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/BookBeat/SwiftGenPlugin.git",
+      "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "branch" : "xcodeproject-support",
-        "revision" : "1228d5a43ca791db0719d42f641c34a00b9c32f3"
+        "revision" : "bbd81b6725ae874c69e9b8c8804d462356b55523",
+        "version" : "1.10.1"
       }
     }
   ],

--- a/PVSupport/Package.swift
+++ b/PVSupport/Package.swift
@@ -2,6 +2,19 @@
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 import PackageDescription
 
+#if os(Linux)
+let platformDeps: [Package.Dependency] = []
+let platformTargetDeps: [Target.Dependency] = []
+#else
+let platformDeps: [Package.Dependency] = [
+    .package(path: "../PVSettings/"),
+    .package(url: "https://github.com/Provenance-Emu/SwiftGenPlugin.git", branch: "develop")
+]
+let platformTargetDeps: [Target.Dependency] = [
+    "PVSettings"
+]
+#endif
+
 let package = Package(
     name: "PVSupport",
     platforms: [
@@ -28,9 +41,7 @@ let package = Package(
 
     dependencies: [
         .package(path: "../PVLogging/"),
-        .package(path: "../PVSettings/"),
-        .package(url: "https://github.com/Provenance-Emu/SwiftGenPlugin.git",branch: "develop")
-    ],
+    ] + platformDeps,
 
     // MARK: - Targets
     targets: [
@@ -39,8 +50,7 @@ let package = Package(
             name: "PVSupport",
             dependencies: [
                 "PVLogging",
-                "PVSettings"
-            ],
+            ] + platformTargetDeps,
             resources: [
                 .process("Resources/AHAP/"),
                 .copy("PrivacyInfo.xcprivacy")
@@ -56,10 +66,6 @@ let package = Package(
             linkerSettings: [
                 .linkedFramework("UIKit", .when(platforms: [.iOS, .tvOS, .macCatalyst])),
                 .linkedFramework("WatchKit", .when(platforms: [.watchOS]))
-            ],
-            plugins: [
-//                .plugin(name: "SwiftGenPlugin", package: "SwiftGenPlugin"),
-//                .plugin(name: "SwiftGen-Generate", package: "SwiftGenPlugin")
             ]
         ),
 

--- a/PVSupport/Sources/PVSupport/Controller/iCade/iCadeSettings+Factory.swift
+++ b/PVSupport/Sources/PVSupport/Controller/iCade/iCadeSettings+Factory.swift
@@ -5,9 +5,8 @@
 //  Created by Joseph Mattiello on 8/8/24.
 //
 
-import PVSettings
-
 #if canImport(UIKit) && canImport(GameController)
+import PVSettings
 
 public extension iCadeControllerSetting {
     nonisolated

--- a/PVSupport/Sources/PVSupport/NSExtensions/UTITypes.swift
+++ b/PVSupport/Sources/PVSupport/NSExtensions/UTITypes.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+#if canImport(UniformTypeIdentifiers)
 import UniformTypeIdentifiers
 
 // also declare the content type in the Info.plist
@@ -16,3 +17,4 @@ extension UTType {
     // Note: rom, artwork, cheat, savestate are declared in PVPrimitives/UTI.swift
     static var retroarchConfigFile: UTType { UTType(exportedAs: "com.provenance.retroarch.config") }
 }
+#endif

--- a/PVSupport/Sources/PVSupport/Threads/RealTimeThead.swift
+++ b/PVSupport/Sources/PVSupport/Threads/RealTimeThead.swift
@@ -6,8 +6,11 @@
 //
 
 import Foundation
+#if canImport(MachO)
 import MachO
+#endif
 
+#if canImport(Darwin)
 @_cdecl("move_pthread_to_realtime_scheduling_class")
 public func movePthreadToRealtimeSchedulingClass(_ pthread: pthread_t) {
 
@@ -40,7 +43,8 @@ public func movePthreadToRealtimeSchedulingClass(_ pthread: pthread_t) {
     }
 }
 
-@_cdecl("MakeCurrentThreadRealTime") 
+@_cdecl("MakeCurrentThreadRealTime")
 public func MakeCurrentThreadRealTime() {
     movePthreadToRealtimeSchedulingClass(pthread_self())
 }
+#endif

--- a/PVSupport/Sources/PVSupport/Threads/Watchdog.swift
+++ b/PVSupport/Sources/PVSupport/Threads/Watchdog.swift
@@ -1,6 +1,9 @@
 import Foundation
+#if canImport(os)
 import os
+#endif
 
+#if !os(Linux)
 /// Class for logging excessive blocking on the main thread.
 final public class Watchdog {
     fileprivate let pingThread: PingThread
@@ -30,7 +33,7 @@ final public class Watchdog {
 
         self.pingThread.start()
     }
-    
+
     deinit {
         pingThread.cancel()
     }
@@ -45,7 +48,7 @@ private final class PingThread: Thread {
     fileprivate var semaphore = DispatchSemaphore(value: 0)
     fileprivate let threshold: Double
     fileprivate let handler: () -> Void
-    
+
     init(threshold: Double, handler: @escaping () -> Void) {
         self.threshold = threshold
         self.handler = handler
@@ -64,48 +67,14 @@ private final class PingThread: Thread {
 //                self.pingTaskIsRunning = false
 //                self.semaphore.signal()
             }
-            
+
             Thread.sleep(forTimeInterval: threshold)
             if pingTaskIsRunning {
                 handler()
             }
-            
+
             _ = semaphore.wait(timeout: DispatchTime.distantFuture)
         }
     }
 }
-
-//private final class PingController {
-//    private var pingTask: Task<Void, Never>?
-//    private let semaphore = DispatchSemaphore(value: 0)
-//    private var isCancelled = false
-//    private let threshold: TimeInterval = 5 // Adjust according to your needs
-//
-//    func start() {
-//        self.pingTask = Task {
-//            while !isCancelled {
-//                await performPingTask()
-//                try? await Task.sleep(nanoseconds: UInt64(threshold * 1_000_000_000))
-//                semaphore.signal()
-////                semaphore.wait()
-//            }
-//        }
-//    }
-//
-//    func cancel() {
-//        isCancelled = true
-//        pingTask?.cancel()
-//    }
-//
-//    private func performPingTask() async {
-//        // Perform the ping task here
-//        // Example:
-//        await withUnsafeContinuation { continuation in
-//            // Placeholder for actual ping operation
-//            DispatchQueue.main.asyncAfter(deadline: .now() + threshold) {
-//                self.semaphore.signal()
-//                continuation.resume()
-//            }
-//        }
-//    }
-//}
+#endif


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does this PR do
Enables building and running unit tests for 7 Swift Package Manager modules on Linux. This was achieved by replacing `OSLog` with `swift-log`, conditionally importing Apple-specific frameworks (`CryptoKit`, `Combine`, `FoundationNetworking`, `os`), and guarding Darwin-specific APIs.

### Where should the reviewer start
Reviewers should start with `PVLogging` for the core `OSLog` replacement logic, then `PVHashing` for `CryptoKit` changes, and `PVCheevos` for `FoundationNetworking` and `URLSession` async API guarding. After that, review the conditional compilation changes in `PVSupport`, `PVPrimitives`, and `PVPlists`.

### How should this be manually tested
1.  Ensure Docker is running.
2.  Navigate to the project root.
3.  Run `docker run --rm -v "$(pwd):/src" -w /src swift:5.9.2-jammy swift test --enable-test-discovery`
4.  Verify that tests for `PVLogging`, `PVHashing`, `PVFeatureFlags`, `PVCheevos`, `PVSupport`, `PVPrimitives`, and `PVPlists` pass.

### Any background context you want to provide
The primary goal is to enable running Swift Package Manager unit tests on Linux-based GitHub Actions runners. This PR addresses several blockers:
*   **`OSLog`**: Replaced with `swift-log` for cross-platform logging.
*   **`CryptoKit`**: Replaced with `swift-crypto` for hashing functionality on Linux.
*   **`Combine`**: Usage is now guarded with `#if canImport(Combine)` as it's Apple-only.
*   **Darwin-specific APIs**: `FoundationNetworking` added for networking, `OSAllocatedUnfairLock` replaced or guarded, and `@objc` attributes made conditional.

**Modules now building and testing on Linux (7 modules):**
*   `PVLogging` (Tier 1) - `OSLog` replaced with `swift-log`. All 38 tests pass.
*   `PVHashing` (Tier 1) - `CryptoKit` replaced with `swift-crypto`. All 15 tests pass.
*   `PVFeatureFlags` (Tier 0) - Already Linux-compatible. All 14 tests pass.
*   `PVCheevos` (Tier 0) - Added `FoundationNetworking`, guarded `URLSession` async APIs. Builds on Linux.
*   `PVSupport` (Tier 3) - `PVSettings` dependency made Apple-only, Darwin-specific threading APIs guarded. Builds on Linux.
*   `PVPrimitives` (Tier 2) - Guarded `CoreGraphics`, `CoreServices`, `CoreTransferable` imports, provided Linux stubs. Builds on Linux.
*   `PVPlists` (Tier 1) - Guarded `@objc` attributes. Builds on Linux.

**Additional `OSLog` fixes in higher-tier modules (not fully Linux-compatible yet):**
*   `PVCoreAudio`: `os_log()` calls guarded with `#if canImport(os)`, fallback to `PVLogging`.
*   `PVLibrary`: `os_log()` in `SwiftCloudDrive` replaced with `PVLogging` functions.
*   `PVLookup`: `CryptoKit` replaced with conditional `CryptoKit`/`Crypto` import.

**Modules not yet Linux-compatible (require larger changes):**
*   `PVSettings`: Blocked by `Defaults` package (no Linux support).
*   `PVAudio`: Blocked by Darwin-specific Mach kernel APIs in ring buffer C code.
*   `PVCoreAudio`: Tightly coupled to Apple audio frameworks.

### What are the relevant tickets
N/A

### Screenshots (important for UI changes)
N/A

### Questions
N/A

<div><a href="https://cursor.com/agents/bc-7fd2248f-ec70-4c34-86c4-1dbc63f0e1d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fd2248f-ec70-4c34-86c4-1dbc63f0e1d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->