### PR TITLE
fix(scanner): wire dynamic libretro core scanner into app init path

### DIFF
--- a/PVCoreLoader/Sources/PVCoreLoader/RetroArch/PVDynamicLibretroCoreScanner.swift
+++ b/PVCoreLoader/Sources/PVCoreLoader/RetroArch/PVDynamicLibretroCoreScanner.swift
@@ -362,7 +362,7 @@ public extension CoreLoader {
     /// - Returns: Updated array that includes a synthetic "Thin Libretro" parent
     ///            containing all newly-discovered dylib cores, or the original array
     ///            unchanged if the feature flag is disabled.
-    static func mergeDiscoveredLibretroCores(
+    public static func mergeDiscoveredLibretroCores(
         into plists: [EmulatorCoreInfoPlist]
     ) -> [EmulatorCoreInfoPlist] {
 

--- a/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
+++ b/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
@@ -737,9 +737,10 @@ public final class GameImporter: GameImporting, ObservableObject {
         }
         await PVEmulatorConfiguration.updateSystems(fromPlists: [systemsPlistURL])
         // Scan frameworks directory off the main actor to avoid blocking UI updates.
-        let corePlists: [EmulatorCoreInfoPlist] = await Task.detached(priority: .userInitiated) {
+        var corePlists: [EmulatorCoreInfoPlist] = await Task.detached(priority: .userInitiated) {
             CoreLoader.getCorePlists()
         }.value
+        corePlists = PVDynamicLibretroCoreScanner.mergeDiscoveredLibretroCores(into: corePlists)
         await PVEmulatorConfiguration.updateCores(fromPlists: corePlists)
     }
 

--- a/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
+++ b/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
@@ -740,7 +740,7 @@ public final class GameImporter: GameImporting, ObservableObject {
         var corePlists: [EmulatorCoreInfoPlist] = await Task.detached(priority: .userInitiated) {
             CoreLoader.getCorePlists()
         }.value
-        corePlists = PVDynamicLibretroCoreScanner.mergeDiscoveredLibretroCores(into: corePlists)
+        corePlists = CoreLoader.mergeDiscoveredLibretroCores(into: corePlists)
         await PVEmulatorConfiguration.updateCores(fromPlists: corePlists)
     }
 


### PR DESCRIPTION
## Summary

- `mergeDiscoveredLibretroCores(into:)` was only called in unit tests, never from the production app boot path — so toggling the **dynamic libretro scanner feature flag** had no visible effect (legacy RetroArch core always loaded after restart)
- Make `mergeDiscoveredLibretroCores(into:)` `public` so `PVLibrary` can access it from `PVCoreLoader`
- Call it in `GameImporter.initCorePlists()` right after `CoreLoader.getCorePlists()`, before `updateCores(fromPlists:)` — the function already guards on `isFeatureEnabled` internally so it's a no-op when disabled

## Test plan

- [ ] Toggle dynamic libretro scanner feature flag ON in Settings → app restart → verify discovered dylib cores appear in core list
- [ ] Toggle feature flag OFF → app restart → verify only bundled cores appear (no regression)
- [ ] Build succeeds: `PVCoreLoader` and `PVLibrary` both compile without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)