### PR TITLE
[Agent] feat(RetroArch): bridge msg_queue OSD messages to PVToast (#2804)

### DIFF
--- a/CoresRetro/RetroArch/PVRetroArch.xcodeproj/project.pbxproj
+++ b/CoresRetro/RetroArch/PVRetroArch.xcodeproj/project.pbxproj
@@ -43,6 +43,8 @@
 		93814F922AAAACAF00DEB9B9 /* PVRetroArchCore+Archive+MAME.m in Sources */ = {isa = PBXBuildFile; fileRef = 93814F912AAAACAF00DEB9B9 /* PVRetroArchCore+Archive+MAME.m */; };
 		9383580D296CDBB600A23231 /* metal.m in Sources */ = {isa = PBXBuildFile; fileRef = 9383580C296CDBB600A23231 /* metal.m */; };
 		93835811296CFAA700A23231 /* cocoa_common.m in Sources */ = {isa = PBXBuildFile; fileRef = 93835810296CFAA600A23231 /* cocoa_common.m */; };
+		2E434850122D7261A75CF7FE /* PVRetroArchOSD.m in Sources */ = {isa = PBXBuildFile; fileRef = 29E408A962408758D92289AF /* PVRetroArchOSD.m */; };
+		039F981B1E6C203CC74BC408 /* PVRetroArchOSD.h in Headers */ = {isa = PBXBuildFile; fileRef = A3D69792B9FCA4012C024F98 /* PVRetroArchOSD.h */; };
 		9383581B296D362C00A23231 /* retroarch.cfg in Resources */ = {isa = PBXBuildFile; fileRef = 9383581A296D362C00A23231 /* retroarch.cfg */; };
 		93835825296D58B900A23231 /* assets.zip in Resources */ = {isa = PBXBuildFile; fileRef = 93835824296D58B900A23231 /* assets.zip */; };
 		9389A8F9297AA46000B27656 /* arrow.png in Resources */ = {isa = PBXBuildFile; fileRef = 9389A8F8297AA46000B27656 /* arrow.png */; };
@@ -325,6 +327,8 @@
 		93814F912AAAACAF00DEB9B9 /* PVRetroArchCore+Archive+MAME.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "PVRetroArchCore+Archive+MAME.m"; sourceTree = "<group>"; };
 		9383580C296CDBB600A23231 /* metal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = metal.m; sourceTree = "<group>"; };
 		93835810296CFAA600A23231 /* cocoa_common.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = cocoa_common.m; sourceTree = "<group>"; };
+		29E408A962408758D92289AF /* PVRetroArchOSD.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PVRetroArchOSD.m; sourceTree = "<group>"; };
+		A3D69792B9FCA4012C024F98 /* PVRetroArchOSD.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PVRetroArchOSD.h; sourceTree = "<group>"; };
 		9383581A296D362C00A23231 /* retroarch.cfg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = retroarch.cfg; sourceTree = "<group>"; };
 		93835824296D58B900A23231 /* assets.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; path = assets.zip; sourceTree = "<group>"; };
 		9389A8F8297AA46000B27656 /* arrow.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = arrow.png; sourceTree = "<group>"; };
@@ -865,6 +869,8 @@
 				9383580C296CDBB600A23231 /* metal.m */,
 				936B47F92969798B00C7D2A3 /* platform_darwin.m */,
 				938E5BB4298B31D400F8596C /* PVDebug.c */,
+				A3D69792B9FCA4012C024F98 /* PVRetroArchOSD.h */,
+				29E408A962408758D92289AF /* PVRetroArchOSD.m */,
 				B3447EA0218B881000557ACE /* PVRetroArch.mm */,
 				B3C76224207833DE009950E4 /* PVRetroArchCoreBridge.mm */,
 				93B3B19A2A8CBC7100B60325 /* PVRetroArchCore+Archive.m */,
@@ -1095,6 +1101,7 @@
 				932A5CC129686AEB0032C168 /* retroarch.h in Headers */,
 				93F66EC52966D6E100203EB3 /* cocoa_common.h in Headers */,
 				B3135BA126E4CC620047F338 /* PVRetroArch.h in Headers */,
+				039F981B1E6C203CC74BC408 /* PVRetroArchOSD.h in Headers */,
 				93B3B1992A8CBA5F00B60325 /* PVRetroArchCoreBridge+Archive.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1384,6 +1391,7 @@
 				B3EEF0702D66AF440080CA51 /* PVRetroArchCoreBridge.swift in Sources */,
 				936BFD8A2986AF03001FF097 /* cocoa_vk_ctx.m in Sources */,
 				93835811296CFAA700A23231 /* cocoa_common.m in Sources */,
+				2E434850122D7261A75CF7FE /* PVRetroArchOSD.m in Sources */,
 				B33CFF0A2ED2E8260029101B /* PVRetroArchCore+Controls+Lynx.m in Sources */,
 				936B47FA2969798B00C7D2A3 /* platform_darwin.m in Sources */,
 				935E7D4B29A4ABDD00D92748 /* vulkan_common.c in Sources */,

--- a/CoresRetro/RetroArch/PVRetroArchCore/Core/PVRetroArchOSD.h
+++ b/CoresRetro/RetroArch/PVRetroArchCore/Core/PVRetroArchOSD.h
@@ -18,9 +18,9 @@ extern "C" {
  * @param msg      The message string (UTF-8).
  * @param category RetroArch MESSAGE_QUEUE_CATEGORY_* value cast to unsigned
  *                 (0=INFO, 1=ERROR, 2=WARNING, 3=SUCCESS). Maps to PVOSDType.
- * @param duration_ms Pre-computed display duration in milliseconds, derived
- *                    from the original frame-count duration and the core's
- *                    actual FPS (caller performs the conversion).
+ * @param duration_ms Pre-computed display duration in milliseconds, typically
+ *                    derived from RetroArch's frame-count duration using its
+ *                    fixed 60 FPS timebase.
  */
 void pv_retroarch_post_osd(const char *msg, unsigned category, unsigned duration_ms);
 

--- a/CoresRetro/RetroArch/PVRetroArchCore/Core/PVRetroArchOSD.h
+++ b/CoresRetro/RetroArch/PVRetroArchCore/Core/PVRetroArchOSD.h
@@ -16,13 +16,12 @@ extern "C" {
  * Post an OSD message to PVToast via PVOSDMessageNotification.
  *
  * @param msg      The message string (UTF-8).
- * @param prio     RetroArch priority (higher = more important).
  * @param category RetroArch MESSAGE_QUEUE_CATEGORY_* value cast to unsigned
  *                 (0=INFO, 1=WARNING, 2=ERROR). Used to derive PVOSDType.
  * @param duration RetroArch original frame-count duration (before any widget
  *                 conversion), converted to seconds at ~60fps.
  */
-void pv_retroarch_post_osd(const char *msg, unsigned prio, unsigned category, unsigned duration);
+void pv_retroarch_post_osd(const char *msg, unsigned category, unsigned duration);
 
 #ifdef __cplusplus
 }

--- a/CoresRetro/RetroArch/PVRetroArchCore/Core/PVRetroArchOSD.h
+++ b/CoresRetro/RetroArch/PVRetroArchCore/Core/PVRetroArchOSD.h
@@ -17,11 +17,12 @@ extern "C" {
  *
  * @param msg      The message string (UTF-8).
  * @param category RetroArch MESSAGE_QUEUE_CATEGORY_* value cast to unsigned
- *                 (0=INFO, 1=WARNING, 2=ERROR). Used to derive PVOSDType.
- * @param duration RetroArch original frame-count duration (before any widget
- *                 conversion), converted to seconds at ~60fps.
+ *                 (0=INFO, 1=ERROR, 2=WARNING, 3=SUCCESS). Maps to PVOSDType.
+ * @param duration_ms Pre-computed display duration in milliseconds, derived
+ *                    from the original frame-count duration and the core's
+ *                    actual FPS (caller performs the conversion).
  */
-void pv_retroarch_post_osd(const char *msg, unsigned category, unsigned duration);
+void pv_retroarch_post_osd(const char *msg, unsigned category, unsigned duration_ms);
 
 #ifdef __cplusplus
 }

--- a/CoresRetro/RetroArch/PVRetroArchCore/Core/PVRetroArchOSD.h
+++ b/CoresRetro/RetroArch/PVRetroArchCore/Core/PVRetroArchOSD.h
@@ -1,0 +1,28 @@
+/*
+ *  PVRetroArchOSD.h
+ *  PVRetroArch
+ *
+ *  Bridges RetroArch OSD messages to PVToast via NSNotificationCenter.
+ */
+
+#ifndef PV_RETROARCH_OSD_H
+#define PV_RETROARCH_OSD_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Post an OSD message to PVToast via PVOSDMessageNotification.
+ *
+ * @param msg      The message string (UTF-8).
+ * @param prio     RetroArch priority (higher = more important).
+ * @param duration RetroArch frame-count duration (converted to seconds at ~60fps).
+ */
+void pv_retroarch_post_osd(const char *msg, unsigned prio, unsigned duration);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PV_RETROARCH_OSD_H */

--- a/CoresRetro/RetroArch/PVRetroArchCore/Core/PVRetroArchOSD.h
+++ b/CoresRetro/RetroArch/PVRetroArchCore/Core/PVRetroArchOSD.h
@@ -17,9 +17,12 @@ extern "C" {
  *
  * @param msg      The message string (UTF-8).
  * @param prio     RetroArch priority (higher = more important).
- * @param duration RetroArch frame-count duration (converted to seconds at ~60fps).
+ * @param category RetroArch MESSAGE_QUEUE_CATEGORY_* value cast to unsigned
+ *                 (0=INFO, 1=WARNING, 2=ERROR). Used to derive PVOSDType.
+ * @param duration RetroArch original frame-count duration (before any widget
+ *                 conversion), converted to seconds at ~60fps.
  */
-void pv_retroarch_post_osd(const char *msg, unsigned prio, unsigned duration);
+void pv_retroarch_post_osd(const char *msg, unsigned prio, unsigned category, unsigned duration);
 
 #ifdef __cplusplus
 }

--- a/CoresRetro/RetroArch/PVRetroArchCore/Core/PVRetroArchOSD.m
+++ b/CoresRetro/RetroArch/PVRetroArchCore/Core/PVRetroArchOSD.m
@@ -6,43 +6,35 @@
  *  Called from runloop_msg_queue_push() in runloop.c.
  */
 
-#import <Foundation/Foundation.h>
+#import <PVCoreObjCBridge/PVOSDNotification.h>
 #import "PVRetroArchOSD.h"
 
-void pv_retroarch_post_osd(const char *msg, unsigned prio, unsigned category, unsigned duration) {
-    @autoreleasepool {
-        if (!msg || msg[0] == '\0')
-            return;
+void pv_retroarch_post_osd(const char *msg, unsigned category, unsigned duration) {
+    if (!msg || msg[0] == '\0')
+        return;
 
-        NSString *nsMsg = [NSString stringWithUTF8String:msg];
-        if (nsMsg.length == 0)
-            return;
+    NSString *nsMsg = [NSString stringWithUTF8String:msg];
+    if (nsMsg.length == 0)
+        return;
 
-        /* Convert RetroArch frame-count duration to seconds (assume ~60fps). */
-        NSTimeInterval seconds = (duration > 0) ? ((double)duration / 60.0) : 3.0;
-        /* Clamp to reasonable range */
-        if (seconds < 1.0) seconds = 1.0;
-        if (seconds > 10.0) seconds = 10.0;
+    /* Convert RetroArch frame-count duration to seconds (assume ~60fps). */
+    NSTimeInterval seconds = (duration > 0) ? ((double)duration / 60.0) : 3.0;
+    /* Clamp to reasonable range */
+    if (seconds < 1.0) seconds = 1.0;
+    if (seconds > 10.0) seconds = 10.0;
 
-        /* Map MESSAGE_QUEUE_CATEGORY_* to PVOSDType:
-         *   0 (INFO)    -> PVOSDTypeInfo    (0)
-         *   1 (WARNING) -> PVOSDTypeWarning (2)
-         *   2 (ERROR)   -> PVOSDTypeError   (3)
-         */
-        int osdType;
-        switch (category) {
-            case 2:  osdType = 3; break;  /* ERROR   -> PVOSDTypeError   */
-            case 1:  osdType = 2; break;  /* WARNING -> PVOSDTypeWarning */
-            default: osdType = 0; break;  /* INFO    -> PVOSDTypeInfo    */
-        }
-
-        /* NSNotificationCenter is thread-safe for posting; no need to
-         * dispatch to the main queue here — the observer decides threading. */
-        [[NSNotificationCenter defaultCenter]
-            postNotificationName:@"PVOSDMessageNotification"
-                          object:nil
-                        userInfo:@{ @"PVOSDMessage":  nsMsg,
-                                    @"PVOSDType":     @(osdType),
-                                    @"PVOSDDuration": @(seconds) }];
+    /* Map MESSAGE_QUEUE_CATEGORY_* to PVOSDType:
+     *   0 (INFO)    -> PVOSDTypeInfo    (0)
+     *   1 (WARNING) -> PVOSDTypeWarning (2)
+     *   2 (ERROR)   -> PVOSDTypeError   (3)
+     */
+    PVOSDType osdType;
+    switch (category) {
+        case 2:  osdType = PVOSDTypeError;   break;
+        case 1:  osdType = PVOSDTypeWarning; break;
+        default: osdType = PVOSDTypeInfo;    break;
     }
+
+    /* PVOSDNotification handles autorelease pool and thread-safe posting. */
+    [PVOSDNotification postMessage:nsMsg type:osdType duration:seconds];
 }

--- a/CoresRetro/RetroArch/PVRetroArchCore/Core/PVRetroArchOSD.m
+++ b/CoresRetro/RetroArch/PVRetroArchCore/Core/PVRetroArchOSD.m
@@ -9,32 +9,37 @@
 #import <PVCoreObjCBridge/PVOSDNotification.h>
 #import "PVRetroArchOSD.h"
 
-void pv_retroarch_post_osd(const char *msg, unsigned category, unsigned duration) {
+void pv_retroarch_post_osd(const char *msg, unsigned category, unsigned duration_ms) {
     if (!msg || msg[0] == '\0')
         return;
 
-    NSString *nsMsg = [NSString stringWithUTF8String:msg];
-    if (nsMsg.length == 0)
-        return;
+    @autoreleasepool {
+        NSString *nsMsg = [NSString stringWithUTF8String:msg];
+        if (nsMsg.length == 0)
+            return;
 
-    /* Convert RetroArch frame-count duration to seconds (assume ~60fps). */
-    NSTimeInterval seconds = (duration > 0) ? ((double)duration / 60.0) : 3.0;
-    /* Clamp to reasonable range */
-    if (seconds < 1.0) seconds = 1.0;
-    if (seconds > 10.0) seconds = 10.0;
+        /* Convert pre-computed millisecond duration to seconds.
+         * The caller (runloop.c) already applied the core FPS conversion. */
+        NSTimeInterval seconds = (duration_ms > 0) ? ((double)duration_ms / 1000.0) : 3.0;
+        /* Clamp to reasonable range */
+        if (seconds < 1.0) seconds = 1.0;
+        if (seconds > 10.0) seconds = 10.0;
 
-    /* Map MESSAGE_QUEUE_CATEGORY_* to PVOSDType:
-     *   0 (INFO)    -> PVOSDTypeInfo    (0)
-     *   1 (WARNING) -> PVOSDTypeWarning (2)
-     *   2 (ERROR)   -> PVOSDTypeError   (3)
-     */
-    PVOSDType osdType;
-    switch (category) {
-        case 2:  osdType = PVOSDTypeError;   break;
-        case 1:  osdType = PVOSDTypeWarning; break;
-        default: osdType = PVOSDTypeInfo;    break;
+        /* Map MESSAGE_QUEUE_CATEGORY_* to PVOSDType.
+         * Actual RetroArch enum (libretro-common/include/queues/message_queue.h):
+         *   0 (INFO)    -> PVOSDTypeInfo    (0)
+         *   1 (ERROR)   -> PVOSDTypeError   (3)
+         *   2 (WARNING) -> PVOSDTypeWarning (2)
+         *   3 (SUCCESS) -> PVOSDTypeSuccess (1)
+         */
+        PVOSDType osdType;
+        switch (category) {
+            case 1:  osdType = PVOSDTypeError;   break;
+            case 2:  osdType = PVOSDTypeWarning; break;
+            case 3:  osdType = PVOSDTypeSuccess; break;
+            default: osdType = PVOSDTypeInfo;    break;
+        }
+
+        [PVOSDNotification postMessage:nsMsg type:osdType duration:seconds];
     }
-
-    /* PVOSDNotification handles autorelease pool and thread-safe posting. */
-    [PVOSDNotification postMessage:nsMsg type:osdType duration:seconds];
 }

--- a/CoresRetro/RetroArch/PVRetroArchCore/Core/PVRetroArchOSD.m
+++ b/CoresRetro/RetroArch/PVRetroArchCore/Core/PVRetroArchOSD.m
@@ -9,32 +9,40 @@
 #import <Foundation/Foundation.h>
 #import "PVRetroArchOSD.h"
 
-void pv_retroarch_post_osd(const char *msg, unsigned prio, unsigned duration) {
-    if (!msg || msg[0] == '\0')
-        return;
+void pv_retroarch_post_osd(const char *msg, unsigned prio, unsigned category, unsigned duration) {
+    @autoreleasepool {
+        if (!msg || msg[0] == '\0')
+            return;
 
-    NSString *nsMsg = [NSString stringWithUTF8String:msg];
-    if (nsMsg.length == 0)
-        return;
+        NSString *nsMsg = [NSString stringWithUTF8String:msg];
+        if (nsMsg.length == 0)
+            return;
 
-    /* Convert RetroArch frame-count duration to seconds (assume ~60fps). */
-    NSTimeInterval seconds = (duration > 0) ? ((double)duration / 60.0) : 3.0;
-    /* Clamp to reasonable range */
-    if (seconds < 1.0) seconds = 1.0;
-    if (seconds > 10.0) seconds = 10.0;
+        /* Convert RetroArch frame-count duration to seconds (assume ~60fps). */
+        NSTimeInterval seconds = (duration > 0) ? ((double)duration / 60.0) : 3.0;
+        /* Clamp to reasonable range */
+        if (seconds < 1.0) seconds = 1.0;
+        if (seconds > 10.0) seconds = 10.0;
 
-    /* Map RetroArch priority to PVOSDType:
-     *   0 = info, 1 = success, 2 = warning, 3 = error
-     * RetroArch uses higher prio for more important messages.
-     * We treat prio >= 3 as warning, otherwise info. */
-    int osdType = (prio >= 3) ? 2 : 0;
+        /* Map MESSAGE_QUEUE_CATEGORY_* to PVOSDType:
+         *   0 (INFO)    -> PVOSDTypeInfo    (0)
+         *   1 (WARNING) -> PVOSDTypeWarning (2)
+         *   2 (ERROR)   -> PVOSDTypeError   (3)
+         */
+        int osdType;
+        switch (category) {
+            case 2:  osdType = 3; break;  /* ERROR   -> PVOSDTypeError   */
+            case 1:  osdType = 2; break;  /* WARNING -> PVOSDTypeWarning */
+            default: osdType = 0; break;  /* INFO    -> PVOSDTypeInfo    */
+        }
 
-    dispatch_async(dispatch_get_main_queue(), ^{
+        /* NSNotificationCenter is thread-safe for posting; no need to
+         * dispatch to the main queue here — the observer decides threading. */
         [[NSNotificationCenter defaultCenter]
             postNotificationName:@"PVOSDMessageNotification"
                           object:nil
                         userInfo:@{ @"PVOSDMessage":  nsMsg,
                                     @"PVOSDType":     @(osdType),
                                     @"PVOSDDuration": @(seconds) }];
-    });
+    }
 }

--- a/CoresRetro/RetroArch/PVRetroArchCore/Core/PVRetroArchOSD.m
+++ b/CoresRetro/RetroArch/PVRetroArchCore/Core/PVRetroArchOSD.m
@@ -18,14 +18,13 @@ void pv_retroarch_post_osd(const char *msg, unsigned category, unsigned duration
         if (nsMsg.length == 0)
             return;
 
-        /* Convert pre-computed millisecond duration to seconds.
-         * The caller (runloop.c) already applied the core FPS conversion. */
+        /* Convert pre-computed RetroArch millisecond duration to seconds.
+         * The caller (runloop.c) has already applied any core FPS / timing conversion,
+         * so we use the provided value directly, falling back to 3s if unset. */
         NSTimeInterval seconds = (duration_ms > 0) ? ((double)duration_ms / 1000.0) : 3.0;
-        /* Clamp to reasonable range */
-        if (seconds < 1.0) seconds = 1.0;
-        if (seconds > 10.0) seconds = 10.0;
 
         /* Map MESSAGE_QUEUE_CATEGORY_* to PVOSDType.
+         * Actual RetroArch enum (libretro-common/include/queues/message_queue.h):
          * Actual RetroArch enum (libretro-common/include/queues/message_queue.h):
          *   0 (INFO)    -> PVOSDTypeInfo    (0)
          *   1 (ERROR)   -> PVOSDTypeError   (3)

--- a/CoresRetro/RetroArch/PVRetroArchCore/Core/PVRetroArchOSD.m
+++ b/CoresRetro/RetroArch/PVRetroArchCore/Core/PVRetroArchOSD.m
@@ -1,0 +1,40 @@
+/*
+ *  PVRetroArchOSD.m
+ *  PVRetroArch
+ *
+ *  Bridges RetroArch OSD messages to PVToast via NSNotificationCenter.
+ *  Called from runloop_msg_queue_push() in runloop.c.
+ */
+
+#import <Foundation/Foundation.h>
+#import "PVRetroArchOSD.h"
+
+void pv_retroarch_post_osd(const char *msg, unsigned prio, unsigned duration) {
+    if (!msg || msg[0] == '\0')
+        return;
+
+    NSString *nsMsg = [NSString stringWithUTF8String:msg];
+    if (nsMsg.length == 0)
+        return;
+
+    /* Convert RetroArch frame-count duration to seconds (assume ~60fps). */
+    NSTimeInterval seconds = (duration > 0) ? ((double)duration / 60.0) : 3.0;
+    /* Clamp to reasonable range */
+    if (seconds < 1.0) seconds = 1.0;
+    if (seconds > 10.0) seconds = 10.0;
+
+    /* Map RetroArch priority to PVOSDType:
+     *   0 = info, 1 = success, 2 = warning, 3 = error
+     * RetroArch uses higher prio for more important messages.
+     * We treat prio >= 3 as warning, otherwise info. */
+    int osdType = (prio >= 3) ? 2 : 0;
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[NSNotificationCenter defaultCenter]
+            postNotificationName:@"PVOSDMessageNotification"
+                          object:nil
+                        userInfo:@{ @"PVOSDMessage":  nsMsg,
+                                    @"PVOSDType":     @(osdType),
+                                    @"PVOSDDuration": @(seconds) }];
+    });
+}

--- a/CoresRetro/RetroArch/PVRetroArchCore/Core/runloop.c
+++ b/CoresRetro/RetroArch/PVRetroArchCore/Core/runloop.c
@@ -5337,15 +5337,12 @@ void runloop_msg_queue_push(
    runloop_state_t *runloop_st    = &runloop_state;
    unsigned pv_osd_duration_ms    = 0;
 
-   /* Convert frame-count duration to ms using the core's actual FPS before
-    * 'duration' is potentially mutated by the widgets path below.
-    * Fallback to 60 fps when no core is loaded or fps is not yet known. */
-   {
-      video_driver_state_t *pv_vst = video_state_get_ptr();
-      float pv_fps = (pv_vst && pv_vst->av_info.timing.fps > 0.0f)
-                     ? (float)pv_vst->av_info.timing.fps : 60.0f;
-      pv_osd_duration_ms = (unsigned)roundf((float)duration / pv_fps * 1000.0f);
-   }
+   /* Convert frame-count duration to ms using the same fixed 60fps timebase that
+    * RetroArch's own gfx_widgets path uses (roundf(duration / 60.0f * 1000.0f)).
+    * This keeps PVToast display times consistent with built-in OSD semantics.
+    * Per-frame status overlays (duration <= 1) are excluded below to prevent spam. */
+   if (duration > 1)
+      pv_osd_duration_ms = (unsigned)roundf((float)duration / 60.0f * 1000.0f);
 
    RUNLOOP_MSG_QUEUE_LOCK(runloop_st);
 #ifdef HAVE_ACCESSIBILITY
@@ -5399,8 +5396,9 @@ void runloop_msg_queue_push(
 
    /* Bridge OSD message to PVToast — called outside the runloop message-queue
     * lock to avoid holding the mutex across ObjC allocations/notifications.
-    * Skip per-frame status overlays (≤1 frame ≈ ≤17ms) to prevent toast spam. */
-   if (pv_osd_duration_ms > 17)
+    * pv_osd_duration_ms is 0 when duration <= 1 (per-frame status overlays),
+    * so the check here naturally skips those without a separate ms threshold. */
+   if (pv_osd_duration_ms > 0)
       pv_retroarch_post_osd(msg, (unsigned)category, pv_osd_duration_ms);
 }
 

--- a/CoresRetro/RetroArch/PVRetroArchCore/Core/runloop.c
+++ b/CoresRetro/RetroArch/PVRetroArchCore/Core/runloop.c
@@ -5335,8 +5335,17 @@ void runloop_msg_queue_push(
    access_state_t *access_st      = access_state_get_ptr();
 #endif
    runloop_state_t *runloop_st    = &runloop_state;
-   /* Capture before duration is potentially mutated by the widgets path. */
-   unsigned pv_duration           = duration;
+   unsigned pv_osd_duration_ms    = 0;
+
+   /* Convert frame-count duration to ms using the core's actual FPS before
+    * 'duration' is potentially mutated by the widgets path below.
+    * Fallback to 60 fps when no core is loaded or fps is not yet known. */
+   {
+      video_driver_state_t *pv_vst = video_state_get_ptr();
+      float pv_fps = (pv_vst && pv_vst->av_info.timing.fps > 0.0f)
+                     ? (float)pv_vst->av_info.timing.fps : 60.0f;
+      pv_osd_duration_ms = (unsigned)roundf((float)duration / pv_fps * 1000.0f);
+   }
 
    RUNLOOP_MSG_QUEUE_LOCK(runloop_st);
 #ifdef HAVE_ACCESSIBILITY
@@ -5390,9 +5399,9 @@ void runloop_msg_queue_push(
 
    /* Bridge OSD message to PVToast — called outside the runloop message-queue
     * lock to avoid holding the mutex across ObjC allocations/notifications.
-    * Skip per-frame status overlays (duration <= 1 frame) to prevent spam. */
-   if (pv_duration > 1)
-      pv_retroarch_post_osd(msg, (unsigned)category, pv_duration);
+    * Skip per-frame status overlays (≤1 frame ≈ ≤17ms) to prevent toast spam. */
+   if (pv_osd_duration_ms > 17)
+      pv_retroarch_post_osd(msg, (unsigned)category, pv_osd_duration_ms);
 }
 
 #ifdef HAVE_MENU

--- a/CoresRetro/RetroArch/PVRetroArchCore/Core/runloop.c
+++ b/CoresRetro/RetroArch/PVRetroArchCore/Core/runloop.c
@@ -5335,6 +5335,8 @@ void runloop_msg_queue_push(
    access_state_t *access_st      = access_state_get_ptr();
 #endif
    runloop_state_t *runloop_st    = &runloop_state;
+   /* Capture before duration is potentially mutated by the widgets path. */
+   unsigned pv_duration           = duration;
 
    RUNLOOP_MSG_QUEUE_LOCK(runloop_st);
 #ifdef HAVE_ACCESSIBILITY
@@ -5384,10 +5386,11 @@ void runloop_msg_queue_push(
    ui_companion_driver_msg_queue_push(
          msg, prio, duration, flush);
 
-   /* Bridge OSD message to PVToast via PVOSDMessageNotification */
-   pv_retroarch_post_osd(msg, prio, duration);
-
    RUNLOOP_MSG_QUEUE_UNLOCK(runloop_st);
+
+   /* Bridge OSD message to PVToast — called outside the runloop message-queue
+    * lock to avoid holding the mutex across ObjC allocations/notifications. */
+   pv_retroarch_post_osd(msg, prio, (unsigned)category, pv_duration);
 }
 
 #ifdef HAVE_MENU

--- a/CoresRetro/RetroArch/PVRetroArchCore/Core/runloop.c
+++ b/CoresRetro/RetroArch/PVRetroArchCore/Core/runloop.c
@@ -5389,8 +5389,10 @@ void runloop_msg_queue_push(
    RUNLOOP_MSG_QUEUE_UNLOCK(runloop_st);
 
    /* Bridge OSD message to PVToast — called outside the runloop message-queue
-    * lock to avoid holding the mutex across ObjC allocations/notifications. */
-   pv_retroarch_post_osd(msg, prio, (unsigned)category, pv_duration);
+    * lock to avoid holding the mutex across ObjC allocations/notifications.
+    * Skip per-frame status overlays (duration <= 1 frame) to prevent spam. */
+   if (pv_duration > 1)
+      pv_retroarch_post_osd(msg, (unsigned)category, pv_duration);
 }
 
 #ifdef HAVE_MENU

--- a/CoresRetro/RetroArch/PVRetroArchCore/Core/runloop.c
+++ b/CoresRetro/RetroArch/PVRetroArchCore/Core/runloop.c
@@ -116,6 +116,7 @@
 
 #include "runtime_file.h"
 #include "runloop.h"
+#include "PVRetroArchOSD.h"
 #include "camera/camera_driver.h"
 #include "location_driver.h"
 #include "record/record_driver.h"
@@ -5382,6 +5383,9 @@ void runloop_msg_queue_push(
 
    ui_companion_driver_msg_queue_push(
          msg, prio, duration, flush);
+
+   /* Bridge OSD message to PVToast via PVOSDMessageNotification */
+   pv_retroarch_post_osd(msg, prio, duration);
 
    RUNLOOP_MSG_QUEUE_UNLOCK(runloop_st);
 }


### PR DESCRIPTION
## Summary
- Bridges RetroArch's internal OSD messages (`runloop_msg_queue_push`) to PVToast via `PVOSDMessageNotification`, matching the pattern already used by Mednafen, PPSSPP, Dolphin, and other cores
- Adds `PVRetroArchOSD.h/.m` with a C-callable `pv_retroarch_post_osd()` function that converts RetroArch frame-count durations to seconds and posts notifications on the main queue
- Hooks the new function into `runloop_msg_queue_push()` in `runloop.c` (bridge layer, not upstream submodule)

Closes #2804

## Test plan
- [ ] Launch a RetroArch-based core (e.g. any libretro core) and verify OSD messages (save state, load state, fast-forward, etc.) appear as PVToast overlays
- [ ] Verify messages do not appear duplicated or excessively spammed
- [ ] Verify non-RetroArch cores (Mednafen, PPSSPP, etc.) still show OSD messages normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)