### PR TITLE
[Agent] feat(PVUI): controller preferred player picker UI (#2774)

### DIFF
--- a/.changelog/3158.md
+++ b/.changelog/3158.md
@@ -1,2 +1,2 @@
-### Fixed
-- **ControllerSettingsView** — Remove unused `import PVSettings`, truncate long disconnected-controller IDs in the player-slot UI, and deduplicate `ModeCategory` enum + picker code into shared `SlotModeCategory`/`SlotModePickerSection` types.
+### Added
+- **Preferred Player Slots UI** — New section in Controller Settings lets users configure per-controller slot-assignment mode (Auto / Preferred / Always) with a P1–P8 slot picker; previously-seen disconnected controllers also appear so preferences can be reviewed and reset without reconnecting

--- a/.changelog/3158.md
+++ b/.changelog/3158.md
@@ -1,0 +1,2 @@
+### Fixed
+- **ControllerSettingsView** — Remove unused `import PVSettings`, truncate long disconnected-controller IDs in the player-slot UI, and deduplicate `ModeCategory` enum + picker code into shared `SlotModeCategory`/`SlotModePickerSection` types.

--- a/PVUI/Sources/PVSwiftUI/Settings/Views/ControllerSettingsView.swift
+++ b/PVUI/Sources/PVSwiftUI/Settings/Views/ControllerSettingsView.swift
@@ -12,6 +12,7 @@ import GameController
 import PVThemes
 import PVLibrary
 import PVRealm
+import PVSettings
 import MarkdownView
 #if canImport(PVUI_IOS)
 import PVUI_IOS
@@ -364,6 +365,38 @@ struct ControllerSettingsView: View {
                         .foregroundColor(.secondary)
                 }
             }
+
+            // Preferred Player Slot Section
+            if !controllerManager.controllers.isEmpty {
+                Section {
+                    ForEach(controllerManager.controllers, id: \.self) { controller in
+                        ControllerSlotModeRow(
+                            controller: controller,
+                            controllerManager: controllerManager,
+                            accentColor: accentColor,
+                            controllerIcon: controllerIcon(controller)
+                        )
+                    }
+                } header: {
+                    HStack {
+                        Image(systemName: "person.2.fill")
+                        Text("Preferred Player Slots")
+                    }
+                    .font(.headline)
+                    #if os(tvOS)
+                    .foregroundColor(.retroPink)
+                    #endif
+                } footer: {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Set which player slot each controller prefers when connected.")
+                            .font(.footnote)
+                            .foregroundColor(.secondary)
+                        Text("Auto: first available slot. Preferred: use chosen slot if free. Always: claim chosen slot, bumping others.")
+                            .font(.footnote)
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
         }
         #if os(tvOS)
         .listStyle(.plain)
@@ -443,6 +476,109 @@ struct ControllerSettingsView: View {
         }
 
         return title
+    }
+}
+
+/// A row showing the slot mode for a single controller with inline pickers.
+private struct ControllerSlotModeRow: View {
+    let controller: GCController
+    @ObservedObject var controllerManager: PVControllerManager
+    let accentColor: Color
+    let controllerIcon: String
+
+    /// The three mode categories available to the user.
+    private enum ModeCategory: String, CaseIterable, Identifiable {
+        case auto = "Auto"
+        case preferred = "Preferred"
+        case always = "Always"
+        var id: String { rawValue }
+    }
+
+    private var currentMode: ControllerSlotMode {
+        controllerManager.slotMode(for: controller)
+    }
+
+    private var modeCategory: ModeCategory {
+        switch currentMode {
+        case .auto: return .auto
+        case .preferred: return .preferred
+        case .always: return .always
+        }
+    }
+
+    private var selectedSlot: Int {
+        currentMode.preferredSlot ?? 1
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            // Controller name header
+            HStack(spacing: 12) {
+                Image(systemName: controllerIcon)
+                    .imageScale(.large)
+                    .foregroundColor(accentColor)
+                    .frame(width: 30)
+
+                Text(controller.vendorName ?? "Unknown Controller")
+                    .font(.headline)
+
+                Spacer()
+
+                if currentMode != .auto {
+                    Button(action: {
+                        controllerManager.clearSlotMode(for: controller)
+                    }) {
+                        Text("Reset")
+                            .font(.caption)
+                            .foregroundColor(.red)
+                    }
+                    .buttonStyle(.borderless)
+                }
+            }
+
+            // Mode picker
+            Picker("Mode", selection: Binding(
+                get: { modeCategory },
+                set: { newCategory in
+                    switch newCategory {
+                    case .auto:
+                        controllerManager.setSlotMode(.auto, for: controller)
+                    case .preferred:
+                        controllerManager.setSlotMode(.preferred(selectedSlot), for: controller)
+                    case .always:
+                        controllerManager.setSlotMode(.always(selectedSlot), for: controller)
+                    }
+                }
+            )) {
+                ForEach(ModeCategory.allCases) { category in
+                    Text(category.rawValue).tag(category)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            // Player slot picker (only when not Auto)
+            if modeCategory != .auto {
+                Picker("Player Slot", selection: Binding(
+                    get: { selectedSlot },
+                    set: { newSlot in
+                        switch modeCategory {
+                        case .auto:
+                            break
+                        case .preferred:
+                            controllerManager.setSlotMode(.preferred(newSlot), for: controller)
+                        case .always:
+                            controllerManager.setSlotMode(.always(newSlot), for: controller)
+                        }
+                    }
+                )) {
+                    ForEach(1...4, id: \.self) { slot in
+                        Text("P\(slot)").tag(slot)
+                    }
+                }
+                .pickerStyle(.segmented)
+            }
+        }
+        .padding(.vertical, 4)
     }
 }
 

--- a/PVUI/Sources/PVSwiftUI/Settings/Views/ControllerSettingsView.swift
+++ b/PVUI/Sources/PVSwiftUI/Settings/Views/ControllerSettingsView.swift
@@ -367,7 +367,9 @@ struct ControllerSettingsView: View {
             }
 
             // Preferred Player Slot Section
-            if !controllerManager.controllers.isEmpty {
+            let connectedIds = Set(controllerManager.controllers.map { controllerManager.controllerIdentifier(for: $0) })
+            let disconnectedIds = controllerManager.storedControllerIds.filter { !connectedIds.contains($0) }
+            if !controllerManager.controllers.isEmpty || !disconnectedIds.isEmpty {
                 Section {
                     ForEach(controllerManager.controllers, id: \.self) { controller in
                         ControllerSlotModeRow(
@@ -375,6 +377,12 @@ struct ControllerSettingsView: View {
                             controllerManager: controllerManager,
                             accentColor: accentColor,
                             controllerIcon: controllerIcon(controller)
+                        )
+                    }
+                    ForEach(disconnectedIds, id: \.self) { id in
+                        DisconnectedControllerSlotModeRow(
+                            id: id,
+                            controllerManager: controllerManager
                         )
                     }
                 } header: {
@@ -525,13 +533,10 @@ private struct ControllerSlotModeRow: View {
                 Spacer()
 
                 if currentMode != .auto {
-                    Button(action: {
+                    Button("Reset", role: .destructive) {
                         controllerManager.clearSlotMode(for: controller)
-                    }) {
-                        Text("Reset")
-                            .font(.caption)
-                            .foregroundColor(.red)
                     }
+                    .font(.caption)
                     .buttonStyle(.borderless)
                 }
             }
@@ -571,7 +576,104 @@ private struct ControllerSlotModeRow: View {
                         }
                     }
                 )) {
-                    ForEach(1...4, id: \.self) { slot in
+                    ForEach(1...8, id: \.self) { slot in
+                        Text("P\(slot)").tag(slot)
+                    }
+                }
+                .pickerStyle(.segmented)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+/// A row showing stored slot-mode for a controller that is no longer connected.
+private struct DisconnectedControllerSlotModeRow: View {
+    let id: String
+    @ObservedObject var controllerManager: PVControllerManager
+
+    private enum ModeCategory: String, CaseIterable, Identifiable {
+        case auto = "Auto"
+        case preferred = "Preferred"
+        case always = "Always"
+        var id: String { rawValue }
+    }
+
+    private var currentMode: ControllerSlotMode {
+        controllerManager.slotMode(forId: id)
+    }
+
+    private var modeCategory: ModeCategory {
+        switch currentMode {
+        case .auto: return .auto
+        case .preferred: return .preferred
+        case .always: return .always
+        }
+    }
+
+    private var selectedSlot: Int {
+        currentMode.preferredSlot ?? 1
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 12) {
+                Image(systemName: "gamecontroller")
+                    .imageScale(.large)
+                    .foregroundColor(.secondary)
+                    .frame(width: 30)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(id)
+                        .font(.headline)
+                    Text("Disconnected")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
+                Spacer()
+
+                Button("Reset", role: .destructive) {
+                    controllerManager.clearSlotMode(forId: id)
+                }
+                .font(.caption)
+                .buttonStyle(.borderless)
+            }
+
+            Picker("Mode", selection: Binding(
+                get: { modeCategory },
+                set: { newCategory in
+                    switch newCategory {
+                    case .auto:
+                        controllerManager.setSlotMode(.auto, forId: id)
+                    case .preferred:
+                        controllerManager.setSlotMode(.preferred(selectedSlot), forId: id)
+                    case .always:
+                        controllerManager.setSlotMode(.always(selectedSlot), forId: id)
+                    }
+                }
+            )) {
+                ForEach(ModeCategory.allCases) { category in
+                    Text(category.rawValue).tag(category)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            if modeCategory != .auto {
+                Picker("Player Slot", selection: Binding(
+                    get: { selectedSlot },
+                    set: { newSlot in
+                        switch modeCategory {
+                        case .auto:
+                            break
+                        case .preferred:
+                            controllerManager.setSlotMode(.preferred(newSlot), forId: id)
+                        case .always:
+                            controllerManager.setSlotMode(.always(newSlot), forId: id)
+                        }
+                    }
+                )) {
+                    ForEach(1...8, id: \.self) { slot in
                         Text("P\(slot)").tag(slot)
                     }
                 }

--- a/PVUI/Sources/PVSwiftUI/Settings/Views/ControllerSettingsView.swift
+++ b/PVUI/Sources/PVSwiftUI/Settings/Views/ControllerSettingsView.swift
@@ -530,6 +530,10 @@ private struct ControllerSlotModeRow: View {
     let accentColor: Color
     let controllerIcon: String
 
+    private var currentPlayerNumber: Int? {
+        controllerManager.allLiveControllers.first(where: { $0.value == controller })?.key
+    }
+
     private var currentMode: ControllerSlotMode {
         controllerManager.slotMode(for: controller)
     }
@@ -589,6 +593,16 @@ private struct ControllerSlotModeRow: View {
                     .font(.headline)
 
                 Spacer()
+
+                if let playerNumber = currentPlayerNumber {
+                    Text("P\(playerNumber)")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(Color.secondary.opacity(0.2))
+                        .clipShape(Capsule())
+                }
 
                 if currentMode != .auto {
                     Button("Reset", role: .destructive) {

--- a/PVUI/Sources/PVSwiftUI/Settings/Views/ControllerSettingsView.swift
+++ b/PVUI/Sources/PVSwiftUI/Settings/Views/ControllerSettingsView.swift
@@ -12,7 +12,6 @@ import GameController
 import PVThemes
 import PVLibrary
 import PVRealm
-import PVSettings
 import MarkdownView
 #if canImport(PVUI_IOS)
 import PVUI_IOS
@@ -487,6 +486,43 @@ struct ControllerSettingsView: View {
     }
 }
 
+// MARK: - Shared slot-mode types
+
+/// The three mode categories available to the user in slot pickers.
+private enum SlotModeCategory: String, CaseIterable, Identifiable {
+    case auto = "Auto"
+    case preferred = "Preferred"
+    case always = "Always"
+    var id: String { rawValue }
+}
+
+/// Shared segmented pickers for mode + player-slot selection.
+/// Used by both `ControllerSlotModeRow` and `DisconnectedControllerSlotModeRow`.
+private struct SlotModePickerSection: View {
+    @Binding var category: SlotModeCategory
+    @Binding var slot: Int
+
+    var body: some View {
+        Picker("Mode", selection: $category) {
+            ForEach(SlotModeCategory.allCases) { cat in
+                Text(cat.rawValue).tag(cat)
+            }
+        }
+        .pickerStyle(.segmented)
+
+        if category != .auto {
+            Picker("Player Slot", selection: $slot) {
+                ForEach(1...8, id: \.self) { s in
+                    Text("P\(s)").tag(s)
+                }
+            }
+            .pickerStyle(.segmented)
+        }
+    }
+}
+
+// MARK: - Row views
+
 /// A row showing the slot mode for a single controller with inline pickers.
 private struct ControllerSlotModeRow: View {
     let controller: GCController
@@ -494,19 +530,11 @@ private struct ControllerSlotModeRow: View {
     let accentColor: Color
     let controllerIcon: String
 
-    /// The three mode categories available to the user.
-    private enum ModeCategory: String, CaseIterable, Identifiable {
-        case auto = "Auto"
-        case preferred = "Preferred"
-        case always = "Always"
-        var id: String { rawValue }
-    }
-
     private var currentMode: ControllerSlotMode {
         controllerManager.slotMode(for: controller)
     }
 
-    private var modeCategory: ModeCategory {
+    private var modeCategory: SlotModeCategory {
         switch currentMode {
         case .auto: return .auto
         case .preferred: return .preferred
@@ -518,9 +546,39 @@ private struct ControllerSlotModeRow: View {
         currentMode.preferredSlot ?? 1
     }
 
+    private var categoryBinding: Binding<SlotModeCategory> {
+        Binding(
+            get: { modeCategory },
+            set: { newCategory in
+                switch newCategory {
+                case .auto:
+                    controllerManager.setSlotMode(.auto, for: controller)
+                case .preferred:
+                    controllerManager.setSlotMode(.preferred(selectedSlot), for: controller)
+                case .always:
+                    controllerManager.setSlotMode(.always(selectedSlot), for: controller)
+                }
+            }
+        )
+    }
+
+    private var slotBinding: Binding<Int> {
+        Binding(
+            get: { selectedSlot },
+            set: { newSlot in
+                switch modeCategory {
+                case .auto: break
+                case .preferred:
+                    controllerManager.setSlotMode(.preferred(newSlot), for: controller)
+                case .always:
+                    controllerManager.setSlotMode(.always(newSlot), for: controller)
+                }
+            }
+        )
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            // Controller name header
             HStack(spacing: 12) {
                 Image(systemName: controllerIcon)
                     .imageScale(.large)
@@ -541,47 +599,7 @@ private struct ControllerSlotModeRow: View {
                 }
             }
 
-            // Mode picker
-            Picker("Mode", selection: Binding(
-                get: { modeCategory },
-                set: { newCategory in
-                    switch newCategory {
-                    case .auto:
-                        controllerManager.setSlotMode(.auto, for: controller)
-                    case .preferred:
-                        controllerManager.setSlotMode(.preferred(selectedSlot), for: controller)
-                    case .always:
-                        controllerManager.setSlotMode(.always(selectedSlot), for: controller)
-                    }
-                }
-            )) {
-                ForEach(ModeCategory.allCases) { category in
-                    Text(category.rawValue).tag(category)
-                }
-            }
-            .pickerStyle(.segmented)
-
-            // Player slot picker (only when not Auto)
-            if modeCategory != .auto {
-                Picker("Player Slot", selection: Binding(
-                    get: { selectedSlot },
-                    set: { newSlot in
-                        switch modeCategory {
-                        case .auto:
-                            break
-                        case .preferred:
-                            controllerManager.setSlotMode(.preferred(newSlot), for: controller)
-                        case .always:
-                            controllerManager.setSlotMode(.always(newSlot), for: controller)
-                        }
-                    }
-                )) {
-                    ForEach(1...8, id: \.self) { slot in
-                        Text("P\(slot)").tag(slot)
-                    }
-                }
-                .pickerStyle(.segmented)
-            }
+            SlotModePickerSection(category: categoryBinding, slot: slotBinding)
         }
         .padding(.vertical, 4)
     }
@@ -592,18 +610,11 @@ private struct DisconnectedControllerSlotModeRow: View {
     let id: String
     @ObservedObject var controllerManager: PVControllerManager
 
-    private enum ModeCategory: String, CaseIterable, Identifiable {
-        case auto = "Auto"
-        case preferred = "Preferred"
-        case always = "Always"
-        var id: String { rawValue }
-    }
-
     private var currentMode: ControllerSlotMode {
         controllerManager.slotMode(forId: id)
     }
 
-    private var modeCategory: ModeCategory {
+    private var modeCategory: SlotModeCategory {
         switch currentMode {
         case .auto: return .auto
         case .preferred: return .preferred
@@ -613,6 +624,37 @@ private struct DisconnectedControllerSlotModeRow: View {
 
     private var selectedSlot: Int {
         currentMode.preferredSlot ?? 1
+    }
+
+    private var categoryBinding: Binding<SlotModeCategory> {
+        Binding(
+            get: { modeCategory },
+            set: { newCategory in
+                switch newCategory {
+                case .auto:
+                    controllerManager.setSlotMode(.auto, forId: id)
+                case .preferred:
+                    controllerManager.setSlotMode(.preferred(selectedSlot), forId: id)
+                case .always:
+                    controllerManager.setSlotMode(.always(selectedSlot), forId: id)
+                }
+            }
+        )
+    }
+
+    private var slotBinding: Binding<Int> {
+        Binding(
+            get: { selectedSlot },
+            set: { newSlot in
+                switch modeCategory {
+                case .auto: break
+                case .preferred:
+                    controllerManager.setSlotMode(.preferred(newSlot), forId: id)
+                case .always:
+                    controllerManager.setSlotMode(.always(newSlot), forId: id)
+                }
+            }
+        )
     }
 
     var body: some View {
@@ -626,6 +668,8 @@ private struct DisconnectedControllerSlotModeRow: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(id)
                         .font(.headline)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
                     Text("Disconnected")
                         .font(.caption)
                         .foregroundColor(.secondary)
@@ -640,45 +684,7 @@ private struct DisconnectedControllerSlotModeRow: View {
                 .buttonStyle(.borderless)
             }
 
-            Picker("Mode", selection: Binding(
-                get: { modeCategory },
-                set: { newCategory in
-                    switch newCategory {
-                    case .auto:
-                        controllerManager.setSlotMode(.auto, forId: id)
-                    case .preferred:
-                        controllerManager.setSlotMode(.preferred(selectedSlot), forId: id)
-                    case .always:
-                        controllerManager.setSlotMode(.always(selectedSlot), forId: id)
-                    }
-                }
-            )) {
-                ForEach(ModeCategory.allCases) { category in
-                    Text(category.rawValue).tag(category)
-                }
-            }
-            .pickerStyle(.segmented)
-
-            if modeCategory != .auto {
-                Picker("Player Slot", selection: Binding(
-                    get: { selectedSlot },
-                    set: { newSlot in
-                        switch modeCategory {
-                        case .auto:
-                            break
-                        case .preferred:
-                            controllerManager.setSlotMode(.preferred(newSlot), forId: id)
-                        case .always:
-                            controllerManager.setSlotMode(.always(newSlot), forId: id)
-                        }
-                    }
-                )) {
-                    ForEach(1...8, id: \.self) { slot in
-                        Text("P\(slot)").tag(slot)
-                    }
-                }
-                .pickerStyle(.segmented)
-            }
+            SlotModePickerSection(category: categoryBinding, slot: slotBinding)
         }
         .padding(.vertical, 4)
     }

--- a/PVUI/Sources/PVUIBase/Controller/PVControllerManager.swift
+++ b/PVUI/Sources/PVUIBase/Controller/PVControllerManager.swift
@@ -342,7 +342,8 @@ public final class PVControllerManager: NSObject, ObservableObject {
         PVControllerManager.shared.disconnectController(controller)
     }
 
-    @objc func disconnectController(_ controller:GCController) {
+    @MainActor
+    @objc func disconnectController(_ controller: GCController) {
         ILOG("Controller disconnected: \(controller.vendorName ?? "No Vendor")")
         guard !PVControllerManager.shared.skipControllerBinding else {
             return

--- a/PVUI/Sources/PVUIBase/Controller/PVControllerManager.swift
+++ b/PVUI/Sources/PVUIBase/Controller/PVControllerManager.swift
@@ -1012,6 +1012,36 @@ public extension PVControllerManager {
         setSlotMode(.auto, for: controller)
     }
 
+    // MARK: ID-based slot mode API (for disconnected / previously-seen controllers)
+
+    /// All controller identifiers that have a non-auto stored slot-mode preference.
+    var storedControllerIds: [String] {
+        Defaults[.controllerSlotModes].keys.sorted()
+    }
+
+    /// Returns the saved ``ControllerSlotMode`` for a controller identified by its string ID, or `.auto` when none is stored.
+    func slotMode(forId id: String) -> ControllerSlotMode {
+        Defaults[.controllerSlotModes][id] ?? .auto
+    }
+
+    /// Persists the ``ControllerSlotMode`` for a controller identified by its string ID.
+    /// Setting `.auto` removes any stored preference.
+    func setSlotMode(_ mode: ControllerSlotMode, forId id: String) {
+        var modes = Defaults[.controllerSlotModes]
+        if case .auto = mode {
+            modes.removeValue(forKey: id)
+        } else {
+            modes[id] = mode
+        }
+        Defaults[.controllerSlotModes] = modes
+        ILOG("Saved slot mode \(mode) for controller [\(id)]")
+    }
+
+    /// Removes any saved slot mode for the given controller ID, reverting to `.auto`.
+    func clearSlotMode(forId id: String) {
+        setSlotMode(.auto, forId: id)
+    }
+
     // MARK: Convenience Int-based API (kept for backward compatibility)
 
     /// Returns the stored preferred player slot (1–8) for a controller, or `nil` if none has been saved.

--- a/PVUI/Sources/PVUIBase/Controller/PVControllerManager.swift
+++ b/PVUI/Sources/PVUIBase/Controller/PVControllerManager.swift
@@ -1016,7 +1016,10 @@ public extension PVControllerManager {
 
     /// All controller identifiers that have a non-auto stored slot-mode preference.
     var storedControllerIds: [String] {
-        Defaults[.controllerSlotModes].keys.sorted()
+        Defaults[.controllerSlotModes].filter { _, mode in
+            if case .auto = mode { return false }
+            return true
+        }.keys.sorted()
     }
 
     /// Returns the saved ``ControllerSlotMode`` for a controller identified by its string ID, or `.auto` when none is stored.

--- a/PVUI/Sources/PVUIBase/Controller/PVControllerManager.swift
+++ b/PVUI/Sources/PVUIBase/Controller/PVControllerManager.swift
@@ -301,6 +301,7 @@ public final class PVControllerManager: NSObject, ObservableObject {
             return
         }
 
+        objectWillChange.send()
         let wrapper = getRemappableController(for: controller)
         /// Mappings are loaded in PVRemappableController.init(), no need to load again
 
@@ -347,6 +348,7 @@ public final class PVControllerManager: NSObject, ObservableObject {
             return
         }
 
+        objectWillChange.send()
         removeRemappableController(for: controller)
 
         if controller == player1 {
@@ -1003,6 +1005,7 @@ public extension PVControllerManager {
         } else {
             modes[id] = mode
         }
+        objectWillChange.send()
         Defaults[.controllerSlotModes] = modes
         ILOG("Saved slot mode \(mode) for controller [\(id)]")
     }
@@ -1017,11 +1020,10 @@ public extension PVControllerManager {
     /// All controller identifiers that have a non-auto stored slot-mode preference.
     var storedControllerIds: [String] {
         Defaults[.controllerSlotModes]
-            .filter { _, mode in
-                if case .auto = mode { return false }
-                return true
+            .compactMap { key, mode -> String? in
+                if case .auto = mode { return nil }
+                return key
             }
-            .map(\.key)
             .sorted()
     }
 
@@ -1039,6 +1041,7 @@ public extension PVControllerManager {
         } else {
             modes[id] = mode
         }
+        objectWillChange.send()
         Defaults[.controllerSlotModes] = modes
         ILOG("Saved slot mode \(mode) for controller [\(id)]")
     }

--- a/PVUI/Sources/PVUIBase/Controller/PVControllerManager.swift
+++ b/PVUI/Sources/PVUIBase/Controller/PVControllerManager.swift
@@ -1016,10 +1016,13 @@ public extension PVControllerManager {
 
     /// All controller identifiers that have a non-auto stored slot-mode preference.
     var storedControllerIds: [String] {
-        Defaults[.controllerSlotModes].filter { _, mode in
-            if case .auto = mode { return false }
-            return true
-        }.keys.sorted()
+        Defaults[.controllerSlotModes]
+            .filter { _, mode in
+                if case .auto = mode { return false }
+                return true
+            }
+            .map(\.key)
+            .sorted()
     }
 
     /// Returns the saved ``ControllerSlotMode`` for a controller identified by its string ID, or `.auto` when none is stored.

--- a/PVUI/Tests/PVUIBaseTests/PVControllerPlayerSlotPreferencesTests.swift
+++ b/PVUI/Tests/PVUIBaseTests/PVControllerPlayerSlotPreferencesTests.swift
@@ -40,6 +40,8 @@ struct PVControllerPlayerSlotPreferencesTests {
     @MainActor
     func preferredPlayerReturnsNilWhenNotSet() async throws {
         let manager = PVControllerManager.shared
+        let restore = snapshotSlotModes()
+        defer { restore() }
         let controller = freshController()
 
         let result = manager.preferredPlayer(for: controller)
@@ -50,9 +52,9 @@ struct PVControllerPlayerSlotPreferencesTests {
     @MainActor
     func roundtripPreferredPlayer() async throws {
         let manager = PVControllerManager.shared
-        let controller = freshController()
         let restore = snapshotSlotModes()
         defer { restore() }
+        let controller = freshController()
 
         manager.setPreferredPlayer(2, for: controller)
         let result = manager.preferredPlayer(for: controller)
@@ -63,9 +65,9 @@ struct PVControllerPlayerSlotPreferencesTests {
     @MainActor
     func clearingPreference() async throws {
         let manager = PVControllerManager.shared
-        let controller = freshController()
         let restore = snapshotSlotModes()
         defer { restore() }
+        let controller = freshController()
 
         manager.setPreferredPlayer(3, for: controller)
         manager.setPreferredPlayer(nil, for: controller)
@@ -77,9 +79,9 @@ struct PVControllerPlayerSlotPreferencesTests {
     @MainActor
     func outOfRangeValuesAreIgnored() async throws {
         let manager = PVControllerManager.shared
-        let controller = freshController()
         let restore = snapshotSlotModes()
         defer { restore() }
+        let controller = freshController()
 
         manager.setPreferredPlayer(0, for: controller)
         #expect(manager.preferredPlayer(for: controller) == nil, "0 should be rejected")
@@ -104,6 +106,8 @@ struct PVControllerPlayerSlotPreferencesTests {
     @Test("slotMode returns .auto when nothing is stored")
     @MainActor
     func slotModeDefaultsToAuto() async throws {
+        let restore = snapshotSlotModes()
+        defer { restore() }
         let controller = freshController()
         let mode = PVControllerManager.shared.slotMode(for: controller)
         #expect(mode == .auto)
@@ -113,9 +117,9 @@ struct PVControllerPlayerSlotPreferencesTests {
     @MainActor
     func slotModePreferredRoundtrip() async throws {
         let manager = PVControllerManager.shared
-        let controller = freshController()
         let restore = snapshotSlotModes()
         defer { restore() }
+        let controller = freshController()
 
         manager.setSlotMode(.preferred(4), for: controller)
         #expect(manager.slotMode(for: controller) == .preferred(4))
@@ -126,9 +130,9 @@ struct PVControllerPlayerSlotPreferencesTests {
     @MainActor
     func slotModeAlwaysRoundtrip() async throws {
         let manager = PVControllerManager.shared
-        let controller = freshController()
         let restore = snapshotSlotModes()
         defer { restore() }
+        let controller = freshController()
 
         manager.setSlotMode(.always(1), for: controller)
         #expect(manager.slotMode(for: controller) == .always(1))
@@ -139,9 +143,9 @@ struct PVControllerPlayerSlotPreferencesTests {
     @MainActor
     func clearSlotModeResetsToAuto() async throws {
         let manager = PVControllerManager.shared
-        let controller = freshController()
         let restore = snapshotSlotModes()
         defer { restore() }
+        let controller = freshController()
 
         manager.setSlotMode(.always(2), for: controller)
         manager.clearSlotMode(for: controller)
@@ -154,9 +158,9 @@ struct PVControllerPlayerSlotPreferencesTests {
     @MainActor
     func setSlotModeAutoClears() async throws {
         let manager = PVControllerManager.shared
-        let controller = freshController()
         let restore = snapshotSlotModes()
         defer { restore() }
+        let controller = freshController()
 
         manager.setSlotMode(.preferred(3), for: controller)
         manager.setSlotMode(.auto, for: controller)
@@ -245,10 +249,10 @@ struct PVControllerPlayerSlotPreferencesTests {
     @MainActor
     func assignPreferredClaimsFreeSlot() async throws {
         let manager = PVControllerManager.shared
-        let controller1 = freshController()
-        let controller2 = freshController()
         let restore = snapshotSlotModes()
         defer { restore() }
+        let controller1 = freshController()
+        let controller2 = freshController()
 
         manager.setSlotMode(.preferred(1), for: controller1)
         manager.setSlotMode(.auto, for: controller2)
@@ -266,10 +270,10 @@ struct PVControllerPlayerSlotPreferencesTests {
     @MainActor
     func assignPreferredFallsBackWhenOccupied() async throws {
         let manager = PVControllerManager.shared
-        let controller1 = freshController()
-        let controller2 = freshController()
         let restore = snapshotSlotModes()
         defer { restore() }
+        let controller1 = freshController()
+        let controller2 = freshController()
 
         // First controller uses auto and should occupy player 1.
         manager.setSlotMode(.auto, for: controller1)
@@ -290,10 +294,10 @@ struct PVControllerPlayerSlotPreferencesTests {
     @MainActor
     func alwaysEvictsOccupantToNextFreeSlot() async throws {
         let manager = PVControllerManager.shared
-        let controller1 = freshController()
-        let controller2 = freshController()
         let restore = snapshotSlotModes()
         defer { restore() }
+        let controller1 = freshController()
+        let controller2 = freshController()
 
         // Start with a single auto-assigned controller on player 1.
         manager.setSlotMode(.auto, for: controller1)

--- a/PVUI/Tests/PVUIBaseTests/PVControllerPlayerSlotPreferencesTests.swift
+++ b/PVUI/Tests/PVUIBaseTests/PVControllerPlayerSlotPreferencesTests.swift
@@ -180,6 +180,45 @@ struct PVControllerPlayerSlotPreferencesTests {
         #expect(bridge.deserialize("unknown:3") == nil)
     }
 
+    // MARK: - ID-based slot mode API
+
+    @Test("slotMode(forId:) returns .auto for unknown ID")
+    @MainActor
+    func slotModeForIdDefaultsToAuto() async throws {
+        let mode = PVControllerManager.shared.slotMode(forId: "NonExistentController-\(UUID().uuidString)")
+        #expect(mode == .auto)
+    }
+
+    @Test("setSlotMode(_:forId:) round-trips via slotMode(forId:)")
+    @MainActor
+    func slotModeForIdRoundtrip() async throws {
+        let manager = PVControllerManager.shared
+        let fakeId = "TestController-\(UUID().uuidString)"
+
+        manager.setSlotMode(.preferred(3), forId: fakeId)
+        #expect(manager.slotMode(forId: fakeId) == .preferred(3))
+        #expect(manager.storedControllerIds.contains(fakeId))
+
+        manager.clearSlotMode(forId: fakeId)
+        #expect(manager.slotMode(forId: fakeId) == .auto)
+        #expect(!manager.storedControllerIds.contains(fakeId))
+    }
+
+    @Test("storedControllerIds only contains IDs with non-auto modes")
+    @MainActor
+    func storedControllerIdsExcludesAuto() async throws {
+        let manager = PVControllerManager.shared
+        let fakeId = "TestController-\(UUID().uuidString)"
+
+        manager.setSlotMode(.auto, forId: fakeId)
+        #expect(!manager.storedControllerIds.contains(fakeId))
+
+        manager.setSlotMode(.always(2), forId: fakeId)
+        #expect(manager.storedControllerIds.contains(fakeId))
+
+        manager.clearSlotMode(forId: fakeId)
+    }
+
     // MARK: - assign(_:) / reapplyPreferences() behavior
 
     @Test("assign - .preferred(n) claims a free slot and auto fills remaining")

--- a/PVUI/Tests/PVUIBaseTests/PVControllerPlayerSlotPreferencesTests.swift
+++ b/PVUI/Tests/PVUIBaseTests/PVControllerPlayerSlotPreferencesTests.swift
@@ -23,6 +23,17 @@ struct PVControllerPlayerSlotPreferencesTests {
         return c
     }
 
+    /// Returns a closure that restores `Defaults[.controllerSlotModes]` to the
+    /// state at call time. Use with `defer` so cleanup runs even on test failure:
+    ///
+    ///     let restore = snapshotSlotModes()
+    ///     defer { restore() }
+    @MainActor
+    private func snapshotSlotModes() -> @MainActor () -> Void {
+        let snapshot = Defaults[.controllerSlotModes]
+        return { Defaults[.controllerSlotModes] = snapshot }
+    }
+
     // MARK: - preferredPlayer / setPreferredPlayer (convenience API)
 
     @Test("preferredPlayer returns nil when no preference stored")
@@ -40,13 +51,12 @@ struct PVControllerPlayerSlotPreferencesTests {
     func roundtripPreferredPlayer() async throws {
         let manager = PVControllerManager.shared
         let controller = freshController()
+        let restore = snapshotSlotModes()
+        defer { restore() }
 
         manager.setPreferredPlayer(2, for: controller)
         let result = manager.preferredPlayer(for: controller)
         #expect(result == 2)
-
-        // Cleanup
-        manager.setPreferredPlayer(nil, for: controller)
     }
 
     @Test("setPreferredPlayer with nil clears an existing preference")
@@ -54,6 +64,8 @@ struct PVControllerPlayerSlotPreferencesTests {
     func clearingPreference() async throws {
         let manager = PVControllerManager.shared
         let controller = freshController()
+        let restore = snapshotSlotModes()
+        defer { restore() }
 
         manager.setPreferredPlayer(3, for: controller)
         manager.setPreferredPlayer(nil, for: controller)
@@ -66,6 +78,8 @@ struct PVControllerPlayerSlotPreferencesTests {
     func outOfRangeValuesAreIgnored() async throws {
         let manager = PVControllerManager.shared
         let controller = freshController()
+        let restore = snapshotSlotModes()
+        defer { restore() }
 
         manager.setPreferredPlayer(0, for: controller)
         #expect(manager.preferredPlayer(for: controller) == nil, "0 should be rejected")
@@ -100,12 +114,12 @@ struct PVControllerPlayerSlotPreferencesTests {
     func slotModePreferredRoundtrip() async throws {
         let manager = PVControllerManager.shared
         let controller = freshController()
+        let restore = snapshotSlotModes()
+        defer { restore() }
 
         manager.setSlotMode(.preferred(4), for: controller)
         #expect(manager.slotMode(for: controller) == .preferred(4))
         #expect(manager.preferredPlayer(for: controller) == 4)
-
-        manager.clearSlotMode(for: controller)
     }
 
     @Test("setSlotMode(.always) round-trips correctly")
@@ -113,12 +127,12 @@ struct PVControllerPlayerSlotPreferencesTests {
     func slotModeAlwaysRoundtrip() async throws {
         let manager = PVControllerManager.shared
         let controller = freshController()
+        let restore = snapshotSlotModes()
+        defer { restore() }
 
         manager.setSlotMode(.always(1), for: controller)
         #expect(manager.slotMode(for: controller) == .always(1))
         #expect(manager.preferredPlayer(for: controller) == 1)
-
-        manager.clearSlotMode(for: controller)
     }
 
     @Test("clearSlotMode resets to .auto")
@@ -126,6 +140,8 @@ struct PVControllerPlayerSlotPreferencesTests {
     func clearSlotModeResetsToAuto() async throws {
         let manager = PVControllerManager.shared
         let controller = freshController()
+        let restore = snapshotSlotModes()
+        defer { restore() }
 
         manager.setSlotMode(.always(2), for: controller)
         manager.clearSlotMode(for: controller)
@@ -139,6 +155,8 @@ struct PVControllerPlayerSlotPreferencesTests {
     func setSlotModeAutoClears() async throws {
         let manager = PVControllerManager.shared
         let controller = freshController()
+        let restore = snapshotSlotModes()
+        defer { restore() }
 
         manager.setSlotMode(.preferred(3), for: controller)
         manager.setSlotMode(.auto, for: controller)
@@ -194,6 +212,8 @@ struct PVControllerPlayerSlotPreferencesTests {
     func slotModeForIdRoundtrip() async throws {
         let manager = PVControllerManager.shared
         let fakeId = "TestController-\(UUID().uuidString)"
+        let restore = snapshotSlotModes()
+        defer { restore() }
 
         manager.setSlotMode(.preferred(3), forId: fakeId)
         #expect(manager.slotMode(forId: fakeId) == .preferred(3))
@@ -209,14 +229,14 @@ struct PVControllerPlayerSlotPreferencesTests {
     func storedControllerIdsExcludesAuto() async throws {
         let manager = PVControllerManager.shared
         let fakeId = "TestController-\(UUID().uuidString)"
+        let restore = snapshotSlotModes()
+        defer { restore() }
 
         manager.setSlotMode(.auto, forId: fakeId)
         #expect(!manager.storedControllerIds.contains(fakeId))
 
         manager.setSlotMode(.always(2), forId: fakeId)
         #expect(manager.storedControllerIds.contains(fakeId))
-
-        manager.clearSlotMode(forId: fakeId)
     }
 
     // MARK: - assign(_:) / reapplyPreferences() behavior
@@ -227,6 +247,8 @@ struct PVControllerPlayerSlotPreferencesTests {
         let manager = PVControllerManager.shared
         let controller1 = freshController()
         let controller2 = freshController()
+        let restore = snapshotSlotModes()
+        defer { restore() }
 
         manager.setSlotMode(.preferred(1), for: controller1)
         manager.setSlotMode(.auto, for: controller2)
@@ -246,6 +268,8 @@ struct PVControllerPlayerSlotPreferencesTests {
         let manager = PVControllerManager.shared
         let controller1 = freshController()
         let controller2 = freshController()
+        let restore = snapshotSlotModes()
+        defer { restore() }
 
         // First controller uses auto and should occupy player 1.
         manager.setSlotMode(.auto, for: controller1)
@@ -268,6 +292,8 @@ struct PVControllerPlayerSlotPreferencesTests {
         let manager = PVControllerManager.shared
         let controller1 = freshController()
         let controller2 = freshController()
+        let restore = snapshotSlotModes()
+        defer { restore() }
 
         // Start with a single auto-assigned controller on player 1.
         manager.setSlotMode(.auto, for: controller1)

--- a/PVUI/Tests/PVUIBaseTests/PVControllerPlayerSlotPreferencesTests.swift
+++ b/PVUI/Tests/PVUIBaseTests/PVControllerPlayerSlotPreferencesTests.swift
@@ -207,6 +207,8 @@ struct PVControllerPlayerSlotPreferencesTests {
     @Test("slotMode(forId:) returns .auto for unknown ID")
     @MainActor
     func slotModeForIdDefaultsToAuto() async throws {
+        let restore = snapshotSlotModes()
+        defer { restore() }
         let mode = PVControllerManager.shared.slotMode(forId: "NonExistentController-\(UUID().uuidString)")
         #expect(mode == .auto)
     }


### PR DESCRIPTION
## Summary
- Adds a "Preferred Player Slots" section to `ControllerSettingsView` for each connected controller
- Users can choose between Auto / Preferred / Always slot modes via a segmented picker
- When Preferred or Always is selected, a P1-P8 player slot picker appears (matching the full 8-player support in `PVControllerManager`)
- Per-controller "Reset" button (destructive role) clears preferences back to Auto
- Previously-seen disconnected controllers also appear so preferences can be reviewed and reset without reconnecting
- Uses the existing `PVControllerManager` API (`slotMode(for:)`, `setSlotMode(_:for:)`, `clearSlotMode(for:)`) plus new ID-based helpers for disconnected controllers
- `objectWillChange.send()` is now called from slot-mode setters and connect/disconnect handlers so the settings UI updates live

Closes #2774

## Test plan
- [ ] Connect one or more controllers to the device
- [ ] Open Settings > Controller Settings and scroll to "Preferred Player Slots"
- [ ] Verify each connected controller appears with its name and icon
- [ ] Toggle between Auto / Preferred / Always and confirm the player slot picker appears/hides
- [ ] Select different player slots (P1-P8) and verify persistence across app restarts
- [ ] Tap "Reset" and confirm the controller reverts to Auto mode
- [ ] Disconnect a controller — verify it still appears in the "Preferred Player Slots" section with its stored preference
- [ ] Reconnect the controller — confirm it moves back to the connected list
- [ ] Verify the section is hidden when no controllers are connected AND no stored preferences exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)
