### PR TITLE
[Agent] fix(vecx): fix blank square in hardware rendering mode (#2984)

### DIFF
--- a/Cores/VecX/Sources/PVVecX/PVVecXCore+Video.m
+++ b/Cores/VecX/Sources/PVVecX/PVVecXCore+Video.m
@@ -120,16 +120,15 @@ static CGSize parseHWResolution(NSString *resStr) {
 /// Override aspectSize for hardware rendering mode.
 ///
 /// The Vectrex has a native 33:41 aspect ratio (~0.805). All HW resolution presets
-/// maintain this ratio, so we can derive it from the parsed HW dimensions rather than
-/// relying on the hardcoded av_info aspect_ratio (also 33.0/41.0, but we want
-/// consistency with the overridden screenRect).
+/// maintain this ratio, but returning the full HW resolution here (e.g. 824×1024)
+/// causes DeltaSkins to treat aspectSize as "screen dimensions" and force a default
+/// 4:3 ratio. Instead, we return a small logical ratio pair (33×41) while
+/// screenRect reports the actual HW texture size.
 - (CGSize)aspectSize {
     if (self.rendersToOpenGL) {
-        CGSize hwSize = parseHWResolution(VecxOptions.resolutionHW);
-        if (!CGSizeEqualToSize(hwSize, CGSizeZero)) {
-            return CGSizeMake(hwSize.width, hwSize.height);
-        }
-        return CGSizeMake(33, 41);
+        // Keep values small so callers (e.g. DeltaSkins) interpret this as a pure
+        // aspect ratio rather than absolute screen dimensions.
+        return CGSizeMake(33.0, 41.0);
     }
     return [super aspectSize];
 }

--- a/Cores/VecX/Sources/PVVecX/PVVecXCore+Video.m
+++ b/Cores/VecX/Sources/PVVecX/PVVecXCore+Video.m
@@ -83,6 +83,58 @@
     return videoBuffer;
 }
 
+#if HAS_GPU
+/// Parse the HW resolution string (e.g. "824x1024") into a CGSize.
+/// Returns CGSizeZero if the string is not in the expected "WxH" format.
+static CGSize parseHWResolution(NSString *resStr) {
+    NSArray<NSString *> *parts = [resStr componentsSeparatedByString:@"x"];
+    if (parts.count == 2) {
+        NSInteger w = [parts[0] integerValue];
+        NSInteger h = [parts[1] integerValue];
+        if (w > 0 && h > 0) {
+            return CGSizeMake((CGFloat)w, (CGFloat)h);
+        }
+    }
+    return CGSizeZero;
+}
+
+/// Override screenRect for hardware rendering mode.
+///
+/// retro_get_system_av_info() in the VecX libretro core hardcodes base_width=330
+/// and base_height=410 regardless of hardware rendering mode.  When in HW mode the
+/// GL viewport is set to the selected HW resolution (e.g. 824×1024), so we must
+/// return that size here so the Metal blit in didRenderFrameOnAlternateThread copies
+/// the full rendered frame rather than only the top-left 330×410 pixel strip.
+- (CGRect)screenRect {
+    if (self.rendersToOpenGL) {
+        CGSize hwSize = parseHWResolution(VecxOptions.resolutionHW);
+        if (!CGSizeEqualToSize(hwSize, CGSizeZero)) {
+            return CGRectMake(0, 0, hwSize.width, hwSize.height);
+        }
+        // Safe default — matches the "824x1024" option index 4 default.
+        return CGRectMake(0, 0, 824, 1024);
+    }
+    return [super screenRect];
+}
+
+/// Override aspectSize for hardware rendering mode.
+///
+/// The Vectrex has a native 33:41 aspect ratio (~0.805). All HW resolution presets
+/// maintain this ratio, so we can derive it from the parsed HW dimensions rather than
+/// relying on the hardcoded av_info aspect_ratio (also 33.0/41.0, but we want
+/// consistency with the overridden screenRect).
+- (CGSize)aspectSize {
+    if (self.rendersToOpenGL) {
+        CGSize hwSize = parseHWResolution(VecxOptions.resolutionHW);
+        if (!CGSizeEqualToSize(hwSize, CGSizeZero)) {
+            return CGSizeMake(hwSize.width, hwSize.height);
+        }
+        return CGSizeMake(33, 41);
+    }
+    return [super aspectSize];
+}
+#endif // HAS_GPU
+
 /*
  memset(info, 0, sizeof(*info));
  info->timing.fps            = 50.0;


### PR DESCRIPTION
Fixes #2984 — VecX hardware rendering mode shows a blank square.

## Root Cause

`retro_get_system_av_info()` in the VecX libretro C core hardcodes `base_width=330, base_height=410` regardless of rendering mode. Even when the GLES viewport is set to the selected HW resolution (e.g. `824x1024`), the av_info geometry always reports the software resolution.

This caused a cascading failure:
1. `PVLibRetroCore+Video.m`'s `screenRect` reads `av_info.geometry.base_width/height` → always returns `(0, 0, 330, 410)` in HW mode
2. `didRenderFrameOnAlternateThread` in `PVMetalViewController` uses `screenRect` to blit from the 2048×2048 IOSurface-backed `backingMTLTexture` to `inputTexture` — it copies only the top-left **330×410** pixel region
3. The VecX GLES renderer draws vectors across the **full 824×1024 viewport** on the IOSurface
4. The copied 330×410 region captures only ~16% of the rendered area — corresponds to the GLES y=0..409 bottom strip (GLES y=0 is the visual bottom), which for most Vectrex games contains little visible content → **blank square**

## Fix

Override `screenRect` in `PVVecXCoreBridge (Video)` to parse the actual HW render dimensions from `VecxOptions.resolutionHW` (e.g. `"824x1024"`) when `rendersToOpenGL` is YES. This is the same string the C core parses to set its internal `WIDTH`/`HEIGHT` globals, keeping them in sync.

Also override `aspectSize` to derive the aspect ratio from the HW dimensions rather than relying on the hardcoded `av_info.aspect_ratio`. Both overrides are inside `#if HAS_GPU` guards so software-only builds are unaffected.

A shared `parseHWResolution()` static helper converts the `"WxH"` string to `CGSize`, with a safe fallback of `(824, 1024)` matching the default option.

## Prior Related Fix

PR #2993 (merged) fixed the enumeration option title lookup so `VecxOptions.useHardware` returns `"Hardware"` instead of `"1"`, and `VecxOptions.resolutionHW` returns `"824x1024"` instead of `"4"`. This fix depends on that being correct.

## Test plan

- [ ] Launch a Vectrex ROM with VecX in **Hardware** rendering mode — game graphics should fill the display
- [ ] Verify all HW resolution presets (434x540 through 1648x2048) render at the correct size
- [ ] Verify **Software** mode still works at 330×410 (no regression)
- [ ] Verify CRT/LCD filter applies correctly with the full-size frame
- [ ] Verify no regression for other libretro/GL cores

🤖 Generated with [Claude Code](https://claude.com/claude-code)