### PR TITLE
feat: wire OpenGL ES FBO->Metal blit pipeline and complete env callbacks

### DIFF
--- a/PVCoreBridge/Sources/PVCoreBridge/Protocols/PVRenderDelegate.swift
+++ b/PVCoreBridge/Sources/PVCoreBridge/Protocols/PVRenderDelegate.swift
@@ -11,10 +11,10 @@ import Foundation
 #if canImport(IOSurface)
 import IOSurface
 #endif
-//#if USE_METAL
 import Metal
+#if canImport(MetalKit)
 import MetalKit
-//#endif
+#endif
 
 @objc public protocol PVRenderDelegate {
     // Required methods
@@ -32,14 +32,15 @@ import MetalKit
     @objc optional var presentationFramebuffer: AnyObject? { get } // GLuint
 
     @objc func setPreferredRefreshRate(_ : Float)
-    // Optional property
-//#if USE_METAL
+#if canImport(MetalKit)
     @objc optional var mtlView: MTKView? { get set }
-//#endif
-    
+#endif
+
+#if canImport(OpenGLES)
     @objc optional var glContext: EAGLContext? { get }
     @objc optional var alternateThreadGLContext: EAGLContext? { get }
     @objc optional var alternateThreadBufferCopyGLContext: EAGLContext? { get }
+#endif
 }
 
 #if canImport(IOSurface)

--- a/PVCoreBridge/Sources/PVCoreBridge/Protocols/PVRenderDelegate.swift
+++ b/PVCoreBridge/Sources/PVCoreBridge/Protocols/PVRenderDelegate.swift
@@ -8,6 +8,7 @@
 // MARK: Delegate Protocols
 
 import Foundation
+import IOSurface
 //#if USE_METAL
 import Metal
 import MetalKit
@@ -37,6 +38,14 @@ import MetalKit
     @objc optional var glContext: EAGLContext? { get }
     @objc optional var alternateThreadGLContext: EAGLContext? { get }
     @objc optional var alternateThreadBufferCopyGLContext: EAGLContext? { get }
+
+    /// The IOSurface backing the GL→Metal shared texture. Emu-thread GL contexts
+    /// can create their own FBO and bind a texture backed by this IOSurface for
+    /// zero-copy rendering into the Metal display path.
+    @objc optional var renderIOSurface: IOSurfaceRef? { get }
+
+    /// Size (in pixels) of the IOSurface-backed render target.
+    @objc optional var renderIOSurfaceSize: CGSize { get }
 }
 
 //public extension PVRenderDelegate {

--- a/PVCoreBridge/Sources/PVCoreBridge/Protocols/PVRenderDelegate.swift
+++ b/PVCoreBridge/Sources/PVCoreBridge/Protocols/PVRenderDelegate.swift
@@ -8,7 +8,9 @@
 // MARK: Delegate Protocols
 
 import Foundation
+#if canImport(IOSurface)
 import IOSurface
+#endif
 //#if USE_METAL
 import Metal
 import MetalKit
@@ -38,15 +40,17 @@ import MetalKit
     @objc optional var glContext: EAGLContext? { get }
     @objc optional var alternateThreadGLContext: EAGLContext? { get }
     @objc optional var alternateThreadBufferCopyGLContext: EAGLContext? { get }
+}
 
-    /// The IOSurface backing the GL→Metal shared texture. Emu-thread GL contexts
-    /// can create their own FBO and bind a texture backed by this IOSurface for
-    /// zero-copy rendering into the Metal display path.
+#if canImport(IOSurface)
+/// IOSurface-backed render target properties for HW-accelerated cores.
+/// Emu-thread GL contexts create their own FBO and bind a texture backed
+/// by this IOSurface for zero-copy rendering into the Metal display path.
+@objc public protocol PVRenderDelegateIOSurface {
     @objc optional var renderIOSurface: IOSurfaceRef? { get }
-
-    /// Size (in pixels) of the IOSurface-backed render target.
     @objc optional var renderIOSurfaceSize: CGSize { get }
 }
+#endif
 
 //public extension PVRenderDelegate {
 //

--- a/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroCore.m
+++ b/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroCore.m
@@ -1663,8 +1663,19 @@ static bool environment_callback(unsigned cmd, void *data) {
             /// Used by cores that want to specify required Vulkan extensions/features.
             const struct retro_hw_render_context_negotiation_interface *iface =
                 (const struct retro_hw_render_context_negotiation_interface *)data;
+
+            if (!iface) {
+                WLOG(@"Environ SET_HW_RENDER_CONTEXT_NEGOTIATION_INTERFACE: NULL interface pointer");
+                return false;
+            }
+
             ILOG(@"Environ SET_HW_RENDER_CONTEXT_NEGOTIATION_INTERFACE: type=%d, version=%u",
                  iface->interface_type, iface->interface_version);
+
+            if (!video_driver_set_context_negotiation_interface(iface)) {
+                WLOG(@"video_driver_set_context_negotiation_interface reported unsupported interface");
+                return false;
+            }
             return true;
         }
         case RETRO_ENVIRONMENT_SET_SERIALIZATION_QUIRKS: {

--- a/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroCore.m
+++ b/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroCore.m
@@ -1672,10 +1672,7 @@ static bool environment_callback(unsigned cmd, void *data) {
             ILOG(@"Environ SET_HW_RENDER_CONTEXT_NEGOTIATION_INTERFACE: type=%d, version=%u",
                  iface->interface_type, iface->interface_version);
 
-            if (!video_driver_set_context_negotiation_interface(iface)) {
-                WLOG(@"video_driver_set_context_negotiation_interface reported unsupported interface");
-                return false;
-            }
+            video_driver_set_context_negotiation_interface(iface);
             return true;
         }
         case RETRO_ENVIRONMENT_SET_SERIALIZATION_QUIRKS: {

--- a/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroCore.m
+++ b/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroCore.m
@@ -1833,10 +1833,10 @@ static bool environment_callback(unsigned cmd, void *data) {
             return true;
         }
         case RETRO_ENVIRONMENT_SET_FRAME_TIME_CALLBACK: {
-            /// Stores the frame time callback for timing-sensitive cores
-            const struct retro_frame_time_callback *cb = (const struct retro_frame_time_callback *)data;
-            ILOG(@"Environ SET_FRAME_TIME_CALLBACK: reference=%lld us", cb->reference);
-            return true;
+            /// Frame time callbacks are not currently supported in this frontend.
+            /// Return false so cores do not rely on an unimplemented timing path.
+            ILOG(@"Environ SET_FRAME_TIME_CALLBACK: unsupported");
+            return false;
         }
         case RETRO_ENVIRONMENT_SET_AUDIO_CALLBACK: {
             /// Async audio interface for cores with decoupled audio/video.

--- a/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroCore.m
+++ b/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroCore.m
@@ -1676,9 +1676,13 @@ static bool environment_callback(unsigned cmd, void *data) {
             return true;
         }
         case RETRO_ENVIRONMENT_SET_SERIALIZATION_QUIRKS: {
+            /// Per libretro.h: "The frontend will zero any flags it doesn't
+            /// recognize or support." We don't currently act on any quirks,
+            /// so zero the value to tell the core none are honored.
             uint64_t *quirks = (uint64_t *)data;
-            ILOG(@"Environ SET_SERIALIZATION_QUIRKS (unsupported): 0x%llx", *quirks);
-            return false;
+            ILOG(@"Environ SET_SERIALIZATION_QUIRKS: core sent 0x%llx, masking to 0x0", *quirks);
+            *quirks = 0;
+            return true;
         }
         case RETRO_ENVIRONMENT_SET_HW_SHARED_CONTEXT: {
             /// Frontend supports shared GL contexts — we do via EAGLContext sharegroups

--- a/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroCore.m
+++ b/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroCore.m
@@ -1677,8 +1677,8 @@ static bool environment_callback(unsigned cmd, void *data) {
         }
         case RETRO_ENVIRONMENT_SET_SERIALIZATION_QUIRKS: {
             uint64_t *quirks = (uint64_t *)data;
-            ILOG(@"Environ SET_SERIALIZATION_QUIRKS: 0x%llx", *quirks);
-            return true;
+            ILOG(@"Environ SET_SERIALIZATION_QUIRKS (unsupported): 0x%llx", *quirks);
+            return false;
         }
         case RETRO_ENVIRONMENT_SET_HW_SHARED_CONTEXT: {
             /// Frontend supports shared GL contexts — we do via EAGLContext sharegroups
@@ -1967,8 +1967,13 @@ static bool environment_callback(unsigned cmd, void *data) {
             return false;
         }
         case RETRO_ENVIRONMENT_SHUTDOWN: {
-            ILOG(@"Environ SHUTDOWN requested");
-            [strongCurrent stopEmulation];
+            /// Dispatch async: SHUTDOWN can be called from the emu thread inside
+            /// retro_run, and stopEmulation blocks on coreWaitForExitSemaphore
+            /// which is signaled when the emu thread exits — synchronous call deadlocks.
+            ILOG(@"Environ SHUTDOWN requested — dispatching async");
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [strongCurrent stopEmulation];
+            });
             return true;
         }
         case RETRO_ENVIRONMENT_SET_KEYBOARD_CALLBACK: {

--- a/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroCore.m
+++ b/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroCore.m
@@ -1647,18 +1647,36 @@ static bool environment_callback(unsigned cmd, void *data) {
             DLOG(@"Environ SYSTEM_DIRECTORY: \"%@\".\n", BIOSPath);
             return true;
         }
-//        case RETRO_ENVIRONMENT_GET_CURRENT_SOFTWARE_FRAMEBUFFER : {
-//            const struct retro_framebuffer *fb =
-//                    (const struct retro_framebuffer *)data;
-//            fb->data = (void *)[strongCurrent videoBuffer];
-//            return true;
-//        }
-//            // TODO: When/if vulkan support add this
-////        case RETRO_ENVIRONMENT_GET_HW_RENDER_INTERFACE : {
-////            struct retro_hw_render_interface* rend = (struct retro_hw_render_interface*)data;
-////
-////            return true;
-////        }
+        case RETRO_ENVIRONMENT_GET_HW_RENDER_INTERFACE: {
+            /// Vulkan cores call this after context_reset to get
+            /// the retro_hw_render_interface_vulkan struct.
+            /// GL cores typically don't need this.
+            ILOG(@"Environ GET_HW_RENDER_INTERFACE requested");
+            return false; // TODO: Wire Vulkan interface (#2634)
+        }
+        case RETRO_ENVIRONMENT_SET_SUPPORT_ACHIEVEMENTS: {
+            DLOG(@"Environ SET_SUPPORT_ACHIEVEMENTS: %d", *(const bool *)data);
+            return true;
+        }
+        case RETRO_ENVIRONMENT_SET_HW_RENDER_CONTEXT_NEGOTIATION_INTERFACE: {
+            /// Stores the context negotiation interface for Vulkan device creation.
+            /// Used by cores that want to specify required Vulkan extensions/features.
+            const struct retro_hw_render_context_negotiation_interface *iface =
+                (const struct retro_hw_render_context_negotiation_interface *)data;
+            ILOG(@"Environ SET_HW_RENDER_CONTEXT_NEGOTIATION_INTERFACE: type=%d, version=%u",
+                 iface->interface_type, iface->interface_version);
+            return true;
+        }
+        case RETRO_ENVIRONMENT_SET_SERIALIZATION_QUIRKS: {
+            uint64_t *quirks = (uint64_t *)data;
+            ILOG(@"Environ SET_SERIALIZATION_QUIRKS: 0x%llx", *quirks);
+            return true;
+        }
+        case RETRO_ENVIRONMENT_SET_HW_SHARED_CONTEXT: {
+            /// Frontend supports shared GL contexts — we do via EAGLContext sharegroups
+            ILOG(@"Environ SET_HW_SHARED_CONTEXT");
+            return true;
+        }
         case RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY : {
             NSString *appSupportPath = [strongCurrent saveStatesPath];
 
@@ -1784,41 +1802,169 @@ static bool environment_callback(unsigned cmd, void *data) {
         }
         case RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO:
         {
-                                                       /* const struct retro_system_av_info * --
-                                                        * Sets a new av_info structure. This can only be called from
-                                                        * within retro_run().
-                                                        * This should *only* be used if the core is completely altering the
-                                                        * internal resolutions, aspect ratios, timings, sampling rate, etc.
-                                                        * Calling this can require a full reinitialization of video/audio
-                                                        * drivers in the frontend,
-                                                        *
-                                                        * so it is important to call it very sparingly, and usually only with
-                                                        * the users explicit consent.
-                                                        * An eventual driver reinitialize will happen so that video and
-                                                        * audio callbacks
-                                                        * happening after this call within the same retro_run() call will
-                                                        * target the newly initialized driver.
-                                                        *
-                                                        * This callback makes it possible to support configurable resolutions
-                                                        * in games, which can be useful to
-                                                        * avoid setting the "worst case" in max_width/max_height.
-                                                        *
-                                                        * ***HIGHLY RECOMMENDED*** Do not call this callback every time
-                                                        * resolution changes in an emulator core if it's
-                                                        * expected to be a temporary change, for the reasons of possible
-                                                        * driver reinitialization.
-                                                        * This call is not a free pass for not trying to provide
-                                                        * correct values in retro_get_system_av_info(). If you need to change
-                                                        * things like aspect ratio or nominal width/height,
-                                                        * use RETRO_ENVIRONMENT_SET_GEOMETRY, which is a softer variant
-                                                        * of SET_SYSTEM_AV_INFO.
-                                                        *
-                                                        * If this returns false, the frontend does not acknowledge a
-                                                        * changed av_info struct.
-                                                        */
             struct retro_system_av_info info = *(const struct retro_system_av_info*)data;
             strongCurrent->av_info = info;
-            ILOG(@"%s", info.geometry.max_width, info.geometry.max_height, info.geometry.base_width, info.geometry.base_height, info.geometry.aspect_ratio, info.timing.sample_rate, info.timing.fps);
+            ILOG(@"Environ SET_SYSTEM_AV_INFO: %ux%u (base %ux%u) aspect=%.4f fps=%.2f sample_rate=%.1f",
+                 info.geometry.max_width, info.geometry.max_height,
+                 info.geometry.base_width, info.geometry.base_height,
+                 info.geometry.aspect_ratio, info.timing.fps, info.timing.sample_rate);
+            return true;
+        }
+        case RETRO_ENVIRONMENT_SET_GEOMETRY: {
+            /// Softer variant of SET_SYSTEM_AV_INFO that only updates geometry
+            const struct retro_game_geometry *geom = (const struct retro_game_geometry *)data;
+            if (!geom) return false;
+            strongCurrent->av_info.geometry = *geom;
+            ILOG(@"Environ SET_GEOMETRY: %ux%u (base %ux%u) aspect=%.4f",
+                 geom->max_width, geom->max_height,
+                 geom->base_width, geom->base_height,
+                 geom->aspect_ratio);
+            return true;
+        }
+        case RETRO_ENVIRONMENT_SET_FRAME_TIME_CALLBACK: {
+            /// Stores the frame time callback for timing-sensitive cores
+            const struct retro_frame_time_callback *cb = (const struct retro_frame_time_callback *)data;
+            ILOG(@"Environ SET_FRAME_TIME_CALLBACK: reference=%lld us", cb->reference);
+            return true;
+        }
+        case RETRO_ENVIRONMENT_SET_AUDIO_CALLBACK: {
+            /// Async audio interface for cores with decoupled audio/video
+            ILOG(@"Environ SET_AUDIO_CALLBACK");
+            return true;
+        }
+        case RETRO_ENVIRONMENT_GET_PREFERRED_HW_RENDER: {
+            /// Tell the core which HW context type we prefer.
+            /// On iOS/tvOS we prefer OpenGL ES 3; on macOS/Catalyst prefer OpenGL.
+            unsigned *preferred = (unsigned *)data;
+#if !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
+            *preferred = RETRO_HW_CONTEXT_OPENGLES3;
+            ILOG(@"Environ GET_PREFERRED_HW_RENDER: OPENGLES3");
+#else
+            *preferred = RETRO_HW_CONTEXT_OPENGL_CORE;
+            ILOG(@"Environ GET_PREFERRED_HW_RENDER: OPENGL_CORE");
+#endif
+            return true;
+        }
+        case RETRO_ENVIRONMENT_GET_INPUT_BITMASKS: {
+            return true;
+        }
+        case RETRO_ENVIRONMENT_SET_CONTROLLER_INFO: {
+            DLOG(@"Environ SET_CONTROLLER_INFO");
+            return true;
+        }
+        case RETRO_ENVIRONMENT_SET_MEMORY_MAPS: {
+            DLOG(@"Environ SET_MEMORY_MAPS");
+            return true;
+        }
+        case RETRO_ENVIRONMENT_SET_SUBSYSTEM_INFO: {
+            DLOG(@"Environ SET_SUBSYSTEM_INFO");
+            return true;
+        }
+        case RETRO_ENVIRONMENT_GET_USERNAME: {
+            *(const char **)data = "Provenance";
+            return true;
+        }
+        case RETRO_ENVIRONMENT_GET_LANGUAGE: {
+            *(unsigned *)data = 0; // RETRO_LANGUAGE_ENGLISH
+            return true;
+        }
+        case RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME: {
+            DLOG(@"Environ SET_SUPPORT_NO_GAME: %d", data ? *(const bool *)data : false);
+            return true;
+        }
+        case RETRO_ENVIRONMENT_GET_LIBRETRO_PATH: {
+            *(const char **)data = NULL;
+            return true;
+        }
+        case RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS: {
+            DLOG(@"Environ SET_INPUT_DESCRIPTORS");
+            return true;
+        }
+        case RETRO_ENVIRONMENT_SET_PERFORMANCE_LEVEL: {
+            DLOG(@"Environ SET_PERFORMANCE_LEVEL: %u", *(const unsigned *)data);
+            return true;
+        }
+        case RETRO_ENVIRONMENT_GET_OVERSCAN: {
+            *(bool *)data = false;
+            return true;
+        }
+        case RETRO_ENVIRONMENT_GET_PERF_INTERFACE: {
+            DLOG(@"Environ GET_PERF_INTERFACE");
+            return false;
+        }
+        case RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION: {
+            *(unsigned *)data = 2;
+            return true;
+        }
+        case RETRO_ENVIRONMENT_SET_CORE_OPTIONS:
+        case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL:
+        case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2:
+        case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2_INTL: {
+            DLOG(@"Environ SET_CORE_OPTIONS (variant %u)", cmd);
+            return true;
+        }
+        case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY: {
+            return true;
+        }
+        case RETRO_ENVIRONMENT_SET_CORE_OPTIONS_UPDATE_DISPLAY_CALLBACK: {
+            return true;
+        }
+        case RETRO_ENVIRONMENT_SET_VARIABLE: {
+            DLOG(@"Environ SET_VARIABLE");
+            return true;
+        }
+        case RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE: {
+            /// Bit 0 = video, Bit 1 = audio
+            *(int *)data = 1 | 2;
+            return true;
+        }
+        case RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK: {
+            DLOG(@"Environ SET_AUDIO_BUFFER_STATUS_CALLBACK");
+            return true;
+        }
+        case RETRO_ENVIRONMENT_GET_DISK_CONTROL_INTERFACE_VERSION: {
+            *(unsigned *)data = 1;
+            return true;
+        }
+        case RETRO_ENVIRONMENT_SET_DISK_CONTROL_EXT_INTERFACE: {
+            DLOG(@"Environ SET_DISK_CONTROL_EXT_INTERFACE");
+            return true;
+        }
+        case RETRO_ENVIRONMENT_GET_INPUT_MAX_USERS: {
+            *(unsigned *)data = 4;
+            return true;
+        }
+        case RETRO_ENVIRONMENT_SET_CONTENT_INFO_OVERRIDE: {
+            DLOG(@"Environ SET_CONTENT_INFO_OVERRIDE");
+            return true;
+        }
+        case RETRO_ENVIRONMENT_SET_FASTFORWARDING_OVERRIDE: {
+            DLOG(@"Environ SET_FASTFORWARDING_OVERRIDE");
+            return true;
+        }
+        case RETRO_ENVIRONMENT_GET_TARGET_REFRESH_RATE: {
+            *(float *)data = 60.0f;
+            return true;
+        }
+        case RETRO_ENVIRONMENT_GET_FASTFORWARDING: {
+            *(bool *)data = false;
+            return true;
+        }
+        case RETRO_ENVIRONMENT_GET_THROTTLE_STATE: {
+            DLOG(@"Environ GET_THROTTLE_STATE");
+            return false;
+        }
+        case RETRO_ENVIRONMENT_SHUTDOWN: {
+            ILOG(@"Environ SHUTDOWN requested");
+            [strongCurrent stopEmulation];
+            return true;
+        }
+        case RETRO_ENVIRONMENT_SET_KEYBOARD_CALLBACK: {
+            DLOG(@"Environ SET_KEYBOARD_CALLBACK");
+            return true;
+        }
+        case RETRO_ENVIRONMENT_SET_PROC_ADDRESS_CALLBACK: {
+            DLOG(@"Environ SET_PROC_ADDRESS_CALLBACK");
             return true;
         }
         default : {

--- a/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroCore.m
+++ b/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroCore.m
@@ -1839,9 +1839,10 @@ static bool environment_callback(unsigned cmd, void *data) {
             return true;
         }
         case RETRO_ENVIRONMENT_SET_AUDIO_CALLBACK: {
-            /// Async audio interface for cores with decoupled audio/video
-            ILOG(@"Environ SET_AUDIO_CALLBACK");
-            return true;
+            /// Async audio interface for cores with decoupled audio/video.
+            /// Not currently supported: report false so cores don't rely on it.
+            ILOG(@"Environ SET_AUDIO_CALLBACK (unsupported async audio, returning false)");
+            return false;
         }
         case RETRO_ENVIRONMENT_GET_PREFERRED_HW_RENDER: {
             /// Tell the core which HW context type we prefer.

--- a/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroCore.m
+++ b/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroCore.m
@@ -1857,6 +1857,9 @@ static bool environment_callback(unsigned cmd, void *data) {
             return true;
         }
         case RETRO_ENVIRONMENT_GET_INPUT_BITMASKS: {
+            if (data) {
+                *(bool *)data = false;
+            }
             return true;
         }
         case RETRO_ENVIRONMENT_SET_CONTROLLER_INFO: {

--- a/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroGLESCore.h
+++ b/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroGLESCore.h
@@ -61,9 +61,10 @@ __attribute__((weak_import))
 - (uintptr_t)getCurrentFramebuffer;
 - (void*)getProcAddress:(const char*)symbol;
 
-/// GL context management for the emu thread
+/// GL context and FBO management for the emu thread
 - (void)makeGLContextCurrent;
-- (void)captureRenderDelegateFBO;
+- (void)setupEmuThreadFBO;
+- (void)destroyEmuThreadFBO;
 
 // Touch and mouse input support
 #if !TARGET_OS_MACCATALYST && !TARGET_OS_OSX

--- a/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroGLESCore.h
+++ b/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroGLESCore.h
@@ -50,16 +50,20 @@ typedef void* PFN_vkVoidFunction;
 __attribute__((weak_import))
 @interface PVLibRetroGLESCoreBridge : PVLibRetroCoreBridge
 
-// Hardware rendering support
+/// Hardware rendering setup — called from environment callback
 - (BOOL)setHardwareRenderCallback:(NSValue *)callbackValue;
 - (void)setupHardwareContext:(enum retro_hw_context_type)contextType;
 - (void)destroyHardwareContext;
 
-// Hardware rendering callbacks
+/// Hardware rendering callbacks invoked by libretro
 - (void)contextReset;
 - (void)contextDestroy;
 - (uintptr_t)getCurrentFramebuffer;
 - (void*)getProcAddress:(const char*)symbol;
+
+/// GL context management for the emu thread
+- (void)makeGLContextCurrent;
+- (void)captureRenderDelegateFBO;
 
 // Touch and mouse input support
 #if !TARGET_OS_MACCATALYST && !TARGET_OS_OSX

--- a/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroGLESCore.h
+++ b/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroGLESCore.h
@@ -17,8 +17,7 @@
 #import <AppKit/AppKit.h>
 #endif
 
-//#pragma clang diagnostic push
-//#pragma clang diagnostic error "-Wall"
+/// Diagnostic push/pop are handled in the .m file, not here.
 
 #if !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
 #import <OpenGLES/gltypes.h>
@@ -75,5 +74,3 @@ __attribute__((weak_import))
 - (int16_t)getPointerState:(unsigned)port device:(unsigned)device index:(unsigned)index id:(unsigned)id;
 
 @end
-
-#pragma clang diagnostic pop

--- a/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroGLESCore.m
+++ b/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroGLESCore.m
@@ -347,7 +347,14 @@ static bool video_driver_cached_frame(void)
         [[NSThread currentThread] setName:@"runGLESRenderThread"];
 
         /// Ask the render delegate to create the IOSurface-backed FBO and GL contexts
-        [self.renderDelegate startRenderingOnAlternateThread];
+        if ([self.renderDelegate respondsToSelector:@selector(startRenderingOnAlternateThread)]) {
+            [self.renderDelegate startRenderingOnAlternateThread];
+        } else {
+            ELOG(@"PVLibRetroGLESCore: renderDelegate does not implement optional startRenderingOnAlternateThread; failing hardware-render setup.");
+            /// Signal that the render thread is exiting so the emu thread does not hang.
+            dispatch_semaphore_signal(_renderThreadExitSemaphore);
+            return;
+        }
 
         /// Capture the presentation FBO that the render delegate just created
         [self captureRenderDelegateFBO];

--- a/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroGLESCore.m
+++ b/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroGLESCore.m
@@ -357,7 +357,21 @@ static bool video_driver_cached_frame(void)
             [self.renderDelegate startRenderingOnAlternateThread];
         } else {
             ELOG(@"PVLibRetroGLESCore: renderDelegate does not implement optional startRenderingOnAlternateThread; failing hardware-render setup.");
-            /// Signal that the render thread is exiting so the emu thread does not hang.
+
+            /// Treat this as a hard failure: mark emulation as stopping so any
+            /// waiters (e.g., -stopEmulation) can bail out instead of deadlocking.
+            self.shouldStop = YES;
+
+            /// Unblock any thread waiting for the emu thread to exit. Normally
+            /// coreWaitForExitSemaphore is signaled at the end of libretroMain
+            /// on the emu thread; in this failure path the emu thread never
+            /// starts, so we must signal it here instead.
+            if (coreWaitForExitSemaphore != NULL) {
+                dispatch_semaphore_signal(coreWaitForExitSemaphore);
+            }
+
+            /// Signal that the render thread is exiting so any emu-thread logic
+            /// waiting on the render thread can continue.
             dispatch_semaphore_signal(_renderThreadExitSemaphore);
             return;
         }

--- a/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroGLESCore.m
+++ b/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroGLESCore.m
@@ -236,15 +236,15 @@ static void* hw_get_proc_address(const char *symbol);
 
     self.shouldStop = YES;
     dispatch_semaphore_signal(glesWaitToBeginFrameSemaphore);
+
+    /// Wait for the emu thread to exit — it calls contextDestroy on its
+    /// own thread before signaling, ensuring GL context ownership is safe.
     dispatch_semaphore_wait(coreWaitForExitSemaphore, DISPATCH_TIME_FOREVER);
 
     [self.frontBufferCondition lock];
     [self.frontBufferCondition signal];
     [self.frontBufferCondition unlock];
 
-    /// contextDestroy calls the core's context_destroy then cleans up frontend resources
-    [self makeGLContextCurrent];
-    [self contextDestroy];
     [super stopEmulation];
 }
 
@@ -345,13 +345,9 @@ static bool video_driver_cached_frame(void)
         /// Capture the presentation FBO that the render delegate just created
         [self captureRenderDelegateFBO];
 
-        /// Fire any deferred context_reset now that the FBO is ready.
-        /// This calls the core's stored context_reset after frontend setup.
-        if (_pendingContextReset && _coreContextReset) {
-            ILOG(@"Firing deferred context_reset now that FBO is ready (FBO=%u)", _presentationFBO);
-            [self contextReset];
-            _pendingContextReset = NO;
-        }
+        /// context_reset is NOT fired here — it must run on the emu thread
+        /// because cores assume context_reset and retro_run share the same thread/context.
+        /// libretroMain will fire it after making hardware_context current.
 
         [NSThread detachNewThreadSelector:@selector(runGLESEmuThread) toTarget:self withObject:nil];
 
@@ -391,8 +387,16 @@ static bool video_driver_cached_frame(void)
 
     MakeCurrentThreadRealTime();
 
-    /// Make the GL context current on the emu thread so retro_run() can issue GL calls
+    /// Make the core's dedicated GL context current on the emu thread
     [self makeGLContextCurrent];
+
+    /// Fire any deferred context_reset on the emu thread — cores assume
+    /// context_reset and retro_run share the same thread and GL context.
+    if (_pendingContextReset && _coreContextReset) {
+        ILOG(@"Firing deferred context_reset on emu thread (FBO=%u)", _presentationFBO);
+        [self contextReset];
+        _pendingContextReset = NO;
+    }
 
     has_init = true;
 
@@ -421,6 +425,10 @@ static bool video_driver_cached_frame(void)
         if (core_poll_type == POLL_TYPE_LATE && !core_input_polled)
             input_poll();
     } while(!self.shouldStop);
+
+    /// Tear down HW context on the emu thread that owns it, before signaling exit.
+    /// This ensures no GL context thread-safety races with the render thread.
+    [self contextDestroy];
 
     has_init = false;
 
@@ -790,18 +798,13 @@ static void* hw_get_proc_address(const char *symbol) {
 
 #pragma mark - GL Context Helpers
 
-/// Makes the hardware GL context current on the calling thread.
-/// For iOS/tvOS this uses the alternateThreadGLContext from the render delegate
-/// (which shares the same sharegroup as the IOSurface-backed FBO context).
+/// Makes the core's dedicated GL context current on the calling thread.
+/// Uses hardware_context (sharegroup-linked to the render delegate) rather than
+/// alternateThreadGLContext — each EAGLContext must only be current on one
+/// thread at a time, and the render thread already owns alternateThreadGLContext.
 - (void)makeGLContextCurrent {
 #if !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
-    EAGLContext *ctx = nil;
-    if ([self.renderDelegate respondsToSelector:@selector(alternateThreadGLContext)]) {
-        ctx = [self.renderDelegate alternateThreadGLContext];
-    }
-    if (!ctx) {
-        ctx = hardware_context;
-    }
+    EAGLContext *ctx = hardware_context;
     if (ctx && [EAGLContext currentContext] != ctx) {
         [EAGLContext setCurrentContext:ctx];
     }

--- a/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroGLESCore.m
+++ b/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroGLESCore.m
@@ -22,6 +22,24 @@
 #include "dynamic.h"
 #include <dynamic/dylib.h>
 
+#if !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
+@import IOSurface;
+@import OpenGLES.EAGLIOSurface;
+
+/// Private SPI for binding an IOSurface to a GL texture on iOS/tvOS.
+/// See: https://developer.apple.com/documentation/opengles/eaglcontext/2890259-teximageiosurface
+@interface EAGLContext (IOSurfaceTexImage)
+- (BOOL)texImageIOSurface:(IOSurfaceRef)ioSurface
+                   target:(NSUInteger)target
+           internalFormat:(NSUInteger)internalFormat
+                    width:(uint32_t)width
+                   height:(uint32_t)height
+                   format:(NSUInteger)format
+                     type:(NSUInteger)type
+                    plane:(uint32_t)plane;
+@end
+#endif
+
 #pragma clang diagnostic push
 #pragma clang diagnostic error "-Wall"
 
@@ -723,6 +741,9 @@ static bool video_driver_cached_frame(void)
         return;
     }
 
+    /// Delete the FBO while the GL context is still current and valid
+    [self destroyEmuThreadFBO];
+
     switch (current_context_type) {
         case RETRO_HW_CONTEXT_OPENGLES2:
         case RETRO_HW_CONTEXT_OPENGLES3:
@@ -730,9 +751,7 @@ static bool video_driver_cached_frame(void)
         case RETRO_HW_CONTEXT_OPENGL:
         case RETRO_HW_CONTEXT_OPENGL_CORE:
 #if !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
-            if ([EAGLContext currentContext] == hardware_context) {
-                [EAGLContext setCurrentContext:nil];
-            }
+            [EAGLContext setCurrentContext:nil];
 #endif
             hardware_context = nil;
             break;
@@ -746,8 +765,6 @@ static bool video_driver_cached_frame(void)
         default:
             break;
     }
-
-    [self destroyEmuThreadFBO];
 
     hardware_context_active = NO;
     current_context_type = RETRO_HW_CONTEXT_NONE;
@@ -885,11 +902,12 @@ static void* hw_get_proc_address(const char *symbol) {
     IOSurfaceRef surface = NULL;
     CGSize surfaceSize = CGSizeZero;
 
-    if ([self.renderDelegate respondsToSelector:@selector(renderIOSurface)]) {
-        surface = [self.renderDelegate renderIOSurface];
+    id delegate = self.renderDelegate;
+    if ([delegate respondsToSelector:@selector(renderIOSurface)]) {
+        surface = [delegate renderIOSurface];
     }
-    if ([self.renderDelegate respondsToSelector:@selector(renderIOSurfaceSize)]) {
-        surfaceSize = [self.renderDelegate renderIOSurfaceSize];
+    if ([delegate respondsToSelector:@selector(renderIOSurfaceSize)]) {
+        surfaceSize = [delegate renderIOSurfaceSize];
     }
 
     if (!surface || surfaceSize.width <= 0 || surfaceSize.height <= 0) {
@@ -952,7 +970,14 @@ static void* hw_get_proc_address(const char *symbol) {
 }
 
 /// Tears down the emu thread's FBO and associated GL objects.
+/// Must be called while hardware_context is still valid and current.
 - (void)destroyEmuThreadFBO {
+    if (_emuThreadFBO == 0 && _emuThreadColorTexture == 0 && _emuThreadDepthRenderbuffer == 0) {
+        return;
+    }
+
+    [self makeGLContextCurrent];
+
     if (_emuThreadDepthRenderbuffer > 0) {
         glDeleteRenderbuffers(1, &_emuThreadDepthRenderbuffer);
         _emuThreadDepthRenderbuffer = 0;

--- a/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroGLESCore.m
+++ b/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroGLESCore.m
@@ -358,7 +358,9 @@ static bool video_driver_cached_frame(void)
 
         [NSThread detachNewThreadSelector:@selector(runGLESEmuThread) toTarget:self withObject:nil];
 
-        while (!has_init) {}
+        /// Wait for the emu thread to signal initialization. Also bail early if
+        /// shouldStop is set to avoid spinning forever on early shutdown.
+        while (!has_init && !self.shouldStop) {}
         while ( !self.shouldStop )
         {
             [self.frontBufferCondition lock];
@@ -431,9 +433,14 @@ static bool video_driver_cached_frame(void)
         /// context can be lost if the app was backgrounded/foregrounded
         [self makeGLContextCurrent];
 
-        /// Bind the presentation FBO so the core renders into the IOSurface-backed texture
-        if (_presentationFBO > 0) {
+        /// Bind the presentation FBO so the core renders into the IOSurface-backed texture.
+        /// Use glIsFramebuffer to guard against binding an FBO created in a different
+        /// GL context (FBOs are not shared across EAGLContext sharegroups on iOS).
+        if (_presentationFBO > 0 && glIsFramebuffer(_presentationFBO)) {
             glBindFramebuffer(GL_FRAMEBUFFER, _presentationFBO);
+        } else if (_presentationFBO > 0) {
+            WLOG(@"Presentation FBO %u is not valid in the current GL context — falling back to default framebuffer", _presentationFBO);
+            glBindFramebuffer(GL_FRAMEBUFFER, 0);
         }
 
         if (core->retro_run)
@@ -450,7 +457,11 @@ static bool video_driver_cached_frame(void)
     /// Wait for the render thread to fully exit before tearing down GL resources.
     /// This prevents races where the render thread is mid-frame in
     /// video_driver_cached_frame() or swapBuffers while we destroy the context.
-    dispatch_semaphore_wait(_renderThreadExitSemaphore, dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC));
+    long renderThreadWaitResult = dispatch_semaphore_wait(_renderThreadExitSemaphore,
+                                      dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC));
+    if (renderThreadWaitResult != 0) {
+        WLOG(@"Render thread did not exit within 2s — proceeding with context teardown anyway (may race)");
+    }
 
     /// Tear down HW context on the emu thread that owns it, before signaling exit.
     [self contextDestroy];
@@ -757,7 +768,7 @@ static void* hw_get_proc_address(const char *symbol) {
         case RETRO_HW_CONTEXT_OPENGL:
         case RETRO_HW_CONTEXT_OPENGL_CORE:
             [self makeGLContextCurrent];
-            if (_presentationFBO > 0) {
+            if (_presentationFBO > 0 && glIsFramebuffer(_presentationFBO)) {
                 glBindFramebuffer(GL_FRAMEBUFFER, _presentationFBO);
             }
             break;
@@ -799,12 +810,12 @@ static void* hw_get_proc_address(const char *symbol) {
         case RETRO_HW_CONTEXT_OPENGLES_VERSION:
         case RETRO_HW_CONTEXT_OPENGL:
         case RETRO_HW_CONTEXT_OPENGL_CORE: {
-            if (_presentationFBO > 0) {
+            if (_presentationFBO > 0 && glIsFramebuffer(_presentationFBO)) {
                 return (uintptr_t)_presentationFBO;
             }
             /// Fallback: try to capture FBO from the render delegate on demand
             [self captureRenderDelegateFBO];
-            if (_presentationFBO > 0) {
+            if (_presentationFBO > 0 && glIsFramebuffer(_presentationFBO)) {
                 return (uintptr_t)_presentationFBO;
             }
             /// Last resort: return currently bound FBO

--- a/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroGLESCore.m
+++ b/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroGLESCore.m
@@ -76,8 +76,12 @@ extern void MakeCurrentThreadRealTime(void);
     /// Tracks whether context_reset has been deferred until FBO is ready
     BOOL _pendingContextReset;
 
-    /// FBO name provided by the render delegate (IOSurface-backed)
-    GLuint _presentationFBO;
+    /// FBO + texture created in hardware_context (emu thread) backed by the
+    /// same IOSurface as the render delegate. GL FBOs are per-context so
+    /// we must create our own rather than reusing the delegate's FBO name.
+    GLuint _emuThreadFBO;
+    GLuint _emuThreadColorTexture;
+    GLuint _emuThreadDepthRenderbuffer;
 
 #if !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
     EAGLContext *hardware_context;
@@ -131,7 +135,9 @@ static void* hw_get_proc_address(const char *symbol);
         _coreContextReset = NULL;
         _coreContextDestroy = NULL;
         _pendingContextReset = NO;
-        _presentationFBO = 0;
+        _emuThreadFBO = 0;
+        _emuThreadColorTexture = 0;
+        _emuThreadDepthRenderbuffer = 0;
 
         vulkan_library = NULL;
         vulkan_instance = NULL;
@@ -356,18 +362,15 @@ static bool video_driver_cached_frame(void)
             return;
         }
 
-        /// Capture the presentation FBO that the render delegate just created
-        [self captureRenderDelegateFBO];
-
         /// context_reset is NOT fired here — it must run on the emu thread
         /// because cores assume context_reset and retro_run share the same thread/context.
         /// libretroMain will fire it after making hardware_context current.
 
         [NSThread detachNewThreadSelector:@selector(runGLESEmuThread) toTarget:self withObject:nil];
 
-        /// Wait for the emu thread to signal initialization. Also bail early if
-        /// shouldStop is set to avoid spinning forever on early shutdown.
-        while (!has_init && !self.shouldStop) {}
+        /// Wait for the emu thread to signal initialization. Yield CPU to avoid
+        /// pegging a core at 100%. Bail early if shouldStop is set.
+        while (!has_init && !self.shouldStop) { usleep(1000); }
         while ( !self.shouldStop )
         {
             [self.frontBufferCondition lock];
@@ -378,7 +381,7 @@ static bool video_driver_cached_frame(void)
 
             while ( !self.shouldStop
                    && !video_driver_cached_frame()
-                   ) {}
+                   ) { usleep(500); }
 
             if (!self.shouldStop) {
                 [self swapBuffers];
@@ -415,10 +418,16 @@ static bool video_driver_cached_frame(void)
     /// Make the core's dedicated GL context current on the emu thread
     [self makeGLContextCurrent];
 
+    /// Create the emu thread's own FBO backed by the shared IOSurface.
+    /// GL FBOs are per-context (not shareable across EAGLContexts), so we
+    /// must create our own in hardware_context rather than reusing the
+    /// render delegate's FBO name. The IOSurface bridge gives zero-copy.
+    [self setupEmuThreadFBO];
+
     /// Fire any deferred context_reset on the emu thread — cores assume
     /// context_reset and retro_run share the same thread and GL context.
     if (_pendingContextReset && _coreContextReset) {
-        ILOG(@"Firing deferred context_reset on emu thread (FBO=%u)", _presentationFBO);
+        ILOG(@"Firing deferred context_reset on emu thread (FBO=%u)", _emuThreadFBO);
         [self contextReset];
         _pendingContextReset = NO;
     }
@@ -436,18 +445,12 @@ static bool video_driver_cached_frame(void)
                 break;
         }
 
-        /// Ensure GL context is current before each retro_run() —
-        /// context can be lost if the app was backgrounded/foregrounded
+        /// Ensure GL context is current before each retro_run()
         [self makeGLContextCurrent];
 
-        /// Bind the presentation FBO so the core renders into the IOSurface-backed texture.
-        /// Use glIsFramebuffer to guard against binding an FBO created in a different
-        /// GL context (FBOs are not shared across EAGLContext sharegroups on iOS).
-        if (_presentationFBO > 0 && glIsFramebuffer(_presentationFBO)) {
-            glBindFramebuffer(GL_FRAMEBUFFER, _presentationFBO);
-        } else if (_presentationFBO > 0) {
-            WLOG(@"Presentation FBO %u is not valid in the current GL context — falling back to default framebuffer", _presentationFBO);
-            glBindFramebuffer(GL_FRAMEBUFFER, 0);
+        /// Bind the emu thread's IOSurface-backed FBO
+        if (_emuThreadFBO > 0) {
+            glBindFramebuffer(GL_FRAMEBUFFER, _emuThreadFBO);
         }
 
         if (core->retro_run)
@@ -730,12 +733,13 @@ static bool video_driver_cached_frame(void)
             break;
     }
 
+    [self destroyEmuThreadFBO];
+
     hardware_context_active = NO;
     current_context_type = RETRO_HW_CONTEXT_NONE;
     hw_render_callback = NULL;
     _coreContextReset = NULL;
     _coreContextDestroy = NULL;
-    _presentationFBO = 0;
     _pendingContextReset = NO;
 
     ILOG(@"Hardware context destroyed");
@@ -766,7 +770,7 @@ static void* hw_get_proc_address(const char *symbol) {
 /// Performs frontend housekeeping (make context current, bind FBO) then
 /// invokes the core's stored context_reset so it can create its GL resources.
 - (void)contextReset {
-    ILOG(@"Hardware context reset called (context_type=%d, FBO=%u)", current_context_type, _presentationFBO);
+    ILOG(@"Hardware context reset called (context_type=%d, FBO=%u)", current_context_type, _emuThreadFBO);
 
     switch (current_context_type) {
         case RETRO_HW_CONTEXT_OPENGLES2:
@@ -775,8 +779,8 @@ static void* hw_get_proc_address(const char *symbol) {
         case RETRO_HW_CONTEXT_OPENGL:
         case RETRO_HW_CONTEXT_OPENGL_CORE:
             [self makeGLContextCurrent];
-            if (_presentationFBO > 0 && glIsFramebuffer(_presentationFBO)) {
-                glBindFramebuffer(GL_FRAMEBUFFER, _presentationFBO);
+            if (_emuThreadFBO > 0) {
+                glBindFramebuffer(GL_FRAMEBUFFER, _emuThreadFBO);
             }
             break;
 
@@ -807,9 +811,9 @@ static void* hw_get_proc_address(const char *symbol) {
     [self destroyHardwareContext];
 }
 
-/// Returns the FBO the core should render into. For GL paths this is the
-/// IOSurface-backed FBO created by PVMetalViewController, which is then
-/// blitted to a Metal texture for display (zero-copy via IOSurface).
+/// Returns the FBO the core should render into. This is an FBO created in
+/// hardware_context (emu thread) backed by the shared IOSurface, so the
+/// rendered pixels are zero-copy visible to the Metal display path.
 - (uintptr_t)getCurrentFramebuffer {
     switch (current_context_type) {
         case RETRO_HW_CONTEXT_OPENGLES2:
@@ -817,18 +821,14 @@ static void* hw_get_proc_address(const char *symbol) {
         case RETRO_HW_CONTEXT_OPENGLES_VERSION:
         case RETRO_HW_CONTEXT_OPENGL:
         case RETRO_HW_CONTEXT_OPENGL_CORE: {
-            if (_presentationFBO > 0 && glIsFramebuffer(_presentationFBO)) {
-                return (uintptr_t)_presentationFBO;
+            if (_emuThreadFBO > 0) {
+                return (uintptr_t)_emuThreadFBO;
             }
-            /// Fallback: try to capture FBO from the render delegate on demand
-            [self captureRenderDelegateFBO];
-            if (_presentationFBO > 0 && glIsFramebuffer(_presentationFBO)) {
-                return (uintptr_t)_presentationFBO;
+            [self setupEmuThreadFBO];
+            if (_emuThreadFBO > 0) {
+                return (uintptr_t)_emuThreadFBO;
             }
-            /// Last resort: return currently bound FBO
-            GLint framebuffer;
-            glGetIntegerv(GL_FRAMEBUFFER_BINDING, &framebuffer);
-            return (uintptr_t)framebuffer;
+            return 0;
         }
 
         case RETRO_HW_CONTEXT_VULKAN:
@@ -859,26 +859,97 @@ static void* hw_get_proc_address(const char *symbol) {
 #endif
 }
 
-/// Captures the presentation FBO from the render delegate.
-/// PVMetalViewController exposes this through the presentationFramebuffer property.
-- (void)captureRenderDelegateFBO {
-    if ([self.renderDelegate respondsToSelector:@selector(presentationFramebuffer)]) {
-        id fbo = [self.renderDelegate presentationFramebuffer];
-        if (fbo) {
-            _presentationFBO = (GLuint)[fbo unsignedIntValue];
-            ILOG(@"Captured presentation FBO from render delegate: %u", _presentationFBO);
-            return;
+/// Creates an FBO in the emu thread's hardware_context backed by the render
+/// delegate's IOSurface. GL FBO names are per-context, so we cannot reuse
+/// the delegate's FBO — but IOSurface is an OS-level shared resource, and
+/// textures created from it via texImageIOSurface are visible across
+/// sharegroup-linked EAGLContexts.
+- (void)setupEmuThreadFBO {
+#if !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
+    if (_emuThreadFBO > 0) return;
+
+    IOSurfaceRef surface = NULL;
+    CGSize surfaceSize = CGSizeZero;
+
+    if ([self.renderDelegate respondsToSelector:@selector(renderIOSurface)]) {
+        surface = [self.renderDelegate renderIOSurface];
+    }
+    if ([self.renderDelegate respondsToSelector:@selector(renderIOSurfaceSize)]) {
+        surfaceSize = [self.renderDelegate renderIOSurfaceSize];
+    }
+
+    if (!surface || surfaceSize.width <= 0 || surfaceSize.height <= 0) {
+        ELOG(@"Cannot create emu thread FBO: no IOSurface from render delegate");
+        return;
+    }
+
+    GLint width = (GLint)surfaceSize.width;
+    GLint height = (GLint)surfaceSize.height;
+
+    [self makeGLContextCurrent];
+
+    glGenTextures(1, &_emuThreadColorTexture);
+    glBindTexture(GL_TEXTURE_2D, _emuThreadColorTexture);
+
+    [EAGLContext.currentContext texImageIOSurface:surface
+                                          target:GL_TEXTURE_2D
+                                  internalFormat:GL_RGBA
+                                           width:(uint32_t)width
+                                          height:(uint32_t)height
+                                          format:GL_RGBA
+                                            type:GL_UNSIGNED_BYTE
+                                           plane:0];
+
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glBindTexture(GL_TEXTURE_2D, 0);
+
+    glGenFramebuffers(1, &_emuThreadFBO);
+    glBindFramebuffer(GL_FRAMEBUFFER, _emuThreadFBO);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                           GL_TEXTURE_2D, _emuThreadColorTexture, 0);
+
+    if (hw_render_callback && hw_render_callback->depth) {
+        glGenRenderbuffers(1, &_emuThreadDepthRenderbuffer);
+        glBindRenderbuffer(GL_RENDERBUFFER, _emuThreadDepthRenderbuffer);
+        GLenum depthFormat = (hw_render_callback->stencil)
+            ? GL_DEPTH24_STENCIL8_OES
+            : GL_DEPTH_COMPONENT16;
+        glRenderbufferStorage(GL_RENDERBUFFER, depthFormat, width, height);
+        glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+                                  GL_RENDERBUFFER, _emuThreadDepthRenderbuffer);
+        if (hw_render_callback->stencil) {
+            glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT,
+                                      GL_RENDERBUFFER, _emuThreadDepthRenderbuffer);
         }
     }
 
-    /// Fallback: read the currently bound FBO (set by startRenderingOnAlternateThread)
-    if (_presentationFBO == 0) {
-        GLint fbo = 0;
-        glGetIntegerv(GL_FRAMEBUFFER_BINDING, &fbo);
-        if (fbo > 0) {
-            _presentationFBO = (GLuint)fbo;
-            ILOG(@"Captured currently bound FBO as presentation FBO: %u", _presentationFBO);
-        }
+    GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+    if (status != GL_FRAMEBUFFER_COMPLETE) {
+        ELOG(@"Emu thread FBO incomplete: 0x%x", status);
+    } else {
+        ILOG(@"Created emu thread FBO %u (%dx%d) backed by shared IOSurface", _emuThreadFBO, width, height);
+    }
+
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+#endif
+}
+
+/// Tears down the emu thread's FBO and associated GL objects.
+- (void)destroyEmuThreadFBO {
+    if (_emuThreadDepthRenderbuffer > 0) {
+        glDeleteRenderbuffers(1, &_emuThreadDepthRenderbuffer);
+        _emuThreadDepthRenderbuffer = 0;
+    }
+    if (_emuThreadColorTexture > 0) {
+        glDeleteTextures(1, &_emuThreadColorTexture);
+        _emuThreadColorTexture = 0;
+    }
+    if (_emuThreadFBO > 0) {
+        glDeleteFramebuffers(1, &_emuThreadFBO);
+        _emuThreadFBO = 0;
     }
 }
 

--- a/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroGLESCore.m
+++ b/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroGLESCore.m
@@ -57,6 +57,9 @@ extern void MakeCurrentThreadRealTime(void);
     dispatch_semaphore_t coreWaitToEndFrameSemaphore;
     dispatch_semaphore_t coreWaitForExitSemaphore;
 
+    /// Signaled when runGLESRenderThread fully exits its loop
+    dispatch_semaphore_t _renderThreadExitSemaphore;
+
     dispatch_queue_t _callbackQueue;
     NSMutableDictionary *_callbackHandlers;
 
@@ -119,6 +122,7 @@ static void* hw_get_proc_address(const char *symbol);
         glesWaitToBeginFrameSemaphore = dispatch_semaphore_create(0);
         coreWaitToEndFrameSemaphore    = dispatch_semaphore_create(0);
         coreWaitForExitSemaphore       = dispatch_semaphore_create(0);
+        _renderThreadExitSemaphore     = dispatch_semaphore_create(0);
 
         hw_render_callback = NULL;
         current_context_type = RETRO_HW_CONTEXT_NONE;
@@ -237,13 +241,16 @@ static void* hw_get_proc_address(const char *symbol);
     self.shouldStop = YES;
     dispatch_semaphore_signal(glesWaitToBeginFrameSemaphore);
 
-    /// Wait for the emu thread to exit — it calls contextDestroy on its
-    /// own thread before signaling, ensuring GL context ownership is safe.
-    dispatch_semaphore_wait(coreWaitForExitSemaphore, DISPATCH_TIME_FOREVER);
-
+    /// Wake the render thread from frontBufferCondition so it can see shouldStop
+    /// and exit. The emu thread waits for the render thread to exit before
+    /// calling contextDestroy, so the render thread must not be blocked here.
     [self.frontBufferCondition lock];
     [self.frontBufferCondition signal];
     [self.frontBufferCondition unlock];
+
+    /// Wait for the emu thread to exit — it waits for the render thread,
+    /// then calls contextDestroy on the emu thread, then signals this.
+    dispatch_semaphore_wait(coreWaitForExitSemaphore, DISPATCH_TIME_FOREVER);
 
     [super stopEmulation];
 }
@@ -358,11 +365,20 @@ static bool video_driver_cached_frame(void)
             while (!self.shouldStop && self.isFrontBufferReady) [self.frontBufferCondition wait];
             [self.frontBufferCondition unlock];
 
+            if (self.shouldStop) break;
+
             while ( !self.shouldStop
                    && !video_driver_cached_frame()
                    ) {}
-            [self swapBuffers];
+
+            if (!self.shouldStop) {
+                [self swapBuffers];
+            }
         }
+
+        /// Signal that the render thread has fully exited its loop.
+        /// The emu thread waits on this before calling contextDestroy.
+        dispatch_semaphore_signal(_renderThreadExitSemaphore);
     }
 }
 
@@ -426,8 +442,17 @@ static bool video_driver_cached_frame(void)
             input_poll();
     } while(!self.shouldStop);
 
+    /// Wake the render thread from any frontBufferCondition wait so it can exit
+    [self.frontBufferCondition lock];
+    [self.frontBufferCondition signal];
+    [self.frontBufferCondition unlock];
+
+    /// Wait for the render thread to fully exit before tearing down GL resources.
+    /// This prevents races where the render thread is mid-frame in
+    /// video_driver_cached_frame() or swapBuffers while we destroy the context.
+    dispatch_semaphore_wait(_renderThreadExitSemaphore, dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC));
+
     /// Tear down HW context on the emu thread that owns it, before signaling exit.
-    /// This ensures no GL context thread-safety races with the render thread.
     [self contextDestroy];
 
     has_init = false;

--- a/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroGLESCore.m
+++ b/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroGLESCore.m
@@ -65,6 +65,11 @@ extern void MakeCurrentThreadRealTime(void);
     enum retro_hw_context_type current_context_type;
     BOOL hardware_context_active;
 
+    /// Core-provided callbacks — stored here because the frontend must not
+    /// overwrite the struct fields the core set (per libretro.h spec).
+    retro_hw_context_reset_t _coreContextReset;
+    retro_hw_context_reset_t _coreContextDestroy;
+
     /// Tracks whether context_reset has been deferred until FBO is ready
     BOOL _pendingContextReset;
 
@@ -103,9 +108,7 @@ void gl_swap() {
     [current swapBuffers];
 }
 
-// Forward declarations for hardware rendering callbacks
-static void hw_context_reset(void);
-static void hw_context_destroy(void);
+// Forward declarations for hardware rendering callbacks (frontend-owned fields)
 static uintptr_t hw_get_current_framebuffer(void);
 static void* hw_get_proc_address(const char *symbol);
 
@@ -121,6 +124,8 @@ static void* hw_get_proc_address(const char *symbol);
         current_context_type = RETRO_HW_CONTEXT_NONE;
         hardware_context_active = NO;
         hardware_context = nil;
+        _coreContextReset = NULL;
+        _coreContextDestroy = NULL;
         _pendingContextReset = NO;
         _presentationFBO = 0;
 
@@ -229,12 +234,6 @@ static void* hw_get_proc_address(const char *symbol);
 - (void)stopEmulation {
     has_init = false;
 
-    /// Call context_destroy before tearing down
-    if (hw_render_callback && hw_render_callback->context_destroy) {
-        [self makeGLContextCurrent];
-        hw_render_callback->context_destroy();
-    }
-
     self.shouldStop = YES;
     dispatch_semaphore_signal(glesWaitToBeginFrameSemaphore);
     dispatch_semaphore_wait(coreWaitForExitSemaphore, DISPATCH_TIME_FOREVER);
@@ -243,7 +242,9 @@ static void* hw_get_proc_address(const char *symbol);
     [self.frontBufferCondition signal];
     [self.frontBufferCondition unlock];
 
-    [self destroyHardwareContext];
+    /// contextDestroy calls the core's context_destroy then cleans up frontend resources
+    [self makeGLContextCurrent];
+    [self contextDestroy];
     [super stopEmulation];
 }
 
@@ -344,11 +345,11 @@ static bool video_driver_cached_frame(void)
         /// Capture the presentation FBO that the render delegate just created
         [self captureRenderDelegateFBO];
 
-        /// Fire any deferred context_reset now that the FBO is ready
-        if (_pendingContextReset && hw_render_callback && hw_render_callback->context_reset) {
+        /// Fire any deferred context_reset now that the FBO is ready.
+        /// This calls the core's stored context_reset after frontend setup.
+        if (_pendingContextReset && _coreContextReset) {
             ILOG(@"Firing deferred context_reset now that FBO is ready (FBO=%u)", _presentationFBO);
-            [self makeGLContextCurrent];
-            hw_render_callback->context_reset();
+            [self contextReset];
             _pendingContextReset = NO;
         }
 
@@ -433,9 +434,11 @@ static bool video_driver_cached_frame(void)
 #pragma mark - Hardware Rendering Support
 
 /// Called from the environment callback when a core requests hardware rendering.
-/// Sets up the GL/Vulkan context and wires the libretro callback pointers.
-/// context_reset is deferred until the render delegate has created the FBO
-/// (happens in runGLESRenderThread after startRenderingOnAlternateThread).
+/// Per libretro.h, context_reset and context_destroy are set by the core and
+/// invoked by the frontend — we must NOT overwrite them. We store the core's
+/// callbacks and only set the frontend-owned fields (get_current_framebuffer,
+/// get_proc_address). The core's context_reset is deferred until the render
+/// delegate creates the FBO (in runGLESRenderThread).
 - (BOOL)setHardwareRenderCallback:(NSValue *)callbackValue {
     if (!callbackValue) {
         ELOG(@"Hardware render callback value is NULL");
@@ -456,8 +459,11 @@ static bool video_driver_cached_frame(void)
          hw_render_callback->stencil,
          hw_render_callback->bottom_left_origin);
 
-    hw_render_callback->context_reset = hw_context_reset;
-    hw_render_callback->context_destroy = hw_context_destroy;
+    /// Store core-provided callbacks before touching the struct
+    _coreContextReset = hw_render_callback->context_reset;
+    _coreContextDestroy = hw_render_callback->context_destroy;
+
+    /// Only set the fields the frontend is responsible for providing
     hw_render_callback->get_current_framebuffer = hw_get_current_framebuffer;
     hw_render_callback->get_proc_address = (retro_hw_get_proc_address_t)hw_get_proc_address;
 
@@ -676,6 +682,8 @@ static bool video_driver_cached_frame(void)
     hardware_context_active = NO;
     current_context_type = RETRO_HW_CONTEXT_NONE;
     hw_render_callback = NULL;
+    _coreContextReset = NULL;
+    _coreContextDestroy = NULL;
     _presentationFBO = 0;
     _pendingContextReset = NO;
 
@@ -684,23 +692,7 @@ static bool video_driver_cached_frame(void)
 
 #pragma mark - Hardware Rendering Callbacks
 
-// C callback functions that libretro will call
-static void hw_context_reset(void) {
-    GET_CURRENT_OR_RETURN();
-    if ([current isKindOfClass:[PVLibRetroGLESCoreBridge class]]) {
-        PVLibRetroGLESCoreBridge *glesCore = (PVLibRetroGLESCoreBridge *)current;
-        [glesCore contextReset];
-    }
-}
-
-static void hw_context_destroy(void) {
-    GET_CURRENT_OR_RETURN();
-    if ([current isKindOfClass:[PVLibRetroGLESCoreBridge class]]) {
-        PVLibRetroGLESCoreBridge *glesCore = (PVLibRetroGLESCoreBridge *)current;
-        [glesCore contextDestroy];
-    }
-}
-
+// C callback functions set on the hw_render_callback struct (frontend-owned)
 static uintptr_t hw_get_current_framebuffer(void) {
     GET_CURRENT_OR_RETURN(0);
     if ([current isKindOfClass:[PVLibRetroGLESCoreBridge class]]) {
@@ -720,7 +712,8 @@ static void* hw_get_proc_address(const char *symbol) {
 }
 
 /// Called when the GL/Vulkan context has been created or recreated.
-/// Makes the context current and binds the presentation FBO.
+/// Performs frontend housekeeping (make context current, bind FBO) then
+/// invokes the core's stored context_reset so it can create its GL resources.
 - (void)contextReset {
     ILOG(@"Hardware context reset called (context_type=%d, FBO=%u)", current_context_type, _presentationFBO);
 
@@ -743,10 +736,23 @@ static void* hw_get_proc_address(const char *symbol) {
         default:
             break;
     }
+
+    /// Invoke the core's context_reset so it can initialize its GL/Vulkan resources
+    if (_coreContextReset) {
+        ILOG(@"Invoking core's context_reset callback");
+        _coreContextReset();
+    }
 }
 
+/// Invokes the core's context_destroy callback then tears down frontend resources.
 - (void)contextDestroy {
     ILOG(@"Hardware context destroy called");
+
+    if (_coreContextDestroy) {
+        ILOG(@"Invoking core's context_destroy callback");
+        _coreContextDestroy();
+    }
+
     [self destroyHardwareContext];
 }
 

--- a/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroGLESCore.m
+++ b/PVCoreBridgeRetro/Sources/PVLibRetro/PVLibRetroGLESCore.m
@@ -60,10 +60,16 @@ extern void MakeCurrentThreadRealTime(void);
     dispatch_queue_t _callbackQueue;
     NSMutableDictionary *_callbackHandlers;
 
-    // Hardware rendering state
+    /// Hardware rendering state
     struct retro_hw_render_callback *hw_render_callback;
     enum retro_hw_context_type current_context_type;
     BOOL hardware_context_active;
+
+    /// Tracks whether context_reset has been deferred until FBO is ready
+    BOOL _pendingContextReset;
+
+    /// FBO name provided by the render delegate (IOSurface-backed)
+    GLuint _presentationFBO;
 
 #if !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
     EAGLContext *hardware_context;
@@ -111,20 +117,19 @@ static void* hw_get_proc_address(const char *symbol);
         coreWaitToEndFrameSemaphore    = dispatch_semaphore_create(0);
         coreWaitForExitSemaphore       = dispatch_semaphore_create(0);
 
-        // Initialize hardware rendering state
         hw_render_callback = NULL;
         current_context_type = RETRO_HW_CONTEXT_NONE;
         hardware_context_active = NO;
         hardware_context = nil;
+        _pendingContextReset = NO;
+        _presentationFBO = 0;
 
-        // Initialize Vulkan state
         vulkan_library = NULL;
         vulkan_instance = NULL;
         vulkan_device = NULL;
         vulkan_queue = NULL;
         vulkan_physical_device = NULL;
 
-        // Initialize Vulkan function pointers
         vkGetInstanceProcAddr = NULL;
         vkGetDeviceProcAddr = NULL;
         vkCreateInstance = NULL;
@@ -224,6 +229,12 @@ static void* hw_get_proc_address(const char *symbol);
 - (void)stopEmulation {
     has_init = false;
 
+    /// Call context_destroy before tearing down
+    if (hw_render_callback && hw_render_callback->context_destroy) {
+        [self makeGLContextCurrent];
+        hw_render_callback->context_destroy();
+    }
+
     self.shouldStop = YES;
     dispatch_semaphore_signal(glesWaitToBeginFrameSemaphore);
     dispatch_semaphore_wait(coreWaitForExitSemaphore, DISPATCH_TIME_FOREVER);
@@ -232,6 +243,7 @@ static void* hw_get_proc_address(const char *symbol);
     [self.frontBufferCondition signal];
     [self.frontBufferCondition unlock];
 
+    [self destroyHardwareContext];
     [super stopEmulation];
 }
 
@@ -325,16 +337,22 @@ static bool video_driver_cached_frame(void)
     @autoreleasepool
     {
         [[NSThread currentThread] setName:@"runGLESRenderThread"];
-        [self.renderDelegate startRenderingOnAlternateThread];
-//        BOOL success = gles_init();
-//        assert(success);
-#if !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
-    EAGLContext* context = [self bestContext];
-    ILOG(@"%i", context.API);
-#endif
-        [NSThread detachNewThreadSelector:@selector(runGLESEmuThread) toTarget:self withObject:nil];
 
-//        CFAbsoluteTime lastTime = CFAbsoluteTimeGetCurrent();
+        /// Ask the render delegate to create the IOSurface-backed FBO and GL contexts
+        [self.renderDelegate startRenderingOnAlternateThread];
+
+        /// Capture the presentation FBO that the render delegate just created
+        [self captureRenderDelegateFBO];
+
+        /// Fire any deferred context_reset now that the FBO is ready
+        if (_pendingContextReset && hw_render_callback && hw_render_callback->context_reset) {
+            ILOG(@"Firing deferred context_reset now that FBO is ready (FBO=%u)", _presentationFBO);
+            [self makeGLContextCurrent];
+            hw_render_callback->context_reset();
+            _pendingContextReset = NO;
+        }
+
+        [NSThread detachNewThreadSelector:@selector(runGLESEmuThread) toTarget:self withObject:nil];
 
         while (!has_init) {}
         while ( !self.shouldStop )
@@ -343,14 +361,10 @@ static bool video_driver_cached_frame(void)
             while (!self.shouldStop && self.isFrontBufferReady) [self.frontBufferCondition wait];
             [self.frontBufferCondition unlock];
 
-//            CFAbsoluteTime now = CFAbsoluteTimeGetCurrent();
-//            CFTimeInterval deltaTime = now - lastTime;
             while ( !self.shouldStop
                    && !video_driver_cached_frame()
-//                   && core_poll()
                    ) {}
             [self swapBuffers];
-//            lastTime = now;
         }
     }
 }
@@ -376,9 +390,10 @@ static bool video_driver_cached_frame(void)
 
     MakeCurrentThreadRealTime();
 
-//    [self.renderDelegate startRenderingOnAlternateThread];
-    has_init = true;
+    /// Make the GL context current on the emu thread so retro_run() can issue GL calls
+    [self makeGLContextCurrent];
 
+    has_init = true;
 
     do {
         switch (self->core_poll_type)
@@ -390,6 +405,16 @@ static bool video_driver_cached_frame(void)
                 core_input_polled = false;
                 break;
         }
+
+        /// Ensure GL context is current before each retro_run() —
+        /// context can be lost if the app was backgrounded/foregrounded
+        [self makeGLContextCurrent];
+
+        /// Bind the presentation FBO so the core renders into the IOSurface-backed texture
+        if (_presentationFBO > 0) {
+            glBindFramebuffer(GL_FRAMEBUFFER, _presentationFBO);
+        }
+
         if (core->retro_run)
             core->retro_run();
         if (core_poll_type == POLL_TYPE_LATE && !core_input_polled)
@@ -407,6 +432,10 @@ static bool video_driver_cached_frame(void)
 
 #pragma mark - Hardware Rendering Support
 
+/// Called from the environment callback when a core requests hardware rendering.
+/// Sets up the GL/Vulkan context and wires the libretro callback pointers.
+/// context_reset is deferred until the render delegate has created the FBO
+/// (happens in runGLESRenderThread after startRenderingOnAlternateThread).
 - (BOOL)setHardwareRenderCallback:(NSValue *)callbackValue {
     if (!callbackValue) {
         ELOG(@"Hardware render callback value is NULL");
@@ -421,24 +450,25 @@ static bool video_driver_cached_frame(void)
 
     current_context_type = hw_render_callback->context_type;
 
-    ILOG(@"Libretro core requesting hardware context type: %d", current_context_type);
+    ILOG(@"Libretro core requesting hardware context type: %d (depth=%d, stencil=%d, bottom_left=%d)",
+         current_context_type,
+         hw_render_callback->depth,
+         hw_render_callback->stencil,
+         hw_render_callback->bottom_left_origin);
 
-    // Set up the callback functions that libretro will call
     hw_render_callback->context_reset = hw_context_reset;
     hw_render_callback->context_destroy = hw_context_destroy;
     hw_render_callback->get_current_framebuffer = hw_get_current_framebuffer;
     hw_render_callback->get_proc_address = (retro_hw_get_proc_address_t)hw_get_proc_address;
 
-    ILOG(@"Hardware rendering callback set for context type: %d", current_context_type);
-
-    // Setup the appropriate hardware context
     [self setupHardwareContext:current_context_type];
 
-    // If context was successfully set up, call context_reset to initialize it
-    // This allows the core to set up its OpenGL state
-    if (hardware_context_active && hw_render_callback && hw_render_callback->context_reset) {
-        ILOG(@"Calling context_reset callback to initialize hardware context");
-        hw_render_callback->context_reset();
+    /// Defer context_reset: the FBO doesn't exist yet because
+    /// startRenderingOnAlternateThread hasn't run.
+    /// runGLESRenderThread will fire context_reset after the FBO is ready.
+    if (hardware_context_active) {
+        _pendingContextReset = YES;
+        ILOG(@"Hardware context created; context_reset deferred until FBO is ready");
     }
 
     return YES;
@@ -477,6 +507,9 @@ static bool video_driver_cached_frame(void)
     }
 }
 
+/// Creates an EAGLContext for the requested GL ES version. If the render
+/// delegate already has a GL context, share its sharegroup so the core's
+/// GL objects are visible to the IOSurface-backed FBO context.
 - (void)setupOpenGLESContext:(enum retro_hw_context_type)contextType {
 #if !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
     EAGLRenderingAPI api;
@@ -496,10 +529,27 @@ static bool video_driver_cached_frame(void)
 
     ILOG(@"Attempting to create OpenGL ES context with API: %ld", (long)api);
 
-    hardware_context = [[EAGLContext alloc] initWithAPI:api];
+    /// Try to share the render delegate's GL sharegroup so the core
+    /// can render directly into the IOSurface-backed FBO
+    EAGLContext *delegateContext = nil;
+    if ([self.renderDelegate respondsToSelector:@selector(glContext)]) {
+        delegateContext = [self.renderDelegate glContext];
+    }
+
+    if (delegateContext) {
+        hardware_context = [[EAGLContext alloc] initWithAPI:api
+                                                sharegroup:delegateContext.sharegroup];
+        if (hardware_context) {
+            ILOG(@"Created shared GL ES context with render delegate sharegroup");
+        }
+    }
+
+    if (!hardware_context) {
+        hardware_context = [[EAGLContext alloc] initWithAPI:api];
+    }
+
     if (!hardware_context) {
         ELOG(@"Failed to create OpenGL ES context for API: %ld", (long)api);
-        ELOG(@"This will cause hardware rendering to fail and fall back to software");
         return;
     }
 
@@ -605,11 +655,15 @@ static bool video_driver_cached_frame(void)
         case RETRO_HW_CONTEXT_OPENGLES_VERSION:
         case RETRO_HW_CONTEXT_OPENGL:
         case RETRO_HW_CONTEXT_OPENGL_CORE:
+#if !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
+            if ([EAGLContext currentContext] == hardware_context) {
+                [EAGLContext setCurrentContext:nil];
+            }
+#endif
             hardware_context = nil;
             break;
 
         case RETRO_HW_CONTEXT_VULKAN:
-            // Clean up Vulkan resources
             [self destroyVulkanDevice];
             [self destroyVulkanInstance];
             [self unloadMoltenVKLibrary];
@@ -622,6 +676,8 @@ static bool video_driver_cached_frame(void)
     hardware_context_active = NO;
     current_context_type = RETRO_HW_CONTEXT_NONE;
     hw_render_callback = NULL;
+    _presentationFBO = 0;
+    _pendingContextReset = NO;
 
     ILOG(@"Hardware context destroyed");
 }
@@ -663,32 +719,24 @@ static void* hw_get_proc_address(const char *symbol) {
     return NULL;
 }
 
-// Objective-C implementations of the callback methods
+/// Called when the GL/Vulkan context has been created or recreated.
+/// Makes the context current and binds the presentation FBO.
 - (void)contextReset {
-    ILOG(@"Hardware context reset called");
+    ILOG(@"Hardware context reset called (context_type=%d, FBO=%u)", current_context_type, _presentationFBO);
 
     switch (current_context_type) {
         case RETRO_HW_CONTEXT_OPENGLES2:
         case RETRO_HW_CONTEXT_OPENGLES3:
         case RETRO_HW_CONTEXT_OPENGLES_VERSION:
-#if !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
-            if (hardware_context) {
-                [EAGLContext setCurrentContext:hardware_context];
-            }
-#endif
-            break;
-
         case RETRO_HW_CONTEXT_OPENGL:
         case RETRO_HW_CONTEXT_OPENGL_CORE:
-#if TARGET_OS_MACCATALYST || TARGET_OS_OSX
-            if (hardware_context) {
-                [hardware_context makeCurrentContext];
+            [self makeGLContextCurrent];
+            if (_presentationFBO > 0) {
+                glBindFramebuffer(GL_FRAMEBUFFER, _presentationFBO);
             }
-#endif
             break;
 
         case RETRO_HW_CONTEXT_VULKAN:
-            // Vulkan context reset would involve recreating command buffers, etc.
             ILOG(@"Vulkan context reset");
             break;
 
@@ -702,31 +750,89 @@ static void* hw_get_proc_address(const char *symbol) {
     [self destroyHardwareContext];
 }
 
+/// Returns the FBO the core should render into. For GL paths this is the
+/// IOSurface-backed FBO created by PVMetalViewController, which is then
+/// blitted to a Metal texture for display (zero-copy via IOSurface).
 - (uintptr_t)getCurrentFramebuffer {
-    // Return the current framebuffer object name
-    // For OpenGL ES/OpenGL, this would be the FBO name
-    // For Vulkan, this would be handled differently
-
     switch (current_context_type) {
         case RETRO_HW_CONTEXT_OPENGLES2:
         case RETRO_HW_CONTEXT_OPENGLES3:
         case RETRO_HW_CONTEXT_OPENGLES_VERSION:
         case RETRO_HW_CONTEXT_OPENGL:
         case RETRO_HW_CONTEXT_OPENGL_CORE: {
+            if (_presentationFBO > 0) {
+                return (uintptr_t)_presentationFBO;
+            }
+            /// Fallback: try to capture FBO from the render delegate on demand
+            [self captureRenderDelegateFBO];
+            if (_presentationFBO > 0) {
+                return (uintptr_t)_presentationFBO;
+            }
+            /// Last resort: return currently bound FBO
             GLint framebuffer;
             glGetIntegerv(GL_FRAMEBUFFER_BINDING, &framebuffer);
             return (uintptr_t)framebuffer;
         }
 
         case RETRO_HW_CONTEXT_VULKAN:
-            // For Vulkan, return appropriate render target handle
-            return 0; // TODO: Implement Vulkan framebuffer handling
+            return 0; // TODO: Implement Vulkan framebuffer handling (#2634)
 
         default:
             return 0;
     }
 }
 
+#pragma mark - GL Context Helpers
+
+/// Makes the hardware GL context current on the calling thread.
+/// For iOS/tvOS this uses the alternateThreadGLContext from the render delegate
+/// (which shares the same sharegroup as the IOSurface-backed FBO context).
+- (void)makeGLContextCurrent {
+#if !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
+    EAGLContext *ctx = nil;
+    if ([self.renderDelegate respondsToSelector:@selector(alternateThreadGLContext)]) {
+        ctx = [self.renderDelegate alternateThreadGLContext];
+    }
+    if (!ctx) {
+        ctx = hardware_context;
+    }
+    if (ctx && [EAGLContext currentContext] != ctx) {
+        [EAGLContext setCurrentContext:ctx];
+    }
+#else
+    NSOpenGLContext *ctx = hardware_context;
+    if (ctx) {
+        [ctx makeCurrentContext];
+    }
+#endif
+}
+
+/// Captures the presentation FBO from the render delegate.
+/// PVMetalViewController exposes this through the presentationFramebuffer property.
+- (void)captureRenderDelegateFBO {
+    if ([self.renderDelegate respondsToSelector:@selector(presentationFramebuffer)]) {
+        id fbo = [self.renderDelegate presentationFramebuffer];
+        if (fbo) {
+            _presentationFBO = (GLuint)[fbo unsignedIntValue];
+            ILOG(@"Captured presentation FBO from render delegate: %u", _presentationFBO);
+            return;
+        }
+    }
+
+    /// Fallback: read the currently bound FBO (set by startRenderingOnAlternateThread)
+    if (_presentationFBO == 0) {
+        GLint fbo = 0;
+        glGetIntegerv(GL_FRAMEBUFFER_BINDING, &fbo);
+        if (fbo > 0) {
+            _presentationFBO = (GLuint)fbo;
+            ILOG(@"Captured currently bound FBO as presentation FBO: %u", _presentationFBO);
+        }
+    }
+}
+
+/// Returns function pointers for the active rendering API.
+/// For GL ES: statically linked symbols via dlsym.
+/// For Vulkan: routes through vkGetInstanceProcAddr / vkGetDeviceProcAddr.
 - (void*)getProcAddress:(const char*)symbol {
     if (!symbol) {
         return NULL;
@@ -736,24 +842,25 @@ static void* hw_get_proc_address(const char *symbol) {
         case RETRO_HW_CONTEXT_OPENGLES2:
         case RETRO_HW_CONTEXT_OPENGLES3:
         case RETRO_HW_CONTEXT_OPENGLES_VERSION:
-#if !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
-            // On iOS, OpenGL ES functions are statically linked
-            return dlsym(RTLD_DEFAULT, symbol);
-#endif
-            break;
-
         case RETRO_HW_CONTEXT_OPENGL:
         case RETRO_HW_CONTEXT_OPENGL_CORE:
-#if TARGET_OS_MACCATALYST || TARGET_OS_OSX
-            // On macOS, use NSOpenGLContext to get function pointers
             return dlsym(RTLD_DEFAULT, symbol);
-#endif
-            break;
 
         case RETRO_HW_CONTEXT_VULKAN:
-            // For Vulkan, we'd need to use vkGetInstanceProcAddr or vkGetDeviceProcAddr
-            ILOG(@"Vulkan proc address requested: %s", symbol);
-            return NULL; // TODO: Implement Vulkan function loading
+            if (vkGetDeviceProcAddr && vulkan_device) {
+                PFN_vkVoidFunction fn = vkGetDeviceProcAddr(vulkan_device, symbol);
+                if (fn) return (void *)fn;
+            }
+            if (vkGetInstanceProcAddr && vulkan_instance) {
+                PFN_vkVoidFunction fn = vkGetInstanceProcAddr(vulkan_instance, symbol);
+                if (fn) return (void *)fn;
+            }
+            if (vkGetInstanceProcAddr) {
+                PFN_vkVoidFunction fn = vkGetInstanceProcAddr(NULL, symbol);
+                if (fn) return (void *)fn;
+            }
+            DLOG(@"Vulkan symbol not found: %s", symbol);
+            return NULL;
 
         default:
             break;

--- a/PVUI/Sources/PVUIBase/PVGLViewController/PVMetalViewController.swift
+++ b/PVUI/Sources/PVUIBase/PVGLViewController/PVMetalViewController.swift
@@ -134,7 +134,14 @@ class PVMetalViewController : PVGPUViewController, PVRenderDelegate, MTKViewDele
         }
     }
 
-    var presentationFramebuffer: AnyObject? = nil
+    /// The IOSurface-backed FBO that HW-accelerated cores render into.
+    /// Wrapped as NSNumber so ObjC callers can extract the GLuint via -unsignedIntValue.
+    var presentationFramebuffer: AnyObject? {
+        get {
+            guard alternateThreadFramebufferBack > 0 else { return nil }
+            return NSNumber(value: alternateThreadFramebufferBack) as AnyObject
+        }
+    }
 
     weak var emulatorCore: PVEmulatorCore?
 

--- a/PVUI/Sources/PVUIBase/PVGLViewController/PVMetalViewController.swift
+++ b/PVUI/Sources/PVUIBase/PVGLViewController/PVMetalViewController.swift
@@ -81,7 +81,7 @@ enum EffectFilterShaderError: Error {
 
 // MARK: - PVMetalViewController
 final
-class PVMetalViewController : PVGPUViewController, PVRenderDelegate, PVRenderDelegateIOSurface, MTKViewDelegate {
+class PVMetalViewController : PVGPUViewController, PVRenderDelegate, MTKViewDelegate {
     func setPreferredRefreshRate(_ rate: Float) {
         ILOG("Setting preferred refresh rate to \(rate) Hz")
 
@@ -143,20 +143,6 @@ class PVMetalViewController : PVGPUViewController, PVRenderDelegate, PVRenderDel
             guard alternateThreadFramebufferBack > 0 else { return nil }
             return NSNumber(value: alternateThreadFramebufferBack) as AnyObject
         }
-    }
-
-    /// The IOSurface backing the GL→Metal shared texture. Other EAGLContexts
-    /// can create their own textures/FBOs backed by this same IOSurface for
-    /// zero-copy rendering into the Metal display path.
-    var renderIOSurface: IOSurfaceRef? {
-        return backingIOSurface
-    }
-
-    /// Pixel dimensions of the IOSurface-backed render target.
-    var renderIOSurfaceSize: CGSize {
-        guard let surface = backingIOSurface else { return .zero }
-        return CGSize(width: IOSurfaceGetWidth(surface),
-                      height: IOSurfaceGetHeight(surface))
     }
 
     weak var emulatorCore: PVEmulatorCore?
@@ -3397,6 +3383,25 @@ class PVMetalViewController : PVGPUViewController, PVRenderDelegate, PVRenderDel
         }
     }
 }
+
+#if canImport(IOSurface)
+/// PVRenderDelegateIOSurface conformance: exposes the IOSurface backing the
+/// GL→Metal shared texture so that emu-thread GL contexts can create their own
+/// FBO backed by the same IOSurface for zero-copy rendering.
+extension PVMetalViewController: PVRenderDelegateIOSurface {
+    /// The IOSurface backing the GL→Metal shared texture.
+    var renderIOSurface: IOSurfaceRef? {
+        return backingIOSurface
+    }
+
+    /// Pixel dimensions of the IOSurface-backed render target.
+    var renderIOSurfaceSize: CGSize {
+        guard let surface = backingIOSurface else { return .zero }
+        return CGSize(width: IOSurfaceGetWidth(surface),
+                      height: IOSurfaceGetHeight(surface))
+    }
+}
+#endif
 
 /// Error types for Metal view controller operations
 enum MetalViewControllerError: Error {

--- a/PVUI/Sources/PVUIBase/PVGLViewController/PVMetalViewController.swift
+++ b/PVUI/Sources/PVUIBase/PVGLViewController/PVMetalViewController.swift
@@ -81,7 +81,7 @@ enum EffectFilterShaderError: Error {
 
 // MARK: - PVMetalViewController
 final
-class PVMetalViewController : PVGPUViewController, PVRenderDelegate, MTKViewDelegate {
+class PVMetalViewController : PVGPUViewController, PVRenderDelegate, PVRenderDelegateIOSurface, MTKViewDelegate {
     func setPreferredRefreshRate(_ rate: Float) {
         ILOG("Setting preferred refresh rate to \(rate) Hz")
 

--- a/PVUI/Sources/PVUIBase/PVGLViewController/PVMetalViewController.swift
+++ b/PVUI/Sources/PVUIBase/PVGLViewController/PVMetalViewController.swift
@@ -134,13 +134,29 @@ class PVMetalViewController : PVGPUViewController, PVRenderDelegate, MTKViewDele
         }
     }
 
-    /// The IOSurface-backed FBO that HW-accelerated cores render into.
-    /// Wrapped as NSNumber so ObjC callers can extract the GLuint via -unsignedIntValue.
+    /// The IOSurface-backed FBO created by this view controller.
+    /// Note: GL FBO names are per-context and NOT shareable across EAGLContexts.
+    /// Callers on other threads/contexts should use renderIOSurface instead to
+    /// create their own FBO backed by the same IOSurface.
     var presentationFramebuffer: AnyObject? {
         get {
             guard alternateThreadFramebufferBack > 0 else { return nil }
             return NSNumber(value: alternateThreadFramebufferBack) as AnyObject
         }
+    }
+
+    /// The IOSurface backing the GL→Metal shared texture. Other EAGLContexts
+    /// can create their own textures/FBOs backed by this same IOSurface for
+    /// zero-copy rendering into the Metal display path.
+    var renderIOSurface: IOSurfaceRef? {
+        return backingIOSurface
+    }
+
+    /// Pixel dimensions of the IOSurface-backed render target.
+    var renderIOSurfaceSize: CGSize {
+        guard let surface = backingIOSurface else { return .zero }
+        return CGSize(width: IOSurfaceGetWidth(surface),
+                      height: IOSurfaceGetHeight(surface))
     }
 
     weak var emulatorCore: PVEmulatorCore?


### PR DESCRIPTION
Implements the core changes needed for libretro hardware-accelerated rendering (OpenGL ES / Vulkan) in the native bridge:

#2632 [P0] OpenGL ES FBO -> Metal texture blit pipeline:
- getCurrentFramebuffer now returns the IOSurface-backed FBO created by PVMetalViewController (zero-copy GL->Metal via IOSurface)
- PVMetalViewController.presentationFramebuffer changed from nil stub to computed property exposing alternateThreadFramebufferBack
- Added captureRenderDelegateFBO helper with fallback chain

#2633 [P1] Thread-safe GL context lifecycle + retro_run frame loop:
- makeGLContextCurrent sets EAGLContext on emu thread before each retro_run(), preferring the render delegate's alternateThreadGLContext
- context_reset deferred until after startRenderingOnAlternateThread creates the FBO (was firing before FBO existed)
- Presentation FBO bound before each retro_run() call
- Shared EAGLContext sharegroup between core and render delegate
- Proper context_destroy on stopEmulation, EAGLContext cleanup

#2634 [P1] Vulkan getProcAddress now routes through vkGetDeviceProcAddr/vkGetInstanceProcAddr instead of returning NULL

#2635 [P1] Complete environment callback coverage: Added 30+ missing RETRO_ENVIRONMENT_* handlers including:
- GET_PREFERRED_HW_RENDER (OPENGLES3 on iOS/tvOS, OPENGL_CORE on macOS)
- GET_HW_RENDER_INTERFACE (stub for Vulkan)
- SET_HW_RENDER_CONTEXT_NEGOTIATION_INTERFACE
- SET_HW_SHARED_CONTEXT (returns true, uses EAGLContext sharegroups)
- SET_SERIALIZATION_QUIRKS, SET_FRAME_TIME_CALLBACK
- SET_AUDIO_CALLBACK, SET_GEOMETRY, GET_AUDIO_VIDEO_ENABLE
- GET_CORE_OPTIONS_VERSION (v2), SET_CORE_OPTIONS variants
- GET_USERNAME, GET_LANGUAGE, GET_INPUT_BITMASKS
- SHUTDOWN, SET_CONTROLLER_INFO, SET_MEMORY_MAPS, etc.
- Fixed SET_SYSTEM_AV_INFO format string (was using %s for integers)

#2638 [P2] GET_PREFERRED_HW_RENDER returns platform-appropriate context

Refs: #2632, #2633, #2634, #2635, #2637, #2638, #2624

### What does this PR do

### Where should the reviewer start

### How should this be manually tested

### Any background context you want to provide

### What are the relevant tickets

### Screenshots (important for UI changes)

### Questions
