### PR TITLE
[Agent] docs: save state version mismatch tickets and PR tracking

### DIFF
--- a/docs/create-save-state-issues.sh
+++ b/docs/create-save-state-issues.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Create GitHub issues for the save state version mismatch epic.
+# Requires: gh CLI (brew install gh) and authentication (gh auth login)
+#
+# Usage: ./docs/create-save-state-issues.sh
+
+set -e
+REPO="${REPO:-Provenance-EMU/Provenance}"
+LABELS="save-states,core-version,agent-work"
+
+# Master ticket
+gh issue create --repo "$REPO" \
+  --title "[Agent] Save State Version Mismatch Detection & UX" \
+  --label "$LABELS,high-priority" \
+  --body-file - <<'BODY'
+See `docs/save-state-version-mismatch-tickets.md` for full spec.
+
+**Objective:** Introduce a unified flow to check save states against the current core version before load, present clear UI when there is a version mismatch, and allow users to load anyway with an explicit warning.
+
+**Priority:** High (next release)
+BODY
+
+# Sub-tickets can be created similarly; adjust titles and bodies as needed.
+echo "Master issue created. Create sub-issues manually or extend this script."
+echo "Labels to use: $LABELS"

--- a/docs/save-state-version-mismatch-PR.md
+++ b/docs/save-state-version-mismatch-PR.md
@@ -1,0 +1,62 @@
+# Save State Version Mismatch — PR Tracking
+
+**Branch:** `agent/save-state-version-mismatch` (or per-sub-ticket branches)  
+**Target:** `develop`  
+**Labels:** `save-states`, `core-version`, `high-priority`, `[Agent]`  
+**Copilot Review:** Enable via `@github/copilot-review` or existing AI review workflow
+
+---
+
+## PR Strategy
+
+Prefer **small, focused PRs** per sub-ticket for easier review. Use this document to track PRs and ensure all launch paths are covered.
+
+| PR | Sub-Ticket | Description | Status |
+|----|------------|-------------|--------|
+| 1 | #2 | Centralized `SaveStateVersionChecker` + alert flow | Pending |
+| 2 | #1 | Add `createdWithCoreVersion` to view models & DTOs | Pending |
+| 3 | #3 | Integrate version check into all launch paths | Pending |
+| 4 | #4 | Reset game investigation (PicoDrive / general) | Pending |
+| 5 | #6 | Wiki page + in-app link | Pending |
+| 6 | #5 | Save state porting research (optional) | Pending |
+
+---
+
+## PR Template Additions
+
+When opening PRs for this epic, include:
+
+### What does this PR do
+
+[Link to sub-ticket from `docs/save-state-version-mismatch-tickets.md`]
+
+### Relevant tickets
+
+- Master: Save State Version Mismatch Detection & UX
+- Sub-ticket: [number and title]
+
+### Tags / Labels to Apply
+
+- `save-states`
+- `core-version`
+- `high-priority` (for master/launch-path PRs)
+- `agent-work` (if from agent)
+- `[Agent]` in PR title for AI review trigger
+
+---
+
+## Copilot / AI Review
+
+- PRs from `agent/**` branches with `[Agent]` in title trigger `ai-review.yml` (see `.github/workflows/ai-review-trigger.yml`)
+- Ensure `@github/copilot-review` or equivalent is enabled for the repo if using Copilot for PR review
+- Reviewers: Check that version check is non-blocking (user can "Load Anyway") and that all launch paths are covered
+
+---
+
+## Checklist Before Merge
+
+- [ ] All affected launch paths have version check or are documented as out of scope
+- [ ] User can load save state after acknowledging version mismatch
+- [ ] No regression: save states with matching version load without extra prompt
+- [ ] SwiftLint passes on changed files
+- [ ] Manual test on iOS and tvOS (or documented as Mac-only validation needed)

--- a/docs/save-state-version-mismatch-tickets.md
+++ b/docs/save-state-version-mismatch-tickets.md
@@ -1,0 +1,207 @@
+# Save State Version Mismatch — Ticket Set
+
+**Priority:** High (next release)  
+**Labels:** `save-states`, `core-version`, `high-priority`, `agent-work`  
+**Epic:** Save state compatibility across core updates
+
+## Background
+
+When emulator cores are updated, save states may become incompatible. Recent PicoDrive updates have caused 32X save states to fail loading, and "Reset Game" does not work when a bad save state is loaded. Core and core version are already tracked in Realm, SwiftData, JSON serialized files, and CloudKit records, but the UI does not consistently check or warn users before loading.
+
+---
+
+## Master Ticket: Save State Version Mismatch Detection & UX
+
+**Labels:** `save-states`, `core-version`, `high-priority`, `agent-work`
+
+### Objective
+
+Introduce a unified flow to check save states against the current core version before load, present clear UI when there is a version mismatch, and allow users to load anyway with an explicit warning that the save may be broken or buggy.
+
+### Acceptance Criteria
+
+- [ ] All save-state launch paths perform a version check before load
+- [ ] Version mismatch shows a clear alert/sheet with option to "Load Anyway" or "Cancel"
+- [ ] User can proceed with load after acknowledging the risk
+- [ ] Wiki/settings link to save state version info when available
+
+### Affected Launch Paths
+
+| Path | File(s) | Current Behavior |
+|------|---------|------------------|
+| In-emulator Save States menu | `PVSaveStatesViewController`, `PVEmulatorViewController+Saves` | Version check exists in `loadSaveState`; shows warning but still loads |
+| ContinuesManagementView | `ContinuesMagementView.swift`, `SaveStateRowView` | No version check; `onLoadSave` goes to parent |
+| RetroSaveStatesStore | `RetroSaveStatesBrowserView.swift` | `openSaveState` → `SceneCoordinator.launchSaveState`; no version check |
+| TVMediaMainView | `TVMediaMainView.swift` | Same as RetroSaveStatesStore |
+| RetroGameLibraryView | `RetroGameLibraryView.swift` | Same store |
+| GameLaunchingViewController | `GameLaunchingViewController.swift` | `openSaveState` loads directly; no version check |
+| Deep link / App open | `ProvenanceApp.swift`, `PVRootViewController` | `openSaveStateID` → launch flow; no version check |
+
+### Data Model Status
+
+- **Realm** `PVSaveState`: `createdWithCoreVersion` ✅
+- **SwiftData** `SaveState_Data`: `createdWithCoreVersion` ✅
+- **CloudKit**: `coreVersion` in schema ✅
+- **PVPrimitives** `SaveState`: No `createdWithCoreVersion` in protocol/struct — needs addition for JSON round-trip
+- **SaveStateRowViewModel** / **RetroSaveStateItem**: No `createdWithCoreVersion` — needs addition for UI checks
+
+---
+
+## Sub-Ticket 1: Add `createdWithCoreVersion` to Save State View Models
+
+**Labels:** `save-states`, `core-version`, `agent-work`
+
+### Objective
+
+Ensure `createdWithCoreVersion` (and optionally `coreIdentifier`) flows from Realm/SwiftData into all view models and DTOs used by save-state UIs.
+
+### Acceptance Criteria
+
+- [ ] `SaveStateRowViewModel` includes `createdWithCoreVersion: String?` and `coreIdentifier: String?`
+- [ ] `RetroSaveStateItem` includes `createdWithCoreVersion: String?` and `coreIdentifier: String?`
+- [ ] `RealmSaveStateDriver` and `RetroSaveStatesStore.mapSaveState` populate these fields
+- [ ] `PVPrimitives.SaveState` and `SaveStateInfoProvider` include `createdWithCoreVersion` for JSON/CloudKit parity
+
+### Affected Modules
+
+- `PVUI` (SaveStateRowViewModel, RealmSaveStateDriver, RetroSaveStatesBrowserView)
+- `PVPrimitives` (SaveState)
+- `PVLibrary` (CloudKit schema already has it)
+
+---
+
+## Sub-Ticket 2: Centralized Version Mismatch Check & Alert Flow
+
+**Labels:** `save-states`, `core-version`, `agent-work`
+
+### Objective
+
+Create a shared service or helper that compares `createdWithCoreVersion` with the current core’s `projectVersion` and presents a consistent alert/sheet before load.
+
+### Acceptance Criteria
+
+- [ ] New helper: `SaveStateVersionChecker` or similar, with `checkAndWarnIfMismatch(saveState:core:onLoad:onCancel:) async -> Bool`
+- [ ] Uses `PVSaveState.createdWithCoreVersion` vs `PVCore.projectVersion`
+- [ ] Presents `RetroAlertState` or equivalent with "Load Anyway" / "Cancel"
+- [ ] Returns whether user chose to proceed
+- [ ] Handles nil/empty `createdWithCoreVersion` (treat as unknown, optional warning)
+
+### Affected Modules
+
+- `PVUI` (new helper, `SceneCoordinator`, `RetroAlertState`)
+
+---
+
+## Sub-Ticket 3: Integrate Version Check into All Save-State Launch Paths
+
+**Labels:** `save-states`, `core-version`, `agent-work`
+
+### Objective
+
+Wire the centralized version check into every path that can load a save state.
+
+### Acceptance Criteria
+
+- [ ] **SceneCoordinator.launchSaveStateWithValidation**: Before launching, call version check; if mismatch and user cancels, abort
+- [ ] **ContinuesManagementView** (onLoadSave): Before calling parent’s load, resolve core and run version check
+- [ ] **PVEmulatorViewController+Saves.loadSaveState**: Already has check; ensure it uses shared helper and allows "Load Anyway"
+- [ ] **GameLaunchingViewController.openSaveState**: Add version check when loading into running game
+- [ ] **RetroSaveStatesStore.openSaveState** → `launchSaveState`: Covered by SceneCoordinator integration
+- [ ] **Deep link** `openSaveStateID`: Covered by SceneCoordinator integration
+
+### Affected Modules
+
+- `PVUI` (SceneCoordinator, ContinuesManagementView, PVEmulatorViewController+Saves, GameLaunchingViewController)
+
+---
+
+## Sub-Ticket 4: Reset Game with Bad Save State (PicoDrive / General)
+
+**Labels:** `save-states`, `reset`, `picodrive`, `agent-work`
+
+### Objective
+
+Investigate why "Reset Game" does not work when a save state fails to load or is incompatible. In theory, reset should boot the game without patching save memory.
+
+### Acceptance Criteria
+
+- [ ] Reproduce reset failure with PicoDrive 32X and incompatible save state
+- [ ] Trace `resetEmulation` flow: `RetroMenuView` → `core.resetEmulation()` → `PVLibRetroCore.resetEmulation` / PicoDrive `retro_reset()`
+- [ ] Determine if the issue is: (a) core state corrupted by failed load, (b) save RAM still patched, (c) core-specific bug
+- [ ] Document findings and implement fix if possible (may be core-specific)
+
+### Notes
+
+- PicoDrive `resetEmulation` calls `retro_reset()` (libretro API)
+- If load state fails mid-way, core may be in inconsistent state; reset might not fully reinitialize
+- Consider: Should we auto-reset or re-load ROM when load state fails?
+
+### Affected Modules
+
+- `PVUI` (RetroMenuView, emulator flow)
+- `Cores/PicoDrive` (PVPicoDriveBridge — do not modify upstream libpicodrive)
+- `PVCoreBridgeRetro` (PVLibRetroCore)
+
+---
+
+## Sub-Ticket 5: Save State Porting / Conversion (Exploratory)
+
+**Labels:** `save-states`, `core-version`, `research`, `agent-work`
+
+### Objective
+
+Explore whether save states can be "ported" to newer core versions, either via core-provided conversion or app-side transformers.
+
+### Acceptance Criteria
+
+- [ ] Survey cores for built-in save state version handling (e.g. Mednafen `load` parameter in `MDFNSS_StateAction`)
+- [ ] Document which cores support versioned save states
+- [ ] If cores expose conversion hooks, design integration point
+- [ ] If not, assess feasibility of app-side transformers from git diffs (low confidence)
+
+### Notes
+
+- Mednafen passes version to `StateAction`; some cores may support backward compatibility
+- App-side transformation is high effort and error-prone; document as future research
+
+---
+
+## Sub-Ticket 6: Wiki & In-App Save State Documentation
+
+**Labels:** `save-states`, `docs`, `wiki`, `agent-work`
+
+### Objective
+
+Add or link to wiki content about save state version mismatches and best practices.
+
+### Acceptance Criteria
+
+- [ ] Create or update page in `provenance-emu/wiki` (e.g. `save-states/version-mismatches.md`)
+- [ ] Content: what version mismatch means, why it happens, how to avoid (create new save after core update), "Load Anyway" risks
+- [ ] In-app wiki browser can link to this page (e.g. from version mismatch alert or Settings)
+- [ ] Wiki content is built into app via existing script/action (see `PVHelp`, `WikiConstants`)
+
+### Notes
+
+- Wiki repo: `Provenance-EMU/wiki` (https://github.com/Provenance-EMU/wiki)
+- App fetches from `https://raw.githubusercontent.com/Provenance-EMU/wiki/master/`
+
+---
+
+## Test Plan (All Tickets)
+
+- [ ] `swift build` passes for affected modules
+- [ ] `swiftlint` reports no new violations
+- [ ] Manual: Launch save state from ContinuesManagementView with version mismatch → see alert, can load anyway
+- [ ] Manual: Launch save state from TVMediaMainView with version mismatch → same
+- [ ] Manual: Launch save state from in-emulator menu with version mismatch → same
+- [ ] Manual: PicoDrive 32X — load old save, try reset → document/fix behavior
+
+---
+
+## Context
+
+- `PVEmulatorViewController+Saves.loadSaveState` (lines 111–121): Existing version check; shows `presentWarning` but still proceeds
+- `PVSaveState.createdWithCoreVersion`, `SaveState_Data.createdWithCoreVersion`, CloudKit `coreVersion`
+- `RetroSaveStatesStore.openSaveState` → `SceneCoordinator.launchSaveState` → `launchSaveStateWithValidation`
+- PicoDrive: `retro_reset()` in `resetEmulation`; `loadSaveFile` for battery saves on ROM load

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -4,7 +4,7 @@ These markdown files are intended to be added to the [Provenance-EMU/wiki](https
 
 ## save-state-version-mismatches.md
 
-Copy to: `info/save-state-version-mismatches.md` (or `info/saves/version-mismatches.md` if you prefer a subfolder).
+Copy to: `info/save-state-version-mismatches.md`. If you prefer to store it in a subfolder (for example, `info/saves/save-state-version-mismatches.md`), be sure to update any related links and URLs (including `SUMMARY.md` entries and the raw/web URLs below) to match the new path.
 
 ### Add to SUMMARY.md (in the wiki repo)
 

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -1,0 +1,29 @@
+# Wiki Content for Provenance-EMU/wiki
+
+These markdown files are intended to be added to the [Provenance-EMU/wiki](https://github.com/Provenance-EMU/wiki) repository.
+
+## save-state-version-mismatches.md
+
+Copy to: `info/save-state-version-mismatches.md` (or `info/saves/version-mismatches.md` if you prefer a subfolder).
+
+### Add to SUMMARY.md (in the wiki repo)
+
+Under the "Using Provenance" section, after the Game Saves entry:
+
+```markdown
+* [Save State Version Mismatches](info/save-state-version-mismatches.md)
+```
+
+Or as a child of Game Saves:
+
+```markdown
+* [Game Saves](info/saves.md)
+  * [Save State Version Mismatches](info/save-state-version-mismatches.md)
+```
+
+### In-App Link
+
+The app can link to this page from the version mismatch alert or Settings. Use:
+
+- Raw URL: `https://raw.githubusercontent.com/Provenance-EMU/wiki/master/info/save-state-version-mismatches.md`
+- Web URL: `https://wiki.provenance-emu.com/info/save-state-version-mismatches`

--- a/docs/wiki/save-state-version-mismatches.md
+++ b/docs/wiki/save-state-version-mismatches.md
@@ -49,7 +49,7 @@ When in doubt, create a new save state with the updated core.
 
 ## Technical Details
 
-- Save states store: `createdWithCoreVersion` (Realm, SwiftData, CloudKit).
+- Save states track the core version they were created with: `createdWithCoreVersion` in Realm/SwiftData (stored in CloudKit as `coreVersion` from `PVSaveState.createdWithCoreVersion`).
 - The app checks this against `core.projectVersion` before load.
 - You can always choose to load anyway; the warning is informational.
 

--- a/docs/wiki/save-state-version-mismatches.md
+++ b/docs/wiki/save-state-version-mismatches.md
@@ -1,0 +1,59 @@
+# Save State Version Mismatches
+
+Save states capture the exact memory and CPU state of an emulator at a moment in time. When an emulator core is updated, the internal format of save states can change. Loading a save state created with an older core version into a newer core (or vice versa) may fail or cause bugs.
+
+## What is a Version Mismatch?
+
+Provenance stores the core version used when each save state was created. When you try to load a save state, the app compares:
+
+- **Save state version:** The core version that created the save
+- **Current core version:** The core version installed on your device
+
+If these differ, you may see a warning before loading.
+
+## Why Does This Happen?
+
+Emulator cores are actively developed. Updates can:
+
+- Change how save state data is serialized
+- Add or remove features that affect saved state
+- Fix bugs that alter memory layout
+
+Save states are **not** designed to be portable across core versions. They are a snapshot of internal state, not a standardized format.
+
+## What Should I Do?
+
+### Before Loading
+
+If you see a version mismatch warning:
+
+1. **Create a new save state** after updating the core — this ensures compatibility.
+2. **Load anyway** only if you understand the save may fail or behave incorrectly.
+3. Consider keeping a backup of important saves before updating cores.
+
+### After a Core Update
+
+1. Start the game fresh (or from a save state made with the new core).
+2. Create a new save state at your desired point.
+3. Old save states may no longer work reliably.
+
+## "Load Anyway" — What Are the Risks?
+
+If you choose to load a save state despite a version mismatch:
+
+- **Load may fail** — The core may reject the file or crash.
+- **Corruption** — The game might run with glitches, wrong graphics, or corrupted data.
+- **Reset may not work** — In some cores, resetting after a failed load can leave the emulator in a bad state.
+
+When in doubt, create a new save state with the updated core.
+
+## Technical Details
+
+- Save states store: `createdWithCoreVersion` (Realm, SwiftData, CloudKit).
+- The app checks this against `core.projectVersion` before load.
+- You can always choose to load anyway; the warning is informational.
+
+## Related
+
+- [Game Saves](saves.md) — Overview of save states and battery saves
+- [Quick Continue](quick-continue.md) — Using save states to resume games


### PR DESCRIPTION
### What does this PR do

Adds documentation for the save state version mismatch epic:
- Master ticket and 6 sub-tickets in `docs/save-state-version-mismatch-tickets.md`
- PR tracking in `docs/save-state-version-mismatch-PR.md`
- Wiki page content for provenance-emu/wiki in `docs/wiki/`
- Script to create GitHub issues via `gh` CLI

### What are the relevant tickets

- #2951 Save State Version Mismatch Detection & UX (master)
- #2952 Add createdWithCoreVersion to Save State View Models
- #2953 Centralized Save State Version Check & Alert Flow
- #2954 Integrate Version Check into All Save-State Launch Paths
- #2955 Reset Game with Bad Save State (PicoDrive / General)
- #2956 Save State Porting / Conversion (Exploratory)
- #2957 Wiki & In-App Save State Documentation

### Labels

save-states, core-version, high-priority