### PR TITLE
fix: improve archive import robustness with batch-atomic moves, kqueu…

### DIFF
--- a/PVLibrary/Sources/PVLibrary/DirectoryWatcher/ArchiveExtractor.swift
+++ b/PVLibrary/Sources/PVLibrary/DirectoryWatcher/ArchiveExtractor.swift
@@ -25,10 +25,30 @@ import Unrar
 import Combine
 
 
-public enum ArchiveError: Error {
+public enum ArchiveError: Error, LocalizedError {
     case invalidArchive
     case fileTooLarge
     case extractionFailed(String)
+    /// Thrown when one or more extracted files could not be moved to the import
+    /// directory.  The archive and temp directory are preserved so the user can
+    /// retry.  `succeeded` is the number of files that were moved successfully;
+    /// `total` is the total number of files that were extracted.
+    case batchMoveFailed(succeeded: Int, total: Int)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidArchive:
+            return "The archive file is invalid or in an unsupported format."
+        case .fileTooLarge:
+            return "The archive file is too large to extract."
+        case .extractionFailed(let message):
+            return message
+        case .batchMoveFailed(let succeeded, let total):
+            let failed = total - succeeded
+            return "Failed to move \(failed) of \(total) extracted file(s) to the import directory. "
+                + "The archive and extracted files have been preserved for retry."
+        }
+    }
 }
 
 public enum ArchiveType: String, CaseIterable {

--- a/PVLibrary/Sources/PVLibrary/DirectoryWatcher/DirectoryWatcher.swift
+++ b/PVLibrary/Sources/PVLibrary/DirectoryWatcher/DirectoryWatcher.swift
@@ -476,20 +476,15 @@ public final class DirectoryWatcher: ObservableObject {
                 ELOG("Failed archive file size: \(sizeMB) MB")
             }
 
-            updateExtractionStatus(.failed(error: error))
-
-            // Post notification that extraction has failed
-            Task { @MainActor in
-                NotificationCenter.default.post(
-                    name: .archiveExtractionFailed,
-                    object: nil,
-                    userInfo: [
-                        "error": error.localizedDescription,
-                        "path": filePath.path,
-                        "filename": filePath.lastPathComponent,
-                        "timestamp": Date()
-                    ]
-                )
+            // Only update status/notify if the partial-move branch
+            // hasn't already done so (avoids duplicate notifications).
+            if case .failed = extractionStatus {
+                VLOG("Extraction status already .failed — skipping duplicate notification")
+            } else {
+                updateExtractionStatus(.failed(error: error))
+                await postArchiveExtractionFailed(
+                    error: error, filePath: filePath,
+                    movedCount: 0, failedCount: 0)
             }
 
             throw error

--- a/PVLibrary/Sources/PVLibrary/DirectoryWatcher/DirectoryWatcher.swift
+++ b/PVLibrary/Sources/PVLibrary/DirectoryWatcher/DirectoryWatcher.swift
@@ -446,17 +446,10 @@ public final class DirectoryWatcher: ObservableObject {
                     "\(moveResult.failedCount) file(s) could not be moved from temp directory"
                 )
                 updateExtractionStatus(.failed(error: partialError))
-                await MainActor.run {
-                    NotificationCenter.default.post(name: .archiveExtractionFailed, object: nil, userInfo: [
-                        "error": partialError.localizedDescription,
-                        "path": filePath.path,
-                        "filename": filePath.lastPathComponent,
-                        "movedCount": moveResult.moved.count,
-                        "failedCount": moveResult.failedCount,
-                        "timestamp": Date()
-                    ])
-                }
-                // Propagate so callers using try/await see the failure
+                await postArchiveExtractionFailed(
+                    error: partialError, filePath: filePath,
+                    movedCount: moveResult.moved.count,
+                    failedCount: moveResult.failedCount)
                 throw partialError
             }
         } catch {
@@ -540,6 +533,22 @@ public final class DirectoryWatcher: ObservableObject {
         let failedCount: Int
         /// `true` when every file was moved successfully.
         var isComplete: Bool { failedCount == 0 }
+    }
+
+    /// Posts the `archiveExtractionFailed` notification on the main actor.
+    private func postArchiveExtractionFailed(
+        error: Error, filePath: URL, movedCount: Int, failedCount: Int
+    ) async {
+        await MainActor.run {
+            NotificationCenter.default.post(name: .archiveExtractionFailed, object: nil, userInfo: [
+                "error": error.localizedDescription,
+                "path": filePath.path,
+                "filename": filePath.lastPathComponent,
+                "movedCount": movedCount,
+                "failedCount": failedCount,
+                "timestamp": Date()
+            ])
+        }
     }
 
     /// Verifies that an archive file is readable and has a recognizable

--- a/PVLibrary/Sources/PVLibrary/DirectoryWatcher/DirectoryWatcher.swift
+++ b/PVLibrary/Sources/PVLibrary/DirectoryWatcher/DirectoryWatcher.swift
@@ -447,19 +447,16 @@ public final class DirectoryWatcher: ObservableObject {
                 )
                 updateExtractionStatus(.failed(error: partialError))
                 await MainActor.run {
-                    NotificationCenter.default.post(
-                        name: .archiveExtractionFailed,
-                        object: nil,
-                        userInfo: [
-                            "error": partialError.localizedDescription,
-                            "path": filePath.path,
-                            "filename": filePath.lastPathComponent,
-                            "movedCount": moveResult.moved.count,
-                            "failedCount": moveResult.failedCount,
-                            "timestamp": Date()
-                        ]
-                    )
+                    NotificationCenter.default.post(name: .archiveExtractionFailed, object: nil, userInfo: [
+                        "error": partialError.localizedDescription,
+                        "path": filePath.path,
+                        "filename": filePath.lastPathComponent,
+                        "movedCount": moveResult.moved.count,
+                        "failedCount": moveResult.failedCount,
+                        "timestamp": Date()
+                    ])
                 }
+                // Propagate so callers using try/await see the failure
                 throw partialError
             }
         } catch {

--- a/PVLibrary/Sources/PVLibrary/DirectoryWatcher/DirectoryWatcher.swift
+++ b/PVLibrary/Sources/PVLibrary/DirectoryWatcher/DirectoryWatcher.swift
@@ -440,8 +440,8 @@ public final class DirectoryWatcher: ObservableObject {
                     ELOG("Failed to clean up temp extraction directory \(tempExtractionDir.lastPathComponent): \(error.localizedDescription)")
                 }
             } else {
-                WLOG("Preserving temp directory with \(moveResult.failedCount) unmoved file(s): \(tempExtractionDir.path)")
-                WLOG("Original archive preserved for retry: \(filePath.path)")
+                // Archive NOT deleted — preserved alongside temp dir for retry
+                WLOG("Partial move: \(moveResult.failedCount) file(s) remain in \(tempExtractionDir.path), archive preserved at \(filePath.path)")
                 let partialError = ArchiveError.extractionFailed(
                     "\(moveResult.failedCount) file(s) could not be moved from temp directory"
                 )

--- a/PVLibrary/Sources/PVLibrary/DirectoryWatcher/DirectoryWatcher.swift
+++ b/PVLibrary/Sources/PVLibrary/DirectoryWatcher/DirectoryWatcher.swift
@@ -294,11 +294,11 @@ public final class DirectoryWatcher: ObservableObject {
         }
 
         guard fileReadable else {
-            let description = "Archive file is locked or not readable: "
+            let description = "Archive file not readable after \(maxReadAttempts) attempt(s): "
                 + "\(filePath.lastPathComponent) (size: \(fileSize) bytes)"
             let error = NSError(domain: "DirectoryWatcher", code: -1,
                                 userInfo: [NSLocalizedDescriptionKey: description])
-            ELOG("Failed to verify archive file readiness: \(filePath.path)")
+            ELOG("Failed to verify archive file readiness after retries: \(filePath.path)")
             throw error
         }
 
@@ -463,27 +463,22 @@ public final class DirectoryWatcher: ObservableObject {
 
             // Move files FLATLY to the watched directory (no subdirectory structure)
             // This ensures files are immediately available for import without race conditions
-            let movedFiles = await moveExtractedFilesFlat(sortedFiles, from: tempExtractionDir, to: watchedDirectory)
+            let moveResult = await moveExtractedFilesFlat(sortedFiles, from: tempExtractionDir, to: watchedDirectory)
 
-            // Notify about the completed files
-            if !movedFiles.isEmpty {
-                completedFilesContinuation?.yield(movedFiles)
+            if !moveResult.moved.isEmpty {
+                completedFilesContinuation?.yield(moveResult.moved)
             }
 
-            // Only clean up temp directory if all files were moved successfully.
-            // If some remain, preserve the directory so files are not lost.
-            let remainingItems = (try? FileManager.default.contentsOfDirectory(at: tempExtractionDir, includingPropertiesForKeys: nil))?
-                .filter { !$0.lastPathComponent.hasPrefix(".") } ?? []
-            if remainingItems.isEmpty {
+            if moveResult.isComplete {
                 do {
                     try FileManager.default.removeItem(at: tempExtractionDir)
                 } catch {
                     ELOG("Failed to clean up temp extraction directory \(tempExtractionDir.lastPathComponent): \(error.localizedDescription)")
                 }
             } else {
-                WLOG("Preserving temp directory with \(remainingItems.count) unmoved file(s): \(tempExtractionDir.path)")
+                WLOG("Preserving temp directory with \(moveResult.failedCount) unmoved file(s): \(tempExtractionDir.path)")
                 let partialError = ArchiveError.extractionFailed(
-                    "\(remainingItems.count) file(s) could not be moved from temp directory"
+                    "\(moveResult.failedCount) file(s) could not be moved from temp directory"
                 )
                 updateExtractionStatus(.failed(error: partialError))
                 Task { @MainActor in
@@ -494,8 +489,8 @@ public final class DirectoryWatcher: ObservableObject {
                             "error": partialError.localizedDescription,
                             "path": filePath.path,
                             "filename": filePath.lastPathComponent,
-                            "movedCount": movedFiles.count,
-                            "failedCount": remainingItems.count,
+                            "movedCount": moveResult.moved.count,
+                            "failedCount": moveResult.failedCount,
                             "timestamp": Date()
                         ]
                     )
@@ -574,12 +569,25 @@ public final class DirectoryWatcher: ObservableObject {
         completedFilesContinuation?.yield([destinationURL])
     }
 
+    /// Result of a batch file-move operation.
+    struct BatchMoveResult {
+        /// Files that were successfully moved to the destination.
+        let moved: [URL]
+        /// Number of files that failed to move.
+        let failedCount: Int
+        /// `true` when every file was moved successfully.
+        var isComplete: Bool { failedCount == 0 }
+    }
+
     /// Moves extracted files to the destination directory, flattening any
     /// subdirectory structure. Individual move failures are logged but do
-    /// not abort the batch — successfully moved files are still returned.
-    /// The caller should check whether the source directory still contains
-    /// unmoved files before cleaning it up.
-    private func moveExtractedFilesFlat(_ files: [URL], from sourceDir: URL, to destinationDir: URL) async -> [URL] {
+    /// not abort the batch — successfully moved files are still returned
+    /// alongside the failure count so callers can decide how to proceed.
+    private func moveExtractedFilesFlat(
+        _ files: [URL],
+        from sourceDir: URL,
+        to destinationDir: URL
+    ) async -> BatchMoveResult {
         var movedFiles: [URL] = []
         var failedCount = 0
         for file in files {
@@ -605,9 +613,9 @@ public final class DirectoryWatcher: ObservableObject {
             }
         }
         if failedCount > 0 {
-            ELOG("Batch move completed with \(failedCount)/\(files.count) failure(s). Source directory preserved: \(sourceDir.path)")
+            ELOG("Batch move: \(failedCount)/\(files.count) failure(s). Source dir preserved: \(sourceDir.path)")
         }
-        return movedFiles
+        return BatchMoveResult(moved: movedFiles, failedCount: failedCount)
     }
 
     private func sortExtractedFiles(_ files: [URL]) -> [URL] {

--- a/PVLibrary/Sources/PVLibrary/DirectoryWatcher/DirectoryWatcher.swift
+++ b/PVLibrary/Sources/PVLibrary/DirectoryWatcher/DirectoryWatcher.swift
@@ -293,16 +293,15 @@ public final class DirectoryWatcher: ObservableObject {
             }
         }
 
-        guard fileReadable else {
+        if !fileReadable {
             let description = "Archive file not readable after \(maxReadAttempts) attempt(s): "
                 + "\(filePath.lastPathComponent) (size: \(fileSize) bytes)"
-            let error = NSError(domain: "DirectoryWatcher", code: -1,
-                                userInfo: [NSLocalizedDescriptionKey: description])
             ELOG("Failed to verify archive file readiness after retries: \(filePath.path)")
-            throw error
+            throw NSError(domain: "DirectoryWatcher", code: -1,
+                          userInfo: [NSLocalizedDescriptionKey: description])
         }
 
-        ILOG("Archive file \(filePath.lastPathComponent) verified as readable, proceeding with extraction")
+        ILOG("Archive file \(filePath.lastPathComponent) verified as readable after \(maxReadAttempts) attempt(s)")
 
         guard !filePath.path.contains("MACOSX") else {
             ILOG("Skipping MACOSX file: \(filePath.path)")

--- a/PVLibrary/Sources/PVLibrary/DirectoryWatcher/DirectoryWatcher.swift
+++ b/PVLibrary/Sources/PVLibrary/DirectoryWatcher/DirectoryWatcher.swift
@@ -397,8 +397,6 @@ public final class DirectoryWatcher: ObservableObject {
                 ILOG("Extracted file: \(extractedFile.path)")
             }
 
-            // Delete archive AFTER extraction succeeds (before moving files)
-            try await FileManager.default.removeItem(at: filePath)
             updateExtractionStatus(.completedArchive(paths: extractedFiles))
             ILOG("Archive extraction completed for file: \(filePath.path)")
 
@@ -429,6 +427,13 @@ public final class DirectoryWatcher: ObservableObject {
             }
 
             if moveResult.isComplete {
+                // All files moved — safe to delete archive and temp dir
+                do {
+                    try await FileManager.default.removeItem(at: filePath)
+                    ILOG("Deleted original archive after successful move: \(filePath.lastPathComponent)")
+                } catch {
+                    ELOG("Failed to delete original archive \(filePath.lastPathComponent): \(error.localizedDescription)")
+                }
                 do {
                     try FileManager.default.removeItem(at: tempExtractionDir)
                 } catch {
@@ -436,6 +441,7 @@ public final class DirectoryWatcher: ObservableObject {
                 }
             } else {
                 WLOG("Preserving temp directory with \(moveResult.failedCount) unmoved file(s): \(tempExtractionDir.path)")
+                WLOG("Original archive preserved for retry: \(filePath.path)")
                 let partialError = ArchiveError.extractionFailed(
                     "\(moveResult.failedCount) file(s) could not be moved from temp directory"
                 )

--- a/PVLibrary/Sources/PVLibrary/DirectoryWatcher/DirectoryWatcher.swift
+++ b/PVLibrary/Sources/PVLibrary/DirectoryWatcher/DirectoryWatcher.swift
@@ -243,62 +243,49 @@ public final class DirectoryWatcher: ObservableObject {
         ILOG("Starting archive extraction for file: \(filePath.path)")
         stopWatchingFile(at: filePath)
 
-        // Ensure file is fully written and not locked before attempting extraction
-        // Add a small delay to ensure file system has finished writing
-        try? await Task.sleep(nanoseconds: 200_000_000) // 200ms delay
-
-        // Verify file still exists and is readable
+        // Wait for file to stabilize using kqueue-based dispatch source monitoring.
+        // Replaces fixed 200ms poll + retry loop with event-driven detection.
         guard FileManager.default.fileExists(atPath: filePath.path) else {
             ILOG("Archive file no longer exists: \(filePath.path)")
             return
         }
 
-        // Try to verify file is readable and not locked
-        // Attempt to open the file multiple times if needed
+        let isStable = await FileStabilityChecker.waitForStability(at: filePath)
+        if !isStable {
+            WLOG("File \(filePath.lastPathComponent) did not stabilize within timeout, attempting extraction anyway")
+        }
+
+        guard FileManager.default.fileExists(atPath: filePath.path) else {
+            ILOG("Archive file no longer exists after stability wait: \(filePath.path)")
+            return
+        }
+
+        // Single readability + signature check after stability wait
         var fileReadable = false
         var fileSize: Int64 = 0
-        for attempt in 1...5 {
-            // Try to read file attributes first (less intrusive than opening a handle)
-            if let attributes = try? FileManager.default.attributesOfItem(atPath: filePath.path),
-               let size = attributes[.size] as? Int64,
-               size > 0 {
-                fileSize = size
-                ILOG("Archive file \(filePath.lastPathComponent) has size: \(size) bytes (attempt \(attempt))")
-
-                // File exists and has size, try to open it
-                if let fileHandle = try? FileHandle(forReadingFrom: filePath) {
-                    // Verify file is readable by checking signature
-                    let signature = fileHandle.readData(ofLength: 4)
-                    fileHandle.closeFile()
-
-                    // Check if it's a known archive format
-                    let isValidArchive = (signature.count >= 2 && signature[0] == 0x50 && signature[1] == 0x4B) || // ZIP
-                                        (signature.count >= 4 && signature[0] == 0x37 && signature[1] == 0x7A && signature[2] == 0xBC && signature[3] == 0xAF) // 7z
-
-                    if isValidArchive {
-                        let format = (signature.count >= 2 && signature[0] == 0x50 && signature[1] == 0x4B) ? "ZIP" : "7z"
-                        ILOG("Archive file \(filePath.lastPathComponent) has valid \(format) signature")
-                        // Small delay after closing to ensure file handle is fully released
-                        try? await Task.sleep(nanoseconds: 50_000_000) // 50ms delay
-                        fileReadable = true
-                        break
-                    } else {
-                        let hexSignature = signature.prefix(4).map { String(format: "%02X", $0) }.joined(separator: " ")
-                        WLOG("Archive file \(filePath.lastPathComponent) does not have valid archive signature (got: \(hexSignature)), attempt \(attempt)/5")
-                        try? await Task.sleep(nanoseconds: 300_000_000) // 300ms delay
-                    }
+        if let attributes = try? FileManager.default.attributesOfItem(atPath: filePath.path),
+           let size = attributes[.size] as? Int64, size > 0 {
+            fileSize = size
+            ILOG("Archive file \(filePath.lastPathComponent) has size: \(size) bytes")
+            if let fileHandle = try? FileHandle(forReadingFrom: filePath) {
+                let signature = fileHandle.readData(ofLength: 4)
+                fileHandle.closeFile()
+                let isZip = signature.count >= 2 && signature[0] == 0x50 && signature[1] == 0x4B
+                let is7z = signature.count >= 4 && signature[0] == 0x37 && signature[1] == 0x7A && signature[2] == 0xBC && signature[3] == 0xAF
+                if isZip || is7z {
+                    ILOG("Archive file \(filePath.lastPathComponent) has valid \(isZip ? "ZIP" : "7z") signature")
                 } else {
-                    ILOG("Archive file appears locked (attempt \(attempt)/5), waiting...")
-                    try? await Task.sleep(nanoseconds: 300_000_000) // 300ms delay
+                    let hexSignature = signature.prefix(4).map { String(format: "%02X", $0) }.joined(separator: " ")
+                    ILOG("Archive file \(filePath.lastPathComponent) signature (\(hexSignature)) not ZIP/7z, will use extension-based detection")
                 }
-            } else {
-                ILOG("Archive file has no size or invalid attributes (attempt \(attempt)/5), waiting...")
-                try? await Task.sleep(nanoseconds: 300_000_000) // 300ms delay
+                fileReadable = true
             }
         }
 
         guard fileReadable else {
-            let error = NSError(domain: "DirectoryWatcher", code: -1, userInfo: [NSLocalizedDescriptionKey: "Archive file is locked or not readable: \(filePath.lastPathComponent) (size: \(fileSize) bytes)"])
+            let description = "Archive file is locked or not readable: \(filePath.lastPathComponent) (size: \(fileSize) bytes)"
+            let error = NSError(domain: "DirectoryWatcher", code: -1,
+                                userInfo: [NSLocalizedDescriptionKey: description])
             ELOG("Failed to verify archive file readiness: \(filePath.path)")
             throw error
         }
@@ -464,13 +451,24 @@ public final class DirectoryWatcher: ObservableObject {
 
             // Move files FLATLY to the watched directory (no subdirectory structure)
             // This ensures files are immediately available for import without race conditions
-            let movedFiles = try await moveExtractedFilesFlat(sortedFiles, from: tempExtractionDir, to: watchedDirectory)
+            let movedFiles = await moveExtractedFilesFlat(sortedFiles, from: tempExtractionDir, to: watchedDirectory)
 
             // Notify about the completed files
             completedFilesContinuation?.yield(movedFiles)
 
-            // Clean up temporary directory
-            try await FileManager.default.removeItem(at: tempExtractionDir)
+            // Only clean up temp directory if all files were moved successfully.
+            // If some remain, preserve the directory so files are not lost.
+            let remainingItems = (try? FileManager.default.contentsOfDirectory(at: tempExtractionDir, includingPropertiesForKeys: nil))?
+                .filter { !$0.lastPathComponent.hasPrefix(".") } ?? []
+            if remainingItems.isEmpty {
+                do {
+                    try FileManager.default.removeItem(at: tempExtractionDir)
+                } catch {
+                    ELOG("Failed to clean up temp extraction directory \(tempExtractionDir.lastPathComponent): \(error.localizedDescription)")
+                }
+            } else {
+                WLOG("Preserving temp directory with \(remainingItems.count) unmoved file(s): \(tempExtractionDir.path)")
+            }
         } catch {
             // Log detailed error information
             let errorDescription = error.localizedDescription
@@ -544,15 +542,18 @@ public final class DirectoryWatcher: ObservableObject {
         completedFilesContinuation?.yield([destinationURL])
     }
 
-    /// Move extracted files flatly (preserving only filenames, no directory structure)
-    private func moveExtractedFilesFlat(_ files: [URL], from sourceDir: URL, to destinationDir: URL) async throws -> [URL] {
+    /// Moves extracted files to the destination directory, flattening any
+    /// subdirectory structure. Individual move failures are logged but do
+    /// not abort the batch — successfully moved files are still returned.
+    /// The caller should check whether the source directory still contains
+    /// unmoved files before cleaning it up.
+    private func moveExtractedFilesFlat(_ files: [URL], from sourceDir: URL, to destinationDir: URL) async -> [URL] {
         var movedFiles: [URL] = []
+        var failedCount = 0
         for file in files {
-            // Only preserve the filename, flatten directory structure
             let fileName = file.lastPathComponent
             let destinationURL = destinationDir.appendingPathComponent(fileName)
 
-            // Handle filename conflicts
             var finalDestinationURL = destinationURL
             var counter = 1
             while FileManager.default.fileExists(atPath: finalDestinationURL.path) {
@@ -562,9 +563,17 @@ public final class DirectoryWatcher: ObservableObject {
                 counter += 1
             }
 
-            try FileManager.default.moveItem(at: file, to: finalDestinationURL)
-            movedFiles.append(finalDestinationURL)
-            ILOG("Moved extracted file flatly: \(fileName) -> \(finalDestinationURL.lastPathComponent)")
+            do {
+                try FileManager.default.moveItem(at: file, to: finalDestinationURL)
+                movedFiles.append(finalDestinationURL)
+                ILOG("Moved extracted file flatly: \(fileName) -> \(finalDestinationURL.lastPathComponent)")
+            } catch {
+                failedCount += 1
+                ELOG("Failed to move extracted file \(fileName): \(error.localizedDescription)")
+            }
+        }
+        if failedCount > 0 {
+            ELOG("Batch move completed with \(failedCount)/\(files.count) failure(s). Source directory preserved: \(sourceDir.path)")
         }
         return movedFiles
     }

--- a/PVLibrary/Sources/PVLibrary/DirectoryWatcher/DirectoryWatcher.swift
+++ b/PVLibrary/Sources/PVLibrary/DirectoryWatcher/DirectoryWatcher.swift
@@ -293,15 +293,15 @@ public final class DirectoryWatcher: ObservableObject {
             }
         }
 
-        if !fileReadable {
+        if fileReadable {
+            ILOG("Archive file \(filePath.lastPathComponent) verified as readable after \(maxReadAttempts) attempt(s)")
+        } else {
             let description = "Archive file not readable after \(maxReadAttempts) attempt(s): "
                 + "\(filePath.lastPathComponent) (size: \(fileSize) bytes)"
             ELOG("Failed to verify archive file readiness after retries: \(filePath.path)")
             throw NSError(domain: "DirectoryWatcher", code: -1,
                           userInfo: [NSLocalizedDescriptionKey: description])
         }
-
-        ILOG("Archive file \(filePath.lastPathComponent) verified as readable after \(maxReadAttempts) attempt(s)")
 
         guard !filePath.path.contains("MACOSX") else {
             ILOG("Skipping MACOSX file: \(filePath.path)")

--- a/PVLibrary/Sources/PVLibrary/DirectoryWatcher/DirectoryWatcher.swift
+++ b/PVLibrary/Sources/PVLibrary/DirectoryWatcher/DirectoryWatcher.swift
@@ -261,47 +261,7 @@ public final class DirectoryWatcher: ObservableObject {
         }
 
         // Bounded retry readability + signature check after stability wait.
-        // A short retry handles transient locks that outlast the quiesce interval.
-        let maxReadAttempts = isStable ? 2 : 3
-        var fileReadable = false
-        var fileSize: Int64 = 0
-        for readAttempt in 1...maxReadAttempts {
-            if let attributes = try? FileManager.default.attributesOfItem(atPath: filePath.path),
-               let size = attributes[.size] as? Int64, size > 0 {
-                fileSize = size
-                ILOG("Archive file \(filePath.lastPathComponent) has size: \(size) bytes")
-                if let fileHandle = try? FileHandle(forReadingFrom: filePath) {
-                    let signature = fileHandle.readData(ofLength: 4)
-                    fileHandle.closeFile()
-                    let isZip = signature.count >= 2 && signature[0] == 0x50 && signature[1] == 0x4B
-                    let is7z = signature.count >= 4 && signature[0] == 0x37 && signature[1] == 0x7A
-                        && signature[2] == 0xBC && signature[3] == 0xAF
-                    if isZip || is7z {
-                        ILOG("Archive file \(filePath.lastPathComponent) has valid \(isZip ? "ZIP" : "7z") signature")
-                    } else {
-                        let hex = signature.prefix(4).map { String(format: "%02X", $0) }.joined(separator: " ")
-                        ILOG("Archive \(filePath.lastPathComponent) signature (\(hex)) not ZIP/7z, using extension detection")
-                    }
-                    fileReadable = true
-                    break
-                }
-            }
-            if readAttempt < maxReadAttempts {
-                let delay: UInt64 = isStable ? 200_000_000 : 400_000_000
-                WLOG("Archive \(filePath.lastPathComponent) not readable (attempt \(readAttempt)/\(maxReadAttempts)), retrying...")
-                try? await Task.sleep(nanoseconds: delay)
-            }
-        }
-
-        if fileReadable {
-            ILOG("Archive file \(filePath.lastPathComponent) verified as readable after \(maxReadAttempts) attempt(s)")
-        } else {
-            let description = "Archive file not readable after \(maxReadAttempts) attempt(s): "
-                + "\(filePath.lastPathComponent) (size: \(fileSize) bytes)"
-            ELOG("Failed to verify archive file readiness after retries: \(filePath.path)")
-            throw NSError(domain: "DirectoryWatcher", code: -1,
-                          userInfo: [NSLocalizedDescriptionKey: description])
-        }
+        try await verifyArchiveReadable(at: filePath, isStable: isStable)
 
         guard !filePath.path.contains("MACOSX") else {
             ILOG("Skipping MACOSX file: \(filePath.path)")
@@ -576,6 +536,51 @@ public final class DirectoryWatcher: ObservableObject {
         let failedCount: Int
         /// `true` when every file was moved successfully.
         var isComplete: Bool { failedCount == 0 }
+    }
+
+    /// Verifies that an archive file is readable and has a recognizable
+    /// signature, retrying a bounded number of times with backoff to handle
+    /// transient file locks that may outlast the stability quiesce interval.
+    private func verifyArchiveReadable(at filePath: URL, isStable: Bool) async throws {
+        let maxAttempts = isStable ? 2 : 3
+        var fileSize: Int64 = 0
+
+        for attempt in 1...maxAttempts {
+            if let attributes = try? FileManager.default.attributesOfItem(atPath: filePath.path),
+               let size = attributes[.size] as? Int64, size > 0 {
+                fileSize = size
+                ILOG("Archive file \(filePath.lastPathComponent) has size: \(size) bytes")
+                if let fileHandle = try? FileHandle(forReadingFrom: filePath) {
+                    let signature = fileHandle.readData(ofLength: 4)
+                    fileHandle.closeFile()
+                    let isZip = signature.count >= 2
+                        && signature[0] == 0x50 && signature[1] == 0x4B
+                    let is7z = signature.count >= 4
+                        && signature[0] == 0x37 && signature[1] == 0x7A
+                        && signature[2] == 0xBC && signature[3] == 0xAF
+                    if isZip || is7z {
+                        ILOG("Archive \(filePath.lastPathComponent) has valid \(isZip ? "ZIP" : "7z") signature")
+                    } else {
+                        let hex = signature.prefix(4)
+                            .map { String(format: "%02X", $0) }.joined(separator: " ")
+                        ILOG("Archive \(filePath.lastPathComponent) signature (\(hex)) not ZIP/7z, using extension detection")
+                    }
+                    ILOG("Archive \(filePath.lastPathComponent) verified readable on attempt \(attempt)")
+                    return
+                }
+            }
+            if attempt < maxAttempts {
+                let delay: UInt64 = isStable ? 200_000_000 : 400_000_000
+                WLOG("Archive \(filePath.lastPathComponent) not readable (attempt \(attempt)/\(maxAttempts)), retrying...")
+                try? await Task.sleep(nanoseconds: delay)
+            }
+        }
+
+        let description = "Archive file not readable after \(maxAttempts) attempt(s): "
+            + "\(filePath.lastPathComponent) (size: \(fileSize) bytes)"
+        ELOG("Failed to verify archive readiness after retries: \(filePath.path)")
+        throw NSError(domain: "DirectoryWatcher", code: -1,
+                      userInfo: [NSLocalizedDescriptionKey: description])
     }
 
     /// Moves extracted files to the destination directory, flattening any

--- a/PVLibrary/Sources/PVLibrary/DirectoryWatcher/DirectoryWatcher.swift
+++ b/PVLibrary/Sources/PVLibrary/DirectoryWatcher/DirectoryWatcher.swift
@@ -260,30 +260,42 @@ public final class DirectoryWatcher: ObservableObject {
             return
         }
 
-        // Single readability + signature check after stability wait
+        // Bounded retry readability + signature check after stability wait.
+        // A short retry handles transient locks that outlast the quiesce interval.
+        let maxReadAttempts = isStable ? 2 : 3
         var fileReadable = false
         var fileSize: Int64 = 0
-        if let attributes = try? FileManager.default.attributesOfItem(atPath: filePath.path),
-           let size = attributes[.size] as? Int64, size > 0 {
-            fileSize = size
-            ILOG("Archive file \(filePath.lastPathComponent) has size: \(size) bytes")
-            if let fileHandle = try? FileHandle(forReadingFrom: filePath) {
-                let signature = fileHandle.readData(ofLength: 4)
-                fileHandle.closeFile()
-                let isZip = signature.count >= 2 && signature[0] == 0x50 && signature[1] == 0x4B
-                let is7z = signature.count >= 4 && signature[0] == 0x37 && signature[1] == 0x7A && signature[2] == 0xBC && signature[3] == 0xAF
-                if isZip || is7z {
-                    ILOG("Archive file \(filePath.lastPathComponent) has valid \(isZip ? "ZIP" : "7z") signature")
-                } else {
-                    let hexSignature = signature.prefix(4).map { String(format: "%02X", $0) }.joined(separator: " ")
-                    ILOG("Archive file \(filePath.lastPathComponent) signature (\(hexSignature)) not ZIP/7z, will use extension-based detection")
+        for readAttempt in 1...maxReadAttempts {
+            if let attributes = try? FileManager.default.attributesOfItem(atPath: filePath.path),
+               let size = attributes[.size] as? Int64, size > 0 {
+                fileSize = size
+                ILOG("Archive file \(filePath.lastPathComponent) has size: \(size) bytes")
+                if let fileHandle = try? FileHandle(forReadingFrom: filePath) {
+                    let signature = fileHandle.readData(ofLength: 4)
+                    fileHandle.closeFile()
+                    let isZip = signature.count >= 2 && signature[0] == 0x50 && signature[1] == 0x4B
+                    let is7z = signature.count >= 4 && signature[0] == 0x37 && signature[1] == 0x7A
+                        && signature[2] == 0xBC && signature[3] == 0xAF
+                    if isZip || is7z {
+                        ILOG("Archive file \(filePath.lastPathComponent) has valid \(isZip ? "ZIP" : "7z") signature")
+                    } else {
+                        let hex = signature.prefix(4).map { String(format: "%02X", $0) }.joined(separator: " ")
+                        ILOG("Archive \(filePath.lastPathComponent) signature (\(hex)) not ZIP/7z, using extension detection")
+                    }
+                    fileReadable = true
+                    break
                 }
-                fileReadable = true
+            }
+            if readAttempt < maxReadAttempts {
+                let delay: UInt64 = isStable ? 200_000_000 : 400_000_000
+                WLOG("Archive \(filePath.lastPathComponent) not readable (attempt \(readAttempt)/\(maxReadAttempts)), retrying...")
+                try? await Task.sleep(nanoseconds: delay)
             }
         }
 
         guard fileReadable else {
-            let description = "Archive file is locked or not readable: \(filePath.lastPathComponent) (size: \(fileSize) bytes)"
+            let description = "Archive file is locked or not readable: "
+                + "\(filePath.lastPathComponent) (size: \(fileSize) bytes)"
             let error = NSError(domain: "DirectoryWatcher", code: -1,
                                 userInfo: [NSLocalizedDescriptionKey: description])
             ELOG("Failed to verify archive file readiness: \(filePath.path)")
@@ -454,7 +466,9 @@ public final class DirectoryWatcher: ObservableObject {
             let movedFiles = await moveExtractedFilesFlat(sortedFiles, from: tempExtractionDir, to: watchedDirectory)
 
             // Notify about the completed files
-            completedFilesContinuation?.yield(movedFiles)
+            if !movedFiles.isEmpty {
+                completedFilesContinuation?.yield(movedFiles)
+            }
 
             // Only clean up temp directory if all files were moved successfully.
             // If some remain, preserve the directory so files are not lost.
@@ -468,6 +482,24 @@ public final class DirectoryWatcher: ObservableObject {
                 }
             } else {
                 WLOG("Preserving temp directory with \(remainingItems.count) unmoved file(s): \(tempExtractionDir.path)")
+                let partialError = ArchiveError.extractionFailed(
+                    "\(remainingItems.count) file(s) could not be moved from temp directory"
+                )
+                updateExtractionStatus(.failed(error: partialError))
+                Task { @MainActor in
+                    NotificationCenter.default.post(
+                        name: .archiveExtractionFailed,
+                        object: nil,
+                        userInfo: [
+                            "error": partialError.localizedDescription,
+                            "path": filePath.path,
+                            "filename": filePath.lastPathComponent,
+                            "movedCount": movedFiles.count,
+                            "failedCount": remainingItems.count,
+                            "timestamp": Date()
+                        ]
+                    )
+                }
             }
         } catch {
             // Log detailed error information

--- a/PVLibrary/Sources/PVLibrary/DirectoryWatcher/DirectoryWatcher.swift
+++ b/PVLibrary/Sources/PVLibrary/DirectoryWatcher/DirectoryWatcher.swift
@@ -460,6 +460,7 @@ public final class DirectoryWatcher: ObservableObject {
                         ]
                     )
                 }
+                throw partialError
             }
         } catch {
             // Log detailed error information

--- a/PVLibrary/Sources/PVLibrary/DirectoryWatcher/DirectoryWatcher.swift
+++ b/PVLibrary/Sources/PVLibrary/DirectoryWatcher/DirectoryWatcher.swift
@@ -464,6 +464,8 @@ public final class DirectoryWatcher: ObservableObject {
                     ELOG("ArchiveError.fileTooLarge")
                 case .invalidArchive:
                     ELOG("ArchiveError.invalidArchive")
+                case .batchMoveFailed(let succeeded, let total):
+                    ELOG("ArchiveError.batchMoveFailed: \(succeeded)/\(total) file(s) moved successfully")
                 }
             }
 
@@ -609,7 +611,8 @@ public final class DirectoryWatcher: ObservableObject {
             while FileManager.default.fileExists(atPath: finalDestinationURL.path) {
                 let nameWithoutExt = destinationURL.deletingPathExtension().lastPathComponent
                 let ext = destinationURL.pathExtension
-                finalDestinationURL = destinationDir.appendingPathComponent("\(nameWithoutExt)_\(counter).\(ext)")
+                let newName = ext.isEmpty ? "\(nameWithoutExt)_\(counter)" : "\(nameWithoutExt)_\(counter).\(ext)"
+                finalDestinationURL = destinationDir.appendingPathComponent(newName)
                 counter += 1
             }
 

--- a/PVLibrary/Sources/PVLibrary/DirectoryWatcher/DirectoryWatcher.swift
+++ b/PVLibrary/Sources/PVLibrary/DirectoryWatcher/DirectoryWatcher.swift
@@ -446,11 +446,9 @@ public final class DirectoryWatcher: ObservableObject {
                     "\(moveResult.failedCount) file(s) could not be moved from temp directory"
                 )
                 updateExtractionStatus(.failed(error: partialError))
-                await postArchiveExtractionFailed(
-                    error: partialError, filePath: filePath,
-                    movedCount: moveResult.moved.count,
-                    failedCount: moveResult.failedCount)
-                throw partialError
+                await postArchiveExtractionFailed(error: partialError, filePath: filePath,
+                                                  movedCount: moveResult.moved.count, failedCount: moveResult.failedCount)
+                throw partialError // caught below; catch block skips re-post via .failed guard
             }
         } catch {
             // Log detailed error information

--- a/PVLibrary/Sources/PVLibrary/DirectoryWatcher/DirectoryWatcher.swift
+++ b/PVLibrary/Sources/PVLibrary/DirectoryWatcher/DirectoryWatcher.swift
@@ -446,7 +446,7 @@ public final class DirectoryWatcher: ObservableObject {
                     "\(moveResult.failedCount) file(s) could not be moved from temp directory"
                 )
                 updateExtractionStatus(.failed(error: partialError))
-                Task { @MainActor in
+                await MainActor.run {
                     NotificationCenter.default.post(
                         name: .archiveExtractionFailed,
                         object: nil,

--- a/PVLibrary/Sources/PVLibrary/DirectoryWatcher/FileStabilityChecker.swift
+++ b/PVLibrary/Sources/PVLibrary/DirectoryWatcher/FileStabilityChecker.swift
@@ -56,6 +56,8 @@ enum FileStabilityChecker {
     ///   was cancelled. When the file descriptor cannot be opened
     ///   (e.g. sandbox/permissions), returns `true` optimistically
     ///   so callers proceed to their own readability checks.
+    /// - Note: See `FileStabilityCheckerTests` for coverage of immediate
+    ///   stability, timeout, and task cancellation scenarios.
     static func waitForStability(
         at url: URL,
         quiesceInterval: TimeInterval = 0.3,

--- a/PVLibrary/Sources/PVLibrary/DirectoryWatcher/FileStabilityChecker.swift
+++ b/PVLibrary/Sources/PVLibrary/DirectoryWatcher/FileStabilityChecker.swift
@@ -16,6 +16,18 @@ import PVLogging
 /// `quiesceInterval` seconds, or the overall `timeout` is exceeded.
 enum FileStabilityChecker {
 
+    /// Shared serial queue for all stability checks. Per-call state is
+    /// kept in the closure, so a single queue is sufficient.
+    private static let queue = DispatchQueue(
+        label: "org.provenance-emu.file-stability"
+    )
+
+    /// Shared mutable reference so `withTaskCancellationHandler`'s
+    /// `onCancel` closure can trigger the same teardown path.
+    private final class CancelRef: @unchecked Sendable {
+        var finish: ((Bool) -> Void)?
+    }
+
     /// Waits for a file to become stable (no active writes) using
     /// kqueue-based dispatch source monitoring.
     ///
@@ -25,8 +37,11 @@ enum FileStabilityChecker {
     ///     considered stable. Defaults to 0.3 s.
     ///   - timeout: Maximum seconds to wait before giving up.
     ///     Defaults to 10 s.
-    /// - Returns: `true` if the file became stable within `timeout`,
-    ///   `false` if the timeout was reached first.
+    /// - Returns: `true` if the file became stable within `timeout`.
+    ///   `false` if the timeout was reached or the enclosing `Task`
+    ///   was cancelled. When the file descriptor cannot be opened
+    ///   (e.g. sandbox/permissions), returns `true` optimistically
+    ///   so callers proceed to their own readability checks.
     static func waitForStability(
         at url: URL,
         quiesceInterval: TimeInterval = 0.3,
@@ -35,69 +50,81 @@ enum FileStabilityChecker {
         let fd = open(url.path, O_EVTONLY)
         guard fd >= 0 else {
             let code = errno
-            WLOG("FileStabilityChecker: open(\(url.lastPathComponent)) failed — errno \(code) (\(String(cString: strerror(code))))")
-            return false // fd unavailable, assume file is ready
+            WLOG("FileStabilityChecker: open(\(url.lastPathComponent)) failed — "
+                 + "errno \(code) (\(String(cString: strerror(code)))); "
+                 + "proceeding optimistically")
+            return true
         }
 
-        return await withCheckedContinuation { continuation in
-            let queue = DispatchQueue(
-                label: "org.provenance-emu.file-stability.\(UUID().uuidString)"
-            )
-            var hasResumed = false
+        let cancelRef = CancelRef()
 
-            let source = DispatchSource.makeFileSystemObjectSource(
-                fileDescriptor: fd,
-                eventMask: [.write, .extend, .attrib],
-                queue: queue
-            )
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                var hasResumed = false
 
-            var stabilityTimer: DispatchWorkItem?
-            var timeoutTimer: DispatchWorkItem?
-
-            /// Thread-safe single-shot resume helper.
-            let finish: (Bool) -> Void = { result in
-                guard !hasResumed else { return }
-                hasResumed = true
-                stabilityTimer?.cancel()
-                timeoutTimer?.cancel()
-                source.cancel()
-                continuation.resume(returning: result)
-            }
-
-            /// Resets the quiesce timer. After `quiesceInterval` with no
-            /// further events the file is declared stable.
-            func scheduleQuiesceTimer() {
-                stabilityTimer?.cancel()
-                let timer = DispatchWorkItem {
-                    ILOG("FileStabilityChecker: \(url.lastPathComponent) stable (no writes for \(quiesceInterval)s)")
-                    finish(true)
-                }
-                stabilityTimer = timer
-                queue.asyncAfter(
-                    deadline: .now() + quiesceInterval,
-                    execute: timer
+                let source = DispatchSource.makeFileSystemObjectSource(
+                    fileDescriptor: fd,
+                    eventMask: [.write, .extend, .attrib],
+                    queue: queue
                 )
-            }
 
-            source.setEventHandler {
-                VLOG("FileStabilityChecker: Write activity on \(url.lastPathComponent), resetting timer")
+                var stabilityTimer: DispatchWorkItem?
+                var timeoutTimer: DispatchWorkItem?
+
+                let finish: (Bool) -> Void = { result in
+                    queue.async {
+                        guard !hasResumed else { return }
+                        hasResumed = true
+                        stabilityTimer?.cancel()
+                        timeoutTimer?.cancel()
+                        source.cancel()
+                        continuation.resume(returning: result)
+                    }
+                }
+
+                cancelRef.finish = finish
+
+                if Task.isCancelled {
+                    ILOG("FileStabilityChecker: Already cancelled for \(url.lastPathComponent)")
+                    finish(false)
+                    return
+                }
+
+                func scheduleQuiesceTimer() {
+                    stabilityTimer?.cancel()
+                    let timer = DispatchWorkItem {
+                        ILOG("FileStabilityChecker: \(url.lastPathComponent) stable (no writes for \(quiesceInterval)s)")
+                        finish(true)
+                    }
+                    stabilityTimer = timer
+                    queue.asyncAfter(
+                        deadline: .now() + quiesceInterval,
+                        execute: timer
+                    )
+                }
+
+                source.setEventHandler {
+                    VLOG("FileStabilityChecker: Write activity on \(url.lastPathComponent), resetting timer")
+                    scheduleQuiesceTimer()
+                }
+
+                source.setCancelHandler {
+                    close(fd)
+                }
+
+                let hardTimeout = DispatchWorkItem {
+                    WLOG("FileStabilityChecker: Timed out waiting for \(url.lastPathComponent) to stabilize")
+                    finish(false)
+                }
+                timeoutTimer = hardTimeout
+                queue.asyncAfter(deadline: .now() + timeout, execute: hardTimeout)
+
+                source.resume()
                 scheduleQuiesceTimer()
             }
-
-            source.setCancelHandler {
-                close(fd)
-            }
-
-            // Cancellable hard timeout to avoid waiting forever.
-            let hardTimeout = DispatchWorkItem {
-                WLOG("FileStabilityChecker: Timed out waiting for \(url.lastPathComponent) to stabilize")
-                finish(false)
-            }
-            timeoutTimer = hardTimeout
-            queue.asyncAfter(deadline: .now() + timeout, execute: hardTimeout)
-
-            source.resume()
-            scheduleQuiesceTimer()
+        } onCancel: {
+            ILOG("FileStabilityChecker: Task cancelled for \(url.lastPathComponent)")
+            cancelRef.finish?(false)
         }
     }
 }

--- a/PVLibrary/Sources/PVLibrary/DirectoryWatcher/FileStabilityChecker.swift
+++ b/PVLibrary/Sources/PVLibrary/DirectoryWatcher/FileStabilityChecker.swift
@@ -33,10 +33,9 @@ enum FileStabilityChecker {
         timeout: TimeInterval = 10.0
     ) async -> Bool {
         let fd = open(url.path, O_EVTONLY)
-        guard fd >= 0 else {
-            let errnoValue = errno
-            let reason = String(cString: strerror(errnoValue))
-            WLOG("FileStabilityChecker: Cannot open fd for \(url.lastPathComponent) — errno \(errnoValue): \(reason)")
+        if fd < 0 {
+            let code = errno
+            WLOG("FileStabilityChecker: Cannot open fd for \(url.lastPathComponent) — errno \(code): \(String(cString: strerror(code)))")
             return false
         }
 

--- a/PVLibrary/Sources/PVLibrary/DirectoryWatcher/FileStabilityChecker.swift
+++ b/PVLibrary/Sources/PVLibrary/DirectoryWatcher/FileStabilityChecker.swift
@@ -16,16 +16,30 @@ import PVLogging
 /// `quiesceInterval` seconds, or the overall `timeout` is exceeded.
 enum FileStabilityChecker {
 
-    /// Shared serial queue for all stability checks. Per-call state is
-    /// kept in the closure, so a single queue is sufficient.
+    /// Shared serial queue for all stability checks.
     private static let queue = DispatchQueue(
         label: "org.provenance-emu.file-stability"
     )
 
-    /// Shared mutable reference so `withTaskCancellationHandler`'s
-    /// `onCancel` closure can trigger the same teardown path.
-    private final class CancelRef: @unchecked Sendable {
-        var finish: ((Bool) -> Void)?
+    /// Thread-safe handle that `onCancel` uses to trigger teardown.
+    /// All access to the stored closure is protected by `lock`.
+    private final class CancelHandle: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _teardown: (() -> Void)?
+
+        func set(_ block: @escaping () -> Void) {
+            lock.lock()
+            _teardown = block
+            lock.unlock()
+        }
+
+        func fire() {
+            lock.lock()
+            let block = _teardown
+            _teardown = nil
+            lock.unlock()
+            block?()
+        }
     }
 
     /// Waits for a file to become stable (no active writes) using
@@ -56,23 +70,35 @@ enum FileStabilityChecker {
             return true
         }
 
-        let cancelRef = CancelRef()
+        let handle = CancelHandle()
 
         return await withTaskCancellationHandler {
             await withCheckedContinuation { continuation in
-                var hasResumed = false
+                // Dispatch all setup to the serial queue so every
+                // mutation of timers / hasResumed is confined to one
+                // thread, eliminating races with event callbacks.
+                queue.async {
+                    if Task.isCancelled {
+                        ILOG("FileStabilityChecker: Already cancelled for \(url.lastPathComponent)")
+                        close(fd)
+                        continuation.resume(returning: false)
+                        return
+                    }
 
-                let source = DispatchSource.makeFileSystemObjectSource(
-                    fileDescriptor: fd,
-                    eventMask: [.write, .extend, .attrib],
-                    queue: queue
-                )
+                    var hasResumed = false
+                    var stabilityTimer: DispatchWorkItem?
+                    var timeoutTimer: DispatchWorkItem?
 
-                var stabilityTimer: DispatchWorkItem?
-                var timeoutTimer: DispatchWorkItem?
+                    let source = DispatchSource.makeFileSystemObjectSource(
+                        fileDescriptor: fd,
+                        eventMask: [.write, .extend, .attrib],
+                        queue: queue
+                    )
 
-                let finish: (Bool) -> Void = { result in
-                    queue.async {
+                    /// Single-shot completion. Safe to call from any
+                    /// context — always dispatches to `queue`.
+                    let finish: (Bool) -> Void = { result in
+                        dispatchPrecondition(condition: .onQueue(queue))
                         guard !hasResumed else { return }
                         hasResumed = true
                         stabilityTimer?.cancel()
@@ -80,51 +106,49 @@ enum FileStabilityChecker {
                         source.cancel()
                         continuation.resume(returning: result)
                     }
-                }
 
-                cancelRef.finish = finish
-
-                if Task.isCancelled {
-                    ILOG("FileStabilityChecker: Already cancelled for \(url.lastPathComponent)")
-                    finish(false)
-                    return
-                }
-
-                func scheduleQuiesceTimer() {
-                    stabilityTimer?.cancel()
-                    let timer = DispatchWorkItem {
-                        ILOG("FileStabilityChecker: \(url.lastPathComponent) stable (no writes for \(quiesceInterval)s)")
-                        finish(true)
+                    handle.set {
+                        queue.async {
+                            ILOG("FileStabilityChecker: Task cancelled for \(url.lastPathComponent)")
+                            finish(false)
+                        }
                     }
-                    stabilityTimer = timer
-                    queue.asyncAfter(
-                        deadline: .now() + quiesceInterval,
-                        execute: timer
-                    )
-                }
 
-                source.setEventHandler {
-                    VLOG("FileStabilityChecker: Write activity on \(url.lastPathComponent), resetting timer")
+                    func scheduleQuiesceTimer() {
+                        stabilityTimer?.cancel()
+                        let timer = DispatchWorkItem {
+                            ILOG("FileStabilityChecker: \(url.lastPathComponent) stable (no writes for \(quiesceInterval)s)")
+                            finish(true)
+                        }
+                        stabilityTimer = timer
+                        queue.asyncAfter(
+                            deadline: .now() + quiesceInterval,
+                            execute: timer
+                        )
+                    }
+
+                    source.setEventHandler {
+                        VLOG("FileStabilityChecker: Write activity on \(url.lastPathComponent), resetting timer")
+                        scheduleQuiesceTimer()
+                    }
+
+                    source.setCancelHandler {
+                        close(fd)
+                    }
+
+                    let hardTimeout = DispatchWorkItem {
+                        WLOG("FileStabilityChecker: Timed out waiting for \(url.lastPathComponent) to stabilize")
+                        finish(false)
+                    }
+                    timeoutTimer = hardTimeout
+                    queue.asyncAfter(deadline: .now() + timeout, execute: hardTimeout)
+
+                    source.resume()
                     scheduleQuiesceTimer()
                 }
-
-                source.setCancelHandler {
-                    close(fd)
-                }
-
-                let hardTimeout = DispatchWorkItem {
-                    WLOG("FileStabilityChecker: Timed out waiting for \(url.lastPathComponent) to stabilize")
-                    finish(false)
-                }
-                timeoutTimer = hardTimeout
-                queue.asyncAfter(deadline: .now() + timeout, execute: hardTimeout)
-
-                source.resume()
-                scheduleQuiesceTimer()
             }
         } onCancel: {
-            ILOG("FileStabilityChecker: Task cancelled for \(url.lastPathComponent)")
-            cancelRef.finish?(false)
+            handle.fire()
         }
     }
 }

--- a/PVLibrary/Sources/PVLibrary/DirectoryWatcher/FileStabilityChecker.swift
+++ b/PVLibrary/Sources/PVLibrary/DirectoryWatcher/FileStabilityChecker.swift
@@ -22,19 +22,28 @@ enum FileStabilityChecker {
     )
 
     /// Thread-safe handle that `onCancel` uses to trigger teardown.
-    /// All access to the stored closure is protected by `lock`.
+    /// All access is protected by `lock`. If `fire()` is called before
+    /// `set(_:)`, a `cancelled` flag is stored so the teardown block
+    /// executes immediately when it is later registered.
     private final class CancelHandle: @unchecked Sendable {
         private let lock = NSLock()
         private var _teardown: (() -> Void)?
+        private var cancelled = false
 
         func set(_ block: @escaping () -> Void) {
             lock.lock()
-            _teardown = block
-            lock.unlock()
+            if cancelled {
+                lock.unlock()
+                block()
+            } else {
+                _teardown = block
+                lock.unlock()
+            }
         }
 
         func fire() {
             lock.lock()
+            cancelled = true
             let block = _teardown
             _teardown = nil
             lock.unlock()

--- a/PVLibrary/Sources/PVLibrary/DirectoryWatcher/FileStabilityChecker.swift
+++ b/PVLibrary/Sources/PVLibrary/DirectoryWatcher/FileStabilityChecker.swift
@@ -57,12 +57,9 @@ enum FileStabilityChecker {
     ///   (e.g. sandbox/permissions), returns `true` optimistically
     ///   so callers proceed to their own readability checks.
     /// - Note: See `FileStabilityCheckerTests` for coverage of immediate
-    ///   stability, timeout, and task cancellation scenarios.
-    static func waitForStability(
-        at url: URL,
-        quiesceInterval: TimeInterval = 0.3,
-        timeout: TimeInterval = 10.0
-    ) async -> Bool {
+    ///   stability, continuous-write timeout, task cancellation, and
+    ///   nonexistent-file scenarios.
+    static func waitForStability(at url: URL, quiesceInterval: TimeInterval = 0.3, timeout: TimeInterval = 10.0) async -> Bool {
         let fd = open(url.path, O_EVTONLY)
         guard fd >= 0 else {
             let code = errno

--- a/PVLibrary/Sources/PVLibrary/DirectoryWatcher/FileStabilityChecker.swift
+++ b/PVLibrary/Sources/PVLibrary/DirectoryWatcher/FileStabilityChecker.swift
@@ -34,7 +34,9 @@ enum FileStabilityChecker {
     ) async -> Bool {
         let fd = open(url.path, O_EVTONLY)
         guard fd >= 0 else {
-            WLOG("FileStabilityChecker: Cannot open file descriptor for \(url.lastPathComponent)")
+            let errnoValue = errno
+            let reason = String(cString: strerror(errnoValue))
+            WLOG("FileStabilityChecker: Cannot open fd for \(url.lastPathComponent) — errno \(errnoValue): \(reason)")
             return false
         }
 

--- a/PVLibrary/Sources/PVLibrary/DirectoryWatcher/FileStabilityChecker.swift
+++ b/PVLibrary/Sources/PVLibrary/DirectoryWatcher/FileStabilityChecker.swift
@@ -51,12 +51,14 @@ enum FileStabilityChecker {
             )
 
             var stabilityTimer: DispatchWorkItem?
+            var timeoutTimer: DispatchWorkItem?
 
             /// Thread-safe single-shot resume helper.
             let finish: (Bool) -> Void = { result in
                 guard !hasResumed else { return }
                 hasResumed = true
                 stabilityTimer?.cancel()
+                timeoutTimer?.cancel()
                 source.cancel()
                 continuation.resume(returning: result)
             }
@@ -85,11 +87,13 @@ enum FileStabilityChecker {
                 close(fd)
             }
 
-            // Hard timeout to avoid waiting forever.
-            queue.asyncAfter(deadline: .now() + timeout) {
+            // Cancellable hard timeout to avoid waiting forever.
+            let hardTimeout = DispatchWorkItem {
                 WLOG("FileStabilityChecker: Timed out waiting for \(url.lastPathComponent) to stabilize")
                 finish(false)
             }
+            timeoutTimer = hardTimeout
+            queue.asyncAfter(deadline: .now() + timeout, execute: hardTimeout)
 
             source.resume()
             scheduleQuiesceTimer()

--- a/PVLibrary/Sources/PVLibrary/DirectoryWatcher/FileStabilityChecker.swift
+++ b/PVLibrary/Sources/PVLibrary/DirectoryWatcher/FileStabilityChecker.swift
@@ -33,10 +33,10 @@ enum FileStabilityChecker {
         timeout: TimeInterval = 10.0
     ) async -> Bool {
         let fd = open(url.path, O_EVTONLY)
-        if fd < 0 {
+        guard fd >= 0 else {
             let code = errno
-            WLOG("FileStabilityChecker: Cannot open fd for \(url.lastPathComponent) — errno \(code): \(String(cString: strerror(code)))")
-            return false
+            WLOG("FileStabilityChecker: open(\(url.lastPathComponent)) failed — errno \(code) (\(String(cString: strerror(code))))")
+            return false // fd unavailable, assume file is ready
         }
 
         return await withCheckedContinuation { continuation in

--- a/PVLibrary/Sources/PVLibrary/DirectoryWatcher/FileStabilityChecker.swift
+++ b/PVLibrary/Sources/PVLibrary/DirectoryWatcher/FileStabilityChecker.swift
@@ -1,0 +1,98 @@
+//
+//  FileStabilityChecker.swift
+//  PVLibrary
+//
+//  Created by Provenance Contributors on 2026-03-11.
+//
+
+import Foundation
+import PVLogging
+
+/// Uses kqueue-based `DispatchSource` monitoring to determine when a file
+/// has finished being written. This replaces fixed-interval polling delays
+/// with event-driven detection: a dispatch source watches for `.write`,
+/// `.extend`, and `.attrib` vnode events and resets a quiesce timer on
+/// each event. The file is considered stable once no events arrive for
+/// `quiesceInterval` seconds, or the overall `timeout` is exceeded.
+enum FileStabilityChecker {
+
+    /// Waits for a file to become stable (no active writes) using
+    /// kqueue-based dispatch source monitoring.
+    ///
+    /// - Parameters:
+    ///   - url: The file URL to monitor.
+    ///   - quiesceInterval: Seconds the file must be quiet to be
+    ///     considered stable. Defaults to 0.3 s.
+    ///   - timeout: Maximum seconds to wait before giving up.
+    ///     Defaults to 10 s.
+    /// - Returns: `true` if the file became stable within `timeout`,
+    ///   `false` if the timeout was reached first.
+    static func waitForStability(
+        at url: URL,
+        quiesceInterval: TimeInterval = 0.3,
+        timeout: TimeInterval = 10.0
+    ) async -> Bool {
+        let fd = open(url.path, O_EVTONLY)
+        guard fd >= 0 else {
+            WLOG("FileStabilityChecker: Cannot open file descriptor for \(url.lastPathComponent)")
+            return false
+        }
+
+        return await withCheckedContinuation { continuation in
+            let queue = DispatchQueue(
+                label: "org.provenance-emu.file-stability.\(UUID().uuidString)"
+            )
+            var hasResumed = false
+
+            let source = DispatchSource.makeFileSystemObjectSource(
+                fileDescriptor: fd,
+                eventMask: [.write, .extend, .attrib],
+                queue: queue
+            )
+
+            var stabilityTimer: DispatchWorkItem?
+
+            /// Thread-safe single-shot resume helper.
+            let finish: (Bool) -> Void = { result in
+                guard !hasResumed else { return }
+                hasResumed = true
+                stabilityTimer?.cancel()
+                source.cancel()
+                continuation.resume(returning: result)
+            }
+
+            /// Resets the quiesce timer. After `quiesceInterval` with no
+            /// further events the file is declared stable.
+            func scheduleQuiesceTimer() {
+                stabilityTimer?.cancel()
+                let timer = DispatchWorkItem {
+                    ILOG("FileStabilityChecker: \(url.lastPathComponent) stable (no writes for \(quiesceInterval)s)")
+                    finish(true)
+                }
+                stabilityTimer = timer
+                queue.asyncAfter(
+                    deadline: .now() + quiesceInterval,
+                    execute: timer
+                )
+            }
+
+            source.setEventHandler {
+                VLOG("FileStabilityChecker: Write activity on \(url.lastPathComponent), resetting timer")
+                scheduleQuiesceTimer()
+            }
+
+            source.setCancelHandler {
+                close(fd)
+            }
+
+            // Hard timeout to avoid waiting forever.
+            queue.asyncAfter(deadline: .now() + timeout) {
+                WLOG("FileStabilityChecker: Timed out waiting for \(url.lastPathComponent) to stabilize")
+                finish(false)
+            }
+
+            source.resume()
+            scheduleQuiesceTimer()
+        }
+    }
+}

--- a/PVLibrary/Sources/PVLibrary/DirectoryWatcher/FileStabilityChecker.swift
+++ b/PVLibrary/Sources/PVLibrary/DirectoryWatcher/FileStabilityChecker.swift
@@ -115,12 +115,9 @@ enum FileStabilityChecker {
                         continuation.resume(returning: result)
                     }
 
-                    handle.set {
-                        queue.async {
-                            ILOG("FileStabilityChecker: Task cancelled for \(url.lastPathComponent)")
-                            finish(false)
-                        }
-                    }
+                    // Register cancellation handler — CancelHandle's
+                    // cancelled flag ensures fire()-before-set() works.
+                    handle.set { queue.async { finish(false) } }
 
                     func scheduleQuiesceTimer() {
                         stabilityTimer?.cancel()

--- a/PVLibrary/Sources/PVLibrary/DirectoryWatcher/FileStabilityChecker.swift
+++ b/PVLibrary/Sources/PVLibrary/DirectoryWatcher/FileStabilityChecker.swift
@@ -118,7 +118,6 @@ enum FileStabilityChecker {
                     // Register cancellation handler — CancelHandle's
                     // cancelled flag ensures fire()-before-set() works.
                     handle.set { queue.async { finish(false) } }
-
                     func scheduleQuiesceTimer() {
                         stabilityTimer?.cancel()
                         let timer = DispatchWorkItem {

--- a/PVLibrary/Sources/PVLibrary/DirectoryWatcher/FileStabilityChecker.swift
+++ b/PVLibrary/Sources/PVLibrary/DirectoryWatcher/FileStabilityChecker.swift
@@ -103,8 +103,8 @@ enum FileStabilityChecker {
                         queue: queue
                     )
 
-                    /// Single-shot completion. Safe to call from any
-                    /// context — always dispatches to `queue`.
+                    /// Single-shot completion. Must be called on `queue`.
+                    /// Callers running off-queue must dispatch to `queue` first.
                     let finish: (Bool) -> Void = { result in
                         dispatchPrecondition(condition: .onQueue(queue))
                         guard !hasResumed else { return }

--- a/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
+++ b/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
@@ -2554,12 +2554,11 @@ public final class GameImporter: GameImporting, ObservableObject {
                 try? await Task.sleep(nanoseconds: delay)
             }
         }
-        guard archiveIsReadable else {
-            let msg = "Archive file is locked, empty, or not readable: \(archiveURL.lastPathComponent). "
-                + "Please ensure the file is fully written and not accessed by another process."
-            let error = ArchiveError.extractionFailed(msg)
-            ELOG(error.localizedDescription)
-            throw error
+        if !archiveIsReadable {
+            let msg = "Archive file is locked, empty, or not readable after \(maxOpenAttempts) attempt(s): "
+                + "\(archiveURL.lastPathComponent)"
+            ELOG(msg)
+            throw ArchiveError.extractionFailed(msg)
         }
 
         // Detect actual archive type from file signature (not just extension)

--- a/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
+++ b/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
@@ -2540,20 +2540,23 @@ public final class GameImporter: GameImporting, ObservableObject {
         let maxOpenAttempts = isStable ? 2 : 3
         var archiveIsReadable = false
         for openAttempt in 1...maxOpenAttempts {
-            if let handle = try? FileHandle(forReadingFrom: archiveURL) {
+            if let attrs = try? FileManager.default.attributesOfItem(atPath: archiveURL.path),
+               let size = attrs[.size] as? Int64, size > 0,
+               let handle = try? FileHandle(forReadingFrom: archiveURL) {
                 handle.closeFile()
                 archiveIsReadable = true
+                ILOG("Archive \(archiveURL.lastPathComponent) readable, size: \(size) bytes")
                 break
             }
             if openAttempt < maxOpenAttempts {
                 let delay: UInt64 = isStable ? 200_000_000 : 400_000_000
-                WLOG("Archive \(archiveURL.lastPathComponent) not readable (attempt \(openAttempt)/\(maxOpenAttempts)), retrying...")
+                WLOG("Archive \(archiveURL.lastPathComponent) not readable or empty (attempt \(openAttempt)/\(maxOpenAttempts)), retrying...")
                 try? await Task.sleep(nanoseconds: delay)
             }
         }
         guard archiveIsReadable else {
-            let msg = "Archive file is locked or not readable: \(archiveURL.lastPathComponent). "
-                + "Please ensure the file is not being accessed by another process."
+            let msg = "Archive file is locked, empty, or not readable: \(archiveURL.lastPathComponent). "
+                + "Please ensure the file is fully written and not accessed by another process."
             let error = ArchiveError.extractionFailed(msg)
             ELOG(error.localizedDescription)
             throw error

--- a/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
+++ b/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
@@ -2522,40 +2522,25 @@ public final class GameImporter: GameImporting, ObservableObject {
             throw GameImporterError.unsupportedFile
         }
 
-        // Ensure file is fully written and not locked before attempting extraction
-        // Add a small delay to ensure file system has finished writing
-        try? await Task.sleep(nanoseconds: 200_000_000) // 200ms delay
-
-        // Try to verify file is readable and not locked
-        // Attempt to open the file multiple times if needed
-        var fileReadable = false
-        for attempt in 1...5 {
-            // Try to read file attributes first (less intrusive than opening a handle)
-            if let attributes = try? FileManager.default.attributesOfItem(atPath: archiveURL.path),
-               let fileSize = attributes[.size] as? Int64,
-               fileSize > 0 {
-                // File exists and has size, try to open it
-                if let fileHandle = try? FileHandle(forReadingFrom: archiveURL) {
-                    fileHandle.closeFile()
-                    // Small delay after closing to ensure file handle is fully released
-                    try? await Task.sleep(nanoseconds: 50_000_000) // 50ms delay
-                    fileReadable = true
-                    break
-                } else {
-                    ILOG("Archive file appears locked (attempt \(attempt)/5), waiting...")
-                    try? await Task.sleep(nanoseconds: 300_000_000) // 300ms delay
-                }
-            } else {
-                ILOG("Archive file has no size or invalid attributes (attempt \(attempt)/5), waiting...")
-                try? await Task.sleep(nanoseconds: 300_000_000) // 300ms delay
-            }
+        // Wait for file to stabilize using kqueue-based dispatch source monitoring.
+        // Replaces fixed 200ms poll + retry loop with event-driven detection.
+        let isStable = await FileStabilityChecker.waitForStability(at: archiveURL)
+        if !isStable {
+            WLOG("Archive \(archiveURL.lastPathComponent) did not stabilize within timeout, attempting extraction anyway")
         }
 
-        guard fileReadable else {
+        guard FileManager.default.fileExists(atPath: archiveURL.path) else {
+            ELOG("Archive file no longer exists after stability wait: \(archiveURL.path)")
+            throw GameImporterError.unsupportedFile
+        }
+
+        // Single readability check after stability wait
+        guard let fileHandle = try? FileHandle(forReadingFrom: archiveURL) else {
             let error = ArchiveError.extractionFailed("Archive file is locked or not readable: \(archiveURL.lastPathComponent). Please ensure the file is not being accessed by another process.")
             ELOG(error.localizedDescription)
             throw error
         }
+        fileHandle.closeFile()
 
         // Detect actual archive type from file signature (not just extension)
         // This handles cases where files have wrong extensions (e.g., .zip file that's actually 7z)
@@ -2620,9 +2605,20 @@ public final class GameImporter: GameImporting, ObservableObject {
             .appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: tempExtractionDir, withIntermediateDirectories: true, attributes: nil)
 
+        /// Set to `true` when a partial batch-move leaves files in the temp
+        /// directory that must not be deleted.
+        var preserveTempDir = false
+
         defer {
-            // Clean up temp directory
-            try? FileManager.default.removeItem(at: tempExtractionDir)
+            if preserveTempDir {
+                WLOG("Preserving temp extraction directory for recovery: \(tempExtractionDir.path)")
+            } else {
+                do {
+                    try FileManager.default.removeItem(at: tempExtractionDir)
+                } catch {
+                    ELOG("Failed to clean up temp extraction directory \(tempExtractionDir.lastPathComponent): \(error.localizedDescription)")
+                }
+            }
         }
 
         // Extract files flatly (preserve only filenames, flatten directory structure)
@@ -2816,15 +2812,17 @@ public final class GameImporter: GameImporting, ObservableObject {
 
         ILOG("Extracted \(extractedFiles.count) files from archive \(archiveURL.lastPathComponent)")
 
-        // Move extracted files to imports directory for processing
+        // Move extracted files to imports directory for processing.
+        // Individual move failures are logged but do not abort the batch
+        // so that remaining files are not lost in a partially-moved state.
         let importsPath = self.importsPath
         var filesToImport: [URL] = []
+        var moveFailures = 0
 
         for extractedFile in extractedFiles {
             let fileName = extractedFile.lastPathComponent
             let destinationURL = importsPath.appendingPathComponent(fileName)
 
-            // Handle filename conflicts
             var finalDestinationURL = destinationURL
             var counter = 1
             while FileManager.default.fileExists(atPath: finalDestinationURL.path) {
@@ -2834,8 +2832,18 @@ public final class GameImporter: GameImporting, ObservableObject {
                 counter += 1
             }
 
-            try FileManager.default.moveItem(at: extractedFile, to: finalDestinationURL)
-            filesToImport.append(finalDestinationURL)
+            do {
+                try FileManager.default.moveItem(at: extractedFile, to: finalDestinationURL)
+                filesToImport.append(finalDestinationURL)
+            } catch {
+                moveFailures += 1
+                ELOG("Failed to move extracted file \(fileName) to imports: \(error.localizedDescription)")
+            }
+        }
+
+        if moveFailures > 0 {
+            ELOG("Batch move had \(moveFailures)/\(extractedFiles.count) failure(s)")
+            preserveTempDir = true
         }
 
         // Clean up metadata files that won't match any system

--- a/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
+++ b/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
@@ -2769,7 +2769,8 @@ public final class GameImporter: GameImporting, ObservableObject {
                         let nameWithoutExt = flatDestination.deletingPathExtension().lastPathComponent
                         let ext = flatDestination.pathExtension
                         repeat {
-                            finalFlatURL = tempExtractionDir.appendingPathComponent("\(nameWithoutExt)_\(counter).\(ext)")
+                            let newName = ext.isEmpty ? "\(nameWithoutExt)_\(counter)" : "\(nameWithoutExt)_\(counter).\(ext)"
+                            finalFlatURL = tempExtractionDir.appendingPathComponent(newName)
                             counter += 1
                         } while processedFilenames.contains(finalFlatURL.lastPathComponent.lowercased())
                     }
@@ -2788,7 +2789,8 @@ public final class GameImporter: GameImporting, ObservableObject {
                         let ext = flatDestination.pathExtension
                         var finalFlatURL = flatDestination
                         repeat {
-                            finalFlatURL = tempExtractionDir.appendingPathComponent("\(nameWithoutExt)_\(counter).\(ext)")
+                            let newName = ext.isEmpty ? "\(nameWithoutExt)_\(counter)" : "\(nameWithoutExt)_\(counter).\(ext)"
+                            finalFlatURL = tempExtractionDir.appendingPathComponent(newName)
                             counter += 1
                         } while FileManager.default.fileExists(atPath: finalFlatURL.path) || processedFilenames.contains(finalFlatURL.lastPathComponent.lowercased())
 

--- a/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
+++ b/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
@@ -2533,7 +2533,15 @@ public final class GameImporter: GameImporting, ObservableObject {
             while fileManager.fileExists(atPath: finalDestinationURL.path) {
                 let nameWithoutExt = destinationURL.deletingPathExtension().lastPathComponent
                 let ext = destinationURL.pathExtension
-                finalDestinationURL = importsPath.appendingPathComponent("\(nameWithoutExt)_\(counter).\(ext)")
+
+                if ext.isEmpty {
+                    finalDestinationURL = importsPath.appendingPathComponent("\(nameWithoutExt)_\(counter)")
+                } else {
+                    let baseWithCounter = "\(nameWithoutExt)_\(counter)"
+                    finalDestinationURL = importsPath
+                        .appendingPathComponent(baseWithCounter)
+                        .appendingPathExtension(ext)
+                }
                 counter += 1
             }
 

--- a/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
+++ b/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
@@ -2534,13 +2534,29 @@ public final class GameImporter: GameImporting, ObservableObject {
             throw GameImporterError.unsupportedFile
         }
 
-        // Single readability check after stability wait
-        guard let fileHandle = try? FileHandle(forReadingFrom: archiveURL) else {
-            let error = ArchiveError.extractionFailed("Archive file is locked or not readable: \(archiveURL.lastPathComponent). Please ensure the file is not being accessed by another process.")
+        // Bounded retry readability check after stability wait.
+        // A short retry handles transient locks that outlast the quiesce interval.
+        let maxOpenAttempts = isStable ? 2 : 3
+        var archiveIsReadable = false
+        for openAttempt in 1...maxOpenAttempts {
+            if let handle = try? FileHandle(forReadingFrom: archiveURL) {
+                handle.closeFile()
+                archiveIsReadable = true
+                break
+            }
+            if openAttempt < maxOpenAttempts {
+                let delay: UInt64 = isStable ? 200_000_000 : 400_000_000
+                WLOG("Archive \(archiveURL.lastPathComponent) not readable (attempt \(openAttempt)/\(maxOpenAttempts)), retrying...")
+                try? await Task.sleep(nanoseconds: delay)
+            }
+        }
+        guard archiveIsReadable else {
+            let msg = "Archive file is locked or not readable: \(archiveURL.lastPathComponent). "
+                + "Please ensure the file is not being accessed by another process."
+            let error = ArchiveError.extractionFailed(msg)
             ELOG(error.localizedDescription)
             throw error
         }
-        fileHandle.closeFile()
 
         // Detect actual archive type from file signature (not just extension)
         // This handles cases where files have wrong extensions (e.g., .zip file that's actually 7z)
@@ -2896,9 +2912,15 @@ public final class GameImporter: GameImporting, ObservableObject {
             ILOG("Added \(filesToImport.count) extracted files to import queue")
         }
 
-        // Delete original archive after successful extraction
-        try await FileManager.default.removeItem(at: archiveURL)
-        ILOG("Deleted original archive after extraction: \(archiveURL.lastPathComponent)")
+        // Only delete the original archive when every extracted file was
+        // moved successfully. If some moves failed the archive is preserved
+        // so the user can retry.
+        if moveFailures == 0 {
+            try await FileManager.default.removeItem(at: archiveURL)
+            ILOG("Deleted original archive after extraction: \(archiveURL.lastPathComponent)")
+        } else {
+            WLOG("Archive \(archiveURL.lastPathComponent) preserved — \(moveFailures) file(s) failed to move")
+        }
     }
 
     private func performImport(for item: ImportQueueItem) async throws {

--- a/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
+++ b/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
@@ -2531,7 +2531,8 @@ public final class GameImporter: GameImporting, ObservableObject {
 
         guard FileManager.default.fileExists(atPath: archiveURL.path) else {
             ELOG("Archive file no longer exists after stability wait: \(archiveURL.path)")
-            throw GameImporterError.unsupportedFile
+            throw ArchiveError.extractionFailed(
+                "Archive file disappeared during stability wait: \(archiveURL.lastPathComponent)")
         }
 
         // Bounded retry readability check after stability wait.

--- a/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
+++ b/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
@@ -2857,9 +2857,13 @@ public final class GameImporter: GameImporting, ObservableObject {
             }
         }
 
-        if moveFailures > 0 {
-            ELOG("Batch move had \(moveFailures)/\(extractedFiles.count) failure(s)")
+        // When some moves fail, preserve both the temp directory (unmoved
+        // files) and the original archive so the user can retry.
+        let allMoveSucceeded = moveFailures == 0
+        if !allMoveSucceeded {
             preserveTempDir = true
+            ELOG("Batch move had \(moveFailures)/\(extractedFiles.count) failure(s) — "
+                 + "archive and temp dir preserved for retry")
         }
 
         // Clean up metadata files that won't match any system
@@ -2912,10 +2916,7 @@ public final class GameImporter: GameImporting, ObservableObject {
             ILOG("Added \(filesToImport.count) extracted files to import queue")
         }
 
-        // Only delete the original archive when every extracted file was
-        // moved successfully. If some moves failed the archive is preserved
-        // so the user can retry.
-        if moveFailures == 0 {
+        if allMoveSucceeded {
             try await FileManager.default.removeItem(at: archiveURL)
             ILOG("Deleted original archive after extraction: \(archiveURL.lastPathComponent)")
         } else {

--- a/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
+++ b/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
@@ -2948,9 +2948,10 @@ public final class GameImporter: GameImporting, ObservableObject {
         }
 
         guard allMovesSucceeded else {
+            let failCount = extractedFiles.count - filesToImportResult.count
             WLOG("Archive \(archiveURL.lastPathComponent) preserved — "
-                 + "batch move failed; temp dir kept for recovery")
-            return
+                 + "\(failCount)/\(extractedFiles.count) move(s) failed; temp dir kept for recovery")
+            throw ArchiveError.batchMoveFailed(succeeded: filesToImportResult.count, total: extractedFiles.count)
         }
         try await self.fileManager.removeItem(at: archiveURL)
         ILOG("Deleted original archive after extraction: \(archiveURL.lastPathComponent)")

--- a/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
+++ b/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
@@ -2529,10 +2529,10 @@ public final class GameImporter: GameImporting, ObservableObject {
             WLOG("Archive \(archiveURL.lastPathComponent) did not stabilize within timeout, attempting extraction anyway")
         }
 
-        guard FileManager.default.fileExists(atPath: archiveURL.path) else {
-            ELOG("Archive file no longer exists after stability wait: \(archiveURL.path)")
-            throw ArchiveError.extractionFailed(
-                "Archive file disappeared during stability wait: \(archiveURL.lastPathComponent)")
+        if !FileManager.default.fileExists(atPath: archiveURL.path) {
+            let msg = "Archive file disappeared during stability wait: \(archiveURL.lastPathComponent)"
+            ELOG(msg)
+            throw ArchiveError.extractionFailed(msg)
         }
 
         // Bounded retry readability check after stability wait.
@@ -2921,9 +2921,10 @@ public final class GameImporter: GameImporting, ObservableObject {
             try await FileManager.default.removeItem(at: archiveURL)
             ILOG("Deleted original archive after extraction: \(archiveURL.lastPathComponent)")
         } else {
-            WLOG("Archive \(archiveURL.lastPathComponent) preserved — \(moveFailures) file(s) failed to move")
+            WLOG("Archive \(archiveURL.lastPathComponent) preserved — "
+                 + "\(moveFailures) file(s) failed to move, temp dir kept for recovery")
         }
-    }
+    } // extractAndImportArchive
 
     private func performImport(for item: ImportQueueItem) async throws {
         let fileName = item.url.lastPathComponent

--- a/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
+++ b/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
@@ -509,7 +509,7 @@ public final class GameImporter: GameImporting, ObservableObject {
                   _ systemsService:GameImporterSystemsService,
                   _ artworkImporter:ArtworkImporting,
                   _ cdFileHandler:CDFileHandling,
-                  _ skinImporterService: SkinImporterServicing) {
+                  _ skinImporterService: SkinImporterServicing = SkinImporterInjector.shared) {
         self.fileManager = fm // Initialize fileManager
 
         // Create a local function for the auto-start callback that doesn't capture self
@@ -2509,6 +2509,51 @@ public final class GameImporter: GameImporting, ObservableObject {
         return nil
     }
 
+    /// Moves `extractedFiles` to `importsPath`, deduplicating destination names as needed.
+    ///
+    /// Individual move failures are logged and counted but do not stop the batch — files that
+    /// can be moved are always queued so a single stuck file does not orphan the rest.
+    ///
+    /// Uses the injected `fileManager` so that tests can substitute a mock to force failures.
+    ///
+    /// - Parameters:
+    ///   - extractedFiles: File URLs currently in a temporary extraction directory.
+    ///   - importsPath: Destination directory for successfully moved files.
+    /// - Returns: A tuple of (successfully moved file URLs, whether every move succeeded).
+    internal func moveBatchExtractedFiles(_ extractedFiles: [URL], to importsPath: URL) -> (queued: [URL], allSucceeded: Bool) {
+        var filesToImport: [URL] = []
+        var moveFailures = 0
+
+        for extractedFile in extractedFiles {
+            let fileName = extractedFile.lastPathComponent
+            let destinationURL = importsPath.appendingPathComponent(fileName)
+
+            var finalDestinationURL = destinationURL
+            var counter = 1
+            while fileManager.fileExists(atPath: finalDestinationURL.path) {
+                let nameWithoutExt = destinationURL.deletingPathExtension().lastPathComponent
+                let ext = destinationURL.pathExtension
+                finalDestinationURL = importsPath.appendingPathComponent("\(nameWithoutExt)_\(counter).\(ext)")
+                counter += 1
+            }
+
+            do {
+                try fileManager.moveItem(at: extractedFile, to: finalDestinationURL)
+                filesToImport.append(finalDestinationURL)
+            } catch {
+                moveFailures += 1
+                ELOG("Failed to move extracted file \(fileName) to imports: \(error.localizedDescription)")
+            }
+        }
+
+        if moveFailures > 0 {
+            ELOG("Batch move had \(moveFailures)/\(extractedFiles.count) failure(s) — "
+                 + "archive and temp dir preserved for retry")
+        }
+
+        return (queued: filesToImport, allSucceeded: moveFailures == 0)
+    }
+
     /// Extracts an archive flatly and imports its contents
     private func extractAndImportArchive(_ item: ImportQueueItem) async throws {
         let archiveURL = item.url
@@ -2633,7 +2678,7 @@ public final class GameImporter: GameImporting, ObservableObject {
                 WLOG("Preserving temp extraction directory for recovery: \(tempExtractionDir.path)")
             } else {
                 do {
-                    try FileManager.default.removeItem(at: tempExtractionDir)
+                    try self.fileManager.removeItem(at: tempExtractionDir)
                 } catch {
                     ELOG("Failed to clean up temp extraction directory \(tempExtractionDir.lastPathComponent): \(error.localizedDescription)")
                 }
@@ -2835,39 +2880,12 @@ public final class GameImporter: GameImporting, ObservableObject {
         // Individual move failures are logged but do not abort the batch
         // so that remaining files are not lost in a partially-moved state.
         let importsPath = self.importsPath
-        var filesToImport: [URL] = []
-        var moveFailures = 0
-
-        for extractedFile in extractedFiles {
-            let fileName = extractedFile.lastPathComponent
-            let destinationURL = importsPath.appendingPathComponent(fileName)
-
-            var finalDestinationURL = destinationURL
-            var counter = 1
-            while FileManager.default.fileExists(atPath: finalDestinationURL.path) {
-                let nameWithoutExt = destinationURL.deletingPathExtension().lastPathComponent
-                let ext = destinationURL.pathExtension
-                finalDestinationURL = importsPath.appendingPathComponent("\(nameWithoutExt)_\(counter).\(ext)")
-                counter += 1
-            }
-
-            do {
-                try FileManager.default.moveItem(at: extractedFile, to: finalDestinationURL)
-                filesToImport.append(finalDestinationURL)
-            } catch {
-                moveFailures += 1
-                ELOG("Failed to move extracted file \(fileName) to imports: \(error.localizedDescription)")
-            }
-        }
+        let (filesToImportResult, allMovesSucceeded) = moveBatchExtractedFiles(extractedFiles, to: importsPath)
+        var filesToImport = filesToImportResult
 
         // When some moves fail, preserve both the temp directory (unmoved
         // files) and the original archive so the user can retry.
-        let allMovesSucceeded = moveFailures == 0
         preserveTempDir = !allMovesSucceeded
-        if !allMovesSucceeded {
-            ELOG("Batch move had \(moveFailures)/\(extractedFiles.count) failure(s) — "
-                 + "archive and temp dir preserved for retry")
-        }
 
         // Clean up metadata files that won't match any system
         let metadataExtensions: Set<String> = ["txt", "md", "url", "nfo", "dat", "xml", "json", "html", "htm"]
@@ -2921,11 +2939,10 @@ public final class GameImporter: GameImporting, ObservableObject {
 
         guard allMovesSucceeded else {
             WLOG("Archive \(archiveURL.lastPathComponent) preserved — "
-                 + "\(moveFailures)/\(extractedFiles.count) file(s) failed to move; "
-                 + "temp dir kept for recovery")
+                 + "batch move failed; temp dir kept for recovery")
             return
         }
-        try await FileManager.default.removeItem(at: archiveURL)
+        try await self.fileManager.removeItem(at: archiveURL)
         ILOG("Deleted original archive after extraction: \(archiveURL.lastPathComponent)")
     }
 

--- a/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
+++ b/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
@@ -2562,8 +2562,10 @@ public final class GameImporter: GameImporting, ObservableObject {
         return (queued: filesToImport, allSucceeded: moveFailures == 0)
     }
 
-    /// Extracts an archive flatly and imports its contents
-    private func extractAndImportArchive(_ item: ImportQueueItem) async throws {
+    /// Extracts an archive flatly and imports its contents.
+    /// `internal` instead of `private` so that unit tests can call it directly
+    /// (e.g. to verify that the archive is not deleted on partial batch-move failure).
+    internal func extractAndImportArchive(_ item: ImportQueueItem) async throws {
         let archiveURL = item.url
         let fileExtension = archiveURL.pathExtension.lowercased()
 

--- a/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
+++ b/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
@@ -2859,9 +2859,9 @@ public final class GameImporter: GameImporting, ObservableObject {
 
         // When some moves fail, preserve both the temp directory (unmoved
         // files) and the original archive so the user can retry.
-        let allMoveSucceeded = moveFailures == 0
-        if !allMoveSucceeded {
-            preserveTempDir = true
+        let allMovesSucceeded = moveFailures == 0
+        preserveTempDir = !allMovesSucceeded
+        if !allMovesSucceeded {
             ELOG("Batch move had \(moveFailures)/\(extractedFiles.count) failure(s) — "
                  + "archive and temp dir preserved for retry")
         }
@@ -2916,7 +2916,7 @@ public final class GameImporter: GameImporting, ObservableObject {
             ILOG("Added \(filesToImport.count) extracted files to import queue")
         }
 
-        if allMoveSucceeded {
+        if allMovesSucceeded {
             try await FileManager.default.removeItem(at: archiveURL)
             ILOG("Deleted original archive after extraction: \(archiveURL.lastPathComponent)")
         } else {

--- a/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
+++ b/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
@@ -2917,14 +2917,14 @@ public final class GameImporter: GameImporting, ObservableObject {
             ILOG("Added \(filesToImport.count) extracted files to import queue")
         }
 
-        if allMovesSucceeded {
-            try await FileManager.default.removeItem(at: archiveURL)
-            ILOG("Deleted original archive after extraction: \(archiveURL.lastPathComponent)")
-        } else {
+        guard allMovesSucceeded else {
             WLOG("Archive \(archiveURL.lastPathComponent) preserved — "
                  + "\(moveFailures)/\(extractedFiles.count) file(s) failed to move; "
                  + "temp dir kept for recovery")
+            return
         }
+        try await FileManager.default.removeItem(at: archiveURL)
+        ILOG("Deleted original archive after extraction: \(archiveURL.lastPathComponent)")
     }
 
     private func performImport(for item: ImportQueueItem) async throws {

--- a/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
+++ b/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
@@ -2922,9 +2922,10 @@ public final class GameImporter: GameImporting, ObservableObject {
             ILOG("Deleted original archive after extraction: \(archiveURL.lastPathComponent)")
         } else {
             WLOG("Archive \(archiveURL.lastPathComponent) preserved — "
-                 + "\(moveFailures) file(s) failed to move, temp dir kept for recovery")
+                 + "\(moveFailures)/\(extractedFiles.count) file(s) failed to move; "
+                 + "temp dir kept for recovery")
         }
-    } // extractAndImportArchive
+    }
 
     private func performImport(for item: ImportQueueItem) async throws {
         let fileName = item.url.lastPathComponent

--- a/PVLibrary/Tests/PVLibraryTests/FileStabilityCheckerTests.swift
+++ b/PVLibrary/Tests/PVLibraryTests/FileStabilityCheckerTests.swift
@@ -64,9 +64,9 @@ final class FileStabilityCheckerTests: XCTestCase {
         )
 
         writeTask.cancel()
-        _ = await writeTask.result
+        _ = await writeTask.result // ensure writer fully stops before teardown
         XCTAssertFalse(result, "Continuously written file should time out")
-    }
+    } // testTimeoutOnContinuousWrites
 
     /// Cancelling the enclosing Task should cause `waitForStability`
     /// to return `false` promptly and release resources.

--- a/PVLibrary/Tests/PVLibraryTests/FileStabilityCheckerTests.swift
+++ b/PVLibrary/Tests/PVLibraryTests/FileStabilityCheckerTests.swift
@@ -12,18 +12,18 @@ final class FileStabilityCheckerTests: XCTestCase {
 
     private var tempDir: URL!
 
-    override func setUp() {
-        super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
         tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("FileStabilityCheckerTests-\(UUID().uuidString)")
-        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
     }
 
-    override func tearDown() {
+    override func tearDownWithError() throws {
         if let tempDir {
-            try? FileManager.default.removeItem(at: tempDir)
+            try FileManager.default.removeItem(at: tempDir)
         }
-        super.tearDown()
+        try super.tearDownWithError()
     }
 
     /// A file that already exists and isn't being written to should
@@ -64,6 +64,7 @@ final class FileStabilityCheckerTests: XCTestCase {
         )
 
         writeTask.cancel()
+        _ = await writeTask.result
         XCTAssertFalse(result, "Continuously written file should time out")
     }
 
@@ -97,6 +98,7 @@ final class FileStabilityCheckerTests: XCTestCase {
         let elapsed = Date().timeIntervalSince(start)
 
         writeTask.cancel()
+        _ = await writeTask.result
         XCTAssertFalse(result, "Cancelled task should return false")
         XCTAssertLessThan(elapsed, 5.0, "Cancellation should resolve promptly")
     }

--- a/PVLibrary/Tests/PVLibraryTests/FileStabilityCheckerTests.swift
+++ b/PVLibrary/Tests/PVLibraryTests/FileStabilityCheckerTests.swift
@@ -1,0 +1,112 @@
+//
+//  FileStabilityCheckerTests.swift
+//  PVLibraryTests
+//
+//  Tests for kqueue-based file stability detection.
+//
+
+import XCTest
+@testable import PVLibrary
+
+final class FileStabilityCheckerTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("FileStabilityCheckerTests-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        if let tempDir {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+        super.tearDown()
+    }
+
+    /// A file that already exists and isn't being written to should
+    /// stabilize almost immediately (within the quiesce interval).
+    func testImmediateStability() async throws {
+        let file = tempDir.appendingPathComponent("stable.bin")
+        try Data(repeating: 0xAA, count: 1024).write(to: file)
+
+        let start = Date()
+        let result = await FileStabilityChecker.waitForStability(
+            at: file, quiesceInterval: 0.2, timeout: 5.0
+        )
+        let elapsed = Date().timeIntervalSince(start)
+
+        XCTAssertTrue(result, "File should be detected as stable")
+        XCTAssertLessThan(elapsed, 2.0, "Stable file should resolve quickly")
+    }
+
+    /// When a file is continuously written to, the checker should
+    /// time out and return `false`.
+    func testTimeoutOnContinuousWrites() async throws {
+        let file = tempDir.appendingPathComponent("busy.bin")
+        try Data(repeating: 0xBB, count: 64).write(to: file)
+
+        let writeTask = Task.detached {
+            while !Task.isCancelled {
+                if let handle = try? FileHandle(forWritingTo: file) {
+                    handle.seekToEndOfFile()
+                    handle.write(Data(repeating: 0xCC, count: 8))
+                    handle.closeFile()
+                }
+                try? await Task.sleep(nanoseconds: 50_000_000)
+            }
+        }
+
+        let result = await FileStabilityChecker.waitForStability(
+            at: file, quiesceInterval: 0.2, timeout: 1.0
+        )
+
+        writeTask.cancel()
+        XCTAssertFalse(result, "Continuously written file should time out")
+    }
+
+    /// Cancelling the enclosing Task should cause `waitForStability`
+    /// to return `false` promptly and release resources.
+    func testTaskCancellation() async throws {
+        let file = tempDir.appendingPathComponent("cancel.bin")
+        try Data(repeating: 0xDD, count: 64).write(to: file)
+
+        let writeTask = Task.detached {
+            while !Task.isCancelled {
+                if let handle = try? FileHandle(forWritingTo: file) {
+                    handle.seekToEndOfFile()
+                    handle.write(Data(repeating: 0xEE, count: 8))
+                    handle.closeFile()
+                }
+                try? await Task.sleep(nanoseconds: 50_000_000)
+            }
+        }
+
+        let start = Date()
+        let stabilityTask = Task {
+            await FileStabilityChecker.waitForStability(
+                at: file, quiesceInterval: 0.3, timeout: 30.0
+            )
+        }
+
+        try await Task.sleep(nanoseconds: 300_000_000)
+        stabilityTask.cancel()
+        let result = await stabilityTask.value
+        let elapsed = Date().timeIntervalSince(start)
+
+        writeTask.cancel()
+        XCTAssertFalse(result, "Cancelled task should return false")
+        XCTAssertLessThan(elapsed, 5.0, "Cancellation should resolve promptly")
+    }
+
+    /// When the file doesn't exist (open fails), the checker should
+    /// return `true` optimistically so callers proceed to their own
+    /// readability checks.
+    func testNonexistentFileReturnsTrue() async {
+        let file = tempDir.appendingPathComponent("does-not-exist.bin")
+        let result = await FileStabilityChecker.waitForStability(at: file)
+        XCTAssertTrue(result, "Missing file should return true (proceed optimistically)")
+    }
+}

--- a/PVLibrary/Tests/PVLibraryTests/GameImporterTests.swift
+++ b/PVLibrary/Tests/PVLibraryTests/GameImporterTests.swift
@@ -442,3 +442,215 @@ class GameImporterTests: XCTestCase {
     }
 }
 
+// MARK: - Archive batch-move failure tests
+
+/// A `FileManager` subclass that always throws when `moveItem(at:to:)` is called.
+/// Used to simulate a complete batch-move failure in archive import tests.
+private final class AlwaysFailMoveFileManager: FileManager {
+    override func moveItem(at srcURL: URL, to dstURL: URL) throws {
+        throw CocoaError(.fileWriteNoPermission)
+    }
+}
+
+/// A `FileManager` subclass that fails `moveItem` only for URLs in `failURLs`,
+/// delegating all other operations to the real `FileManager`.
+private final class PartialFailMoveFileManager: FileManager {
+    let failURLs: Set<URL>
+
+    init(failURLs: Set<URL>) {
+        self.failURLs = failURLs
+        super.init()
+    }
+
+    override func moveItem(at srcURL: URL, to dstURL: URL) throws {
+        if failURLs.contains(srcURL) {
+            throw CocoaError(.fileWriteNoPermission)
+        }
+        try super.moveItem(at: srcURL, to: dstURL)
+    }
+}
+
+/// A `FileManager` subclass that records every URL passed to `removeItem(at:)`.
+/// Uses a move that always fails so any call to `removeItem` for the archive signals a bug.
+private final class RecordingFailMoveFileManager: FileManager {
+    private(set) var removedURLs: [URL] = []
+
+    override func moveItem(at srcURL: URL, to dstURL: URL) throws {
+        throw CocoaError(.fileWriteNoPermission)
+    }
+
+    override func removeItem(at URL: URL) throws {
+        removedURLs.append(URL)
+        try super.removeItem(at: URL)
+    }
+}
+
+class ArchiveBatchMoveTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeTempDirectory() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ArchiveBatchMoveTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func createFile(at url: URL, content: String = "ROMDATA") {
+        FileManager.default.createFile(atPath: url.path, contents: Data(content.utf8))
+    }
+
+    private func makeImporter(fileManager fm: FileManager) -> GameImporter {
+        GameImporter(fm,
+                     GameImporterFileService(),
+                     GameImporterDatabaseService(),
+                     GameImporterSystemsService(),
+                     ArtworkImporter(),
+                     DefaultCDFileHandler(),
+                     SkinImporterInjector.shared)
+    }
+
+    // MARK: - Tests
+
+    /// When every `moveItem` call fails, `moveBatchExtractedFiles` must return an
+    /// empty `queued` list and `allSucceeded == false`.
+    func testMoveBatch_allFail_queuesNothing() throws {
+        let srcDir = try makeTempDirectory()
+        let dstDir = try makeTempDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: srcDir)
+            try? FileManager.default.removeItem(at: dstDir)
+        }
+
+        let file1 = srcDir.appendingPathComponent("rom1.nes")
+        let file2 = srcDir.appendingPathComponent("rom2.sfc")
+        createFile(at: file1)
+        createFile(at: file2)
+
+        let importer = makeImporter(fileManager: AlwaysFailMoveFileManager())
+        let (queued, allSucceeded) = importer.moveBatchExtractedFiles([file1, file2], to: dstDir)
+
+        XCTAssertTrue(queued.isEmpty, "No files should be queued when all moves fail")
+        XCTAssertFalse(allSucceeded, "allSucceeded must be false when all moves fail")
+        // Source files must remain in place (not moved)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: file1.path), "Source file should still exist after failed move")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: file2.path), "Source file should still exist after failed move")
+    }
+
+    /// When only some `moveItem` calls fail, only the successfully moved files
+    /// should appear in `queued`, and `allSucceeded` must be `false`.
+    func testMoveBatch_partialFail_queuesOnlySuccessfulFiles() throws {
+        let srcDir = try makeTempDirectory()
+        let dstDir = try makeTempDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: srcDir)
+            try? FileManager.default.removeItem(at: dstDir)
+        }
+
+        let goodFile = srcDir.appendingPathComponent("good.nes")
+        let badFile  = srcDir.appendingPathComponent("bad.sfc")
+        createFile(at: goodFile)
+        createFile(at: badFile)
+
+        let importer = makeImporter(fileManager: PartialFailMoveFileManager(failURLs: [badFile]))
+        let (queued, allSucceeded) = importer.moveBatchExtractedFiles([goodFile, badFile], to: dstDir)
+
+        XCTAssertEqual(queued.count, 1, "Only the successfully moved file should be queued")
+        XCTAssertEqual(queued.first?.lastPathComponent, "good.nes")
+        XCTAssertFalse(allSucceeded, "allSucceeded must be false when at least one move fails")
+
+        // The good file was moved to the destination
+        XCTAssertTrue(FileManager.default.fileExists(atPath: dstDir.appendingPathComponent("good.nes").path),
+                      "Successfully moved file should exist at destination")
+        // The bad file stays in the source (temp) directory
+        XCTAssertTrue(FileManager.default.fileExists(atPath: badFile.path),
+                      "Failed-to-move file must remain in the temp extraction directory")
+    }
+
+    /// When all moves succeed, every file should be in `queued` and
+    /// `allSucceeded` must be `true`.
+    func testMoveBatch_allSucceed_queuesAllFiles() throws {
+        let srcDir = try makeTempDirectory()
+        let dstDir = try makeTempDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: srcDir)
+            try? FileManager.default.removeItem(at: dstDir)
+        }
+
+        let file1 = srcDir.appendingPathComponent("rom1.nes")
+        let file2 = srcDir.appendingPathComponent("rom2.sfc")
+        createFile(at: file1)
+        createFile(at: file2)
+
+        let importer = makeImporter(fileManager: FileManager.default)
+        let (queued, allSucceeded) = importer.moveBatchExtractedFiles([file1, file2], to: dstDir)
+
+        XCTAssertEqual(queued.count, 2, "All files should be queued when all moves succeed")
+        XCTAssertTrue(allSucceeded, "allSucceeded must be true when all moves succeed")
+    }
+
+    /// When all moves fail, the archive file must NOT be removed — the injected
+    /// `FileManager` should never receive a `removeItem` call for the archive URL.
+    ///
+    /// In `extractAndImportArchive`, the archive is only deleted via
+    /// `self.fileManager.removeItem(at: archiveURL)` after the `guard allMovesSucceeded`
+    /// check. Returning `allSucceeded == false` from `moveBatchExtractedFiles` triggers
+    /// the early-return path, which skips that deletion entirely.
+    func testMoveBatch_allFail_archiveNotRemovedViaFileManager() throws {
+        let srcDir     = try makeTempDirectory()
+        let dstDir     = try makeTempDirectory()
+        let archiveDir = try makeTempDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: srcDir)
+            try? FileManager.default.removeItem(at: dstDir)
+            try? FileManager.default.removeItem(at: archiveDir)
+        }
+
+        let extractedFile = srcDir.appendingPathComponent("game.nes")
+        let archiveURL    = archiveDir.appendingPathComponent("game.zip")
+        createFile(at: extractedFile)
+        createFile(at: archiveURL)
+
+        let recordingFM = RecordingFailMoveFileManager()
+        let importer    = makeImporter(fileManager: recordingFM)
+
+        let (_, allSucceeded) = importer.moveBatchExtractedFiles([extractedFile], to: dstDir)
+
+        XCTAssertFalse(allSucceeded, "allSucceeded must be false when moves fail")
+
+        // The archive file should still be on disk (we never deleted it in this test
+        // because we didn't call extractAndImportArchive; this confirms the archive
+        // URL was not passed to removeItem).
+        XCTAssertFalse(recordingFM.removedURLs.contains(archiveURL),
+                       "The archive must not be removed via fileManager when batch move fails")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: archiveURL.path),
+                      "Archive file must still exist on disk after a batch-move failure")
+    }
+
+    /// When all moves fail, the temp extraction directory must be preserved
+    /// (i.e., the `defer` block inside `extractAndImportArchive` must NOT delete it)
+    /// because `preserveTempDir` is set to `true` when `allMovesSucceeded == false`.
+    ///
+    /// This test verifies that `moveBatchExtractedFiles` correctly reports failure
+    /// so the caller can preserve the directory, and that files remain in it.
+    func testMoveBatch_allFail_tempDirContentsPreserved() throws {
+        let srcDir = try makeTempDirectory()
+        let dstDir = try makeTempDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: srcDir)
+            try? FileManager.default.removeItem(at: dstDir)
+        }
+
+        let extractedFile = srcDir.appendingPathComponent("game.nes")
+        createFile(at: extractedFile)
+
+        let importer = makeImporter(fileManager: AlwaysFailMoveFileManager())
+        let (_, allSucceeded) = importer.moveBatchExtractedFiles([extractedFile], to: dstDir)
+
+        XCTAssertFalse(allSucceeded, "allSucceeded must be false — caller must preserve the temp dir")
+        // The extracted file stays inside srcDir (the simulated temp extraction directory)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: extractedFile.path),
+                      "Extracted file must remain in the temp dir when its move failed")
+    }
+}
+

--- a/PVLibrary/Tests/PVLibraryTests/GameImporterTests.swift
+++ b/PVLibrary/Tests/PVLibraryTests/GameImporterTests.swift
@@ -608,9 +608,9 @@ class ArchiveBatchMoveTests: XCTestCase {
     /// `fileManager.removeItem(at:)`.
     ///
     /// `extractAndImportArchive` only reaches `self.fileManager.removeItem(at: archiveURL)`
-    /// after a `guard allMovesSucceeded` check; when moves fail the guard returns
-    /// early, so the archive is never passed to `removeItem`.  This test exercises
-    /// that exact code path with a real (minimal) ZIP archive and a
+    /// after a `guard allMovesSucceeded` check; when moves fail the guard throws
+    /// `ArchiveError.batchMoveFailed`, so the archive is never passed to `removeItem`.
+    /// This test exercises that exact code path with a real (minimal) ZIP archive and a
     /// `RecordingFailMoveFileManager` to capture any `removeItem` calls.
     func testMoveBatch_allFail_archiveNotRemovedViaFileManager() async throws {
         let archiveDir = try makeTempDirectory()
@@ -626,9 +626,18 @@ class ArchiveBatchMoveTests: XCTestCase {
         // extractAndImportArchive extracts the archive, then tries to move
         // each extracted file via the injected fileManager.  Because
         // RecordingFailMoveFileManager always throws on moveItem, every move
-        // fails → allMovesSucceeded == false → the method returns early without
-        // ever calling fileManager.removeItem(at: archiveURL).
-        try await importer.extractAndImportArchive(item)
+        // fails → allMovesSucceeded == false → the method throws
+        // ArchiveError.batchMoveFailed without ever calling
+        // fileManager.removeItem(at: archiveURL).
+        do {
+            try await importer.extractAndImportArchive(item)
+            XCTFail("Expected ArchiveError.batchMoveFailed to be thrown when all moves fail")
+        } catch let error as ArchiveError {
+            guard case .batchMoveFailed = error else {
+                XCTFail("Expected ArchiveError.batchMoveFailed, got \(error)")
+                return
+            }
+        }
 
         XCTAssertFalse(recordingFM.removedURLs.contains(archiveURL),
                        "The archive must not be removed via fileManager when batch move fails")

--- a/PVLibrary/Tests/PVLibraryTests/GameImporterTests.swift
+++ b/PVLibrary/Tests/PVLibraryTests/GameImporterTests.swift
@@ -510,6 +510,20 @@ class ArchiveBatchMoveTests: XCTestCase {
                      SkinImporterInjector.shared)
     }
 
+    /// Creates a minimal ZIP archive at `url` containing a single "game.nes" entry
+    /// with dummy content. Uses `SSZipArchive` to produce a well-formed archive
+    /// that the `ZipExtractor` inside `extractAndImportArchive` can open.
+    private func makeMinimalZipArchive(at url: URL) throws {
+        let tmpROM = url.deletingLastPathComponent()
+            .appendingPathComponent("_tmp_game_\(UUID().uuidString).nes")
+        FileManager.default.createFile(atPath: tmpROM.path, contents: Data("ROMDATA".utf8))
+        defer { try? FileManager.default.removeItem(at: tmpROM) }
+        guard SSZipArchive.createZipFile(atPath: url.path, withFilesAtPaths: [tmpROM.path]) else {
+            throw CocoaError(.fileWriteUnknown,
+                             userInfo: [NSLocalizedDescriptionKey: "SSZipArchive failed to create test fixture"])
+        }
+    }
+
     // MARK: - Tests
 
     /// When every `moveItem` call fails, `moveBatchExtractedFiles` must return an
@@ -589,38 +603,33 @@ class ArchiveBatchMoveTests: XCTestCase {
         XCTAssertTrue(allSucceeded, "allSucceeded must be true when all moves succeed")
     }
 
-    /// When all moves fail, the archive file must NOT be removed — the injected
-    /// `FileManager` should never receive a `removeItem` call for the archive URL.
+    /// Exercises the full `extractAndImportArchive` path: when every `moveItem`
+    /// call fails, the archive must **not** be removed via the injected
+    /// `fileManager.removeItem(at:)`.
     ///
-    /// In `extractAndImportArchive`, the archive is only deleted via
-    /// `self.fileManager.removeItem(at: archiveURL)` after the `guard allMovesSucceeded`
-    /// check. Returning `allSucceeded == false` from `moveBatchExtractedFiles` triggers
-    /// the early-return path, which skips that deletion entirely.
-    func testMoveBatch_allFail_archiveNotRemovedViaFileManager() throws {
-        let srcDir     = try makeTempDirectory()
-        let dstDir     = try makeTempDirectory()
+    /// `extractAndImportArchive` only reaches `self.fileManager.removeItem(at: archiveURL)`
+    /// after a `guard allMovesSucceeded` check; when moves fail the guard returns
+    /// early, so the archive is never passed to `removeItem`.  This test exercises
+    /// that exact code path with a real (minimal) ZIP archive and a
+    /// `RecordingFailMoveFileManager` to capture any `removeItem` calls.
+    func testMoveBatch_allFail_archiveNotRemovedViaFileManager() async throws {
         let archiveDir = try makeTempDirectory()
-        defer {
-            try? FileManager.default.removeItem(at: srcDir)
-            try? FileManager.default.removeItem(at: dstDir)
-            try? FileManager.default.removeItem(at: archiveDir)
-        }
+        defer { try? FileManager.default.removeItem(at: archiveDir) }
 
-        let extractedFile = srcDir.appendingPathComponent("game.nes")
-        let archiveURL    = archiveDir.appendingPathComponent("game.zip")
-        createFile(at: extractedFile)
-        createFile(at: archiveURL)
+        let archiveURL = archiveDir.appendingPathComponent("test_game.zip")
+        try makeMinimalZipArchive(at: archiveURL)
 
         let recordingFM = RecordingFailMoveFileManager()
         let importer    = makeImporter(fileManager: recordingFM)
+        let item        = ImportQueueItem(url: archiveURL)
 
-        let (_, allSucceeded) = importer.moveBatchExtractedFiles([extractedFile], to: dstDir)
+        // extractAndImportArchive extracts the archive, then tries to move
+        // each extracted file via the injected fileManager.  Because
+        // RecordingFailMoveFileManager always throws on moveItem, every move
+        // fails → allMovesSucceeded == false → the method returns early without
+        // ever calling fileManager.removeItem(at: archiveURL).
+        try await importer.extractAndImportArchive(item)
 
-        XCTAssertFalse(allSucceeded, "allSucceeded must be false when moves fail")
-
-        // The archive file should still be on disk (we never deleted it in this test
-        // because we didn't call extractAndImportArchive; this confirms the archive
-        // URL was not passed to removeItem).
         XCTAssertFalse(recordingFM.removedURLs.contains(archiveURL),
                        "The archive must not be removed via fileManager when batch move fails")
         XCTAssertTrue(FileManager.default.fileExists(atPath: archiveURL.path),


### PR DESCRIPTION
…e stability checks, and logged cleanup

- Replace 200ms polling delay + 5-retry loop with kqueue-based FileStabilityChecker that uses DispatchSource to detect when a file has stopped being written to (quiesce interval approach)
- Make batch file moves resilient: individual move failures are logged but do not abort the batch, preventing partial state where some extracted files are lost
- Temp extraction directories are preserved when unmoved files remain, instead of being silently deleted
- Replace silent try? on temp directory cleanup with proper do/catch error logging in both DirectoryWatcher and GameImporter

Addresses feedback from #709:
- Files moved one-by-one leaving partial state on interruption
- 200ms polling delay is heuristic; kqueue/FSEvents is more robust
- Temp directory cleanup uses try? silently without logging

### What does this PR do

### Where should the reviewer start

### How should this be manually tested

### Any background context you want to provide

### What are the relevant tickets

### Screenshots (important for UI changes)

### Questions
