### PR TITLE
[Agent] feat(JIT): wire JIT onboarding into core launch lifecycle (#2798)

### DIFF
--- a/PVJIT/Sources/JITManager/JITOnboardingManager.swift
+++ b/PVJIT/Sources/JITManager/JITOnboardingManager.swift
@@ -57,9 +57,7 @@ public final class JITOnboardingManager {
             return false
         }
 
-        hasShownThisSession = true
-
-        ILOG("JITOnboarding: Presenting JIT onboarding alert")
+        ILOG("JITOnboarding: Preparing JIT onboarding alert")
 
         let alert = UIAlertController(
             title: "JIT Not Enabled",
@@ -85,7 +83,19 @@ public final class JITOnboardingManager {
             }
         })
 
-        viewController.present(alert, animated: true)
+        // Ensure we can actually present before marking the onboarding as shown
+        guard viewController.viewIfLoaded?.window != nil,
+            viewController.presentedViewController == nil else {
+            WLOG("JITOnboarding: Unable to present onboarding alert (VC not in window or already presenting); will allow retry later")
+            return false
+        }
+
+        ILOG("JITOnboarding: Presenting JIT onboarding alert")
+
+        viewController.present(alert, animated: true) { [weak self] in
+            self?.hasShownThisSession = true
+        }
+
         return true
     }
 

--- a/PVJIT/Sources/JITManager/JITOnboardingManager.swift
+++ b/PVJIT/Sources/JITManager/JITOnboardingManager.swift
@@ -1,0 +1,95 @@
+//
+//  JITOnboardingManager.swift
+//
+//
+//  Created by Provenance EMU on 2026-03-15.
+//
+
+import Foundation
+import PVLogging
+
+#if canImport(UIKit) && !os(watchOS)
+import UIKit
+
+/// Manages JIT onboarding presentation at core launch time.
+///
+/// Call `presentOnboardingIfNeeded(for:from:)` before starting emulation
+/// to inform the user when JIT has not been acquired. The alert is presented
+/// at most once per app session and does not block emulation — it is purely
+/// informational with optional actions to retry JIT acquisition.
+@MainActor
+public final class JITOnboardingManager {
+
+    public static let shared = JITOnboardingManager()
+
+    /// Whether the onboarding alert has already been shown this session.
+    private var hasShownThisSession = false
+
+    private init() {}
+
+    /// Present JIT onboarding if JIT is required but not yet acquired.
+    ///
+    /// - Parameters:
+    ///   - jitManager: The JIT manager to query for JIT status. Defaults to `DOLJitManager.shared`.
+    ///   - viewController: The view controller to present the alert from.
+    /// - Returns: `true` if the onboarding was presented, `false` otherwise.
+    @discardableResult
+    public func presentOnboardingIfNeeded(
+        for jitManager: DOLJitManager = .shared,
+        from viewController: UIViewController
+    ) -> Bool {
+        // Only show once per session
+        guard !hasShownThisSession else {
+            DLOG("JITOnboarding: Already shown this session, skipping")
+            return false
+        }
+
+        // If JIT is already acquired, no need to show anything
+        guard !jitManager.appHasAcquiredJit() else {
+            DLOG("JITOnboarding: JIT already acquired, skipping")
+            return false
+        }
+
+        // If the JIT type is unrestricted or not applicable, skip
+        let jitType = jitManager.getJitType()
+        guard jitType != .notRestricted else {
+            DLOG("JITOnboarding: JIT not restricted on this device, skipping")
+            return false
+        }
+
+        hasShownThisSession = true
+
+        ILOG("JITOnboarding: Presenting JIT onboarding alert")
+
+        let alert = UIAlertController(
+            title: "JIT Not Enabled",
+            message: "Some emulator cores perform better with Just-In-Time (JIT) compilation enabled. "
+                + "JIT has not been acquired for this session. You can continue playing, but performance "
+                + "may be reduced for cores that rely on JIT.\n\n"
+                + "To enable JIT, connect via AltServer, JITStreamer, or a debugger before launching a game.",
+            preferredStyle: .alert
+        )
+
+        alert.addAction(UIAlertAction(title: "Continue", style: .default, handler: nil))
+
+        alert.addAction(UIAlertAction(title: "Try JITStreamer", style: .default) { _ in
+            ILOG("JITOnboarding: User chose to retry via JITStreamer")
+            jitManager.attemptToAcquireJitByJitStreamer()
+        })
+
+        alert.addAction(UIAlertAction(title: "Learn More", style: .default) { _ in
+            if let url = URL(string: "https://wiki.provenance-emu.com/jit-help") {
+                UIApplication.shared.open(url)
+            }
+        })
+
+        viewController.present(alert, animated: true)
+        return true
+    }
+
+    /// Reset session tracking (useful for testing).
+    public func resetSession() {
+        hasShownThisSession = false
+    }
+}
+#endif

--- a/PVJIT/Sources/JITManager/JITOnboardingManager.swift
+++ b/PVJIT/Sources/JITManager/JITOnboardingManager.swift
@@ -72,10 +72,12 @@ public final class JITOnboardingManager {
 
         alert.addAction(UIAlertAction(title: "Continue", style: .default, handler: nil))
 
-        alert.addAction(UIAlertAction(title: "Try JITStreamer", style: .default) { _ in
-            ILOG("JITOnboarding: User chose to retry via JITStreamer")
-            jitManager.attemptToAcquireJitByJitStreamer()
-        })
+        if jitType == .debugger {
+            alert.addAction(UIAlertAction(title: "Try JITStreamer", style: .default) { _ in
+                ILOG("JITOnboarding: User chose to retry via JITStreamer")
+                jitManager.attemptToAcquireJitByJitStreamer()
+            })
+        }
 
         alert.addAction(UIAlertAction(title: "Learn More", style: .default) { _ in
             if let url = URL(string: "https://wiki.provenance-emu.com/jit-help") {

--- a/PVUI/Sources/PVUIBase/PVEmulatorVC/PVEmulatorViewController.swift
+++ b/PVUI/Sources/PVUIBase/PVEmulatorVC/PVEmulatorViewController.swift
@@ -27,6 +27,9 @@ import PVSettings
 import PVThemes
 import SwiftUI
 import ZipArchive
+#if canImport(PVJIT)
+import JITManager
+#endif
 
 private weak var staticSelf: PVEmualatorControllerProtocol?
 
@@ -577,6 +580,11 @@ final class PVEmulatorViewController: PVEmulatorViewControllerRootClass, PVEmual
 
         // Pause CloudKit when gameplay starts
         CloudKitDownloadQueue.shared.pauseQueue()
+
+        // Present JIT onboarding if JIT has not been acquired this session
+        #if canImport(PVJIT) && os(iOS)
+        JITOnboardingManager.shared.presentOnboardingIfNeeded(from: self)
+        #endif
 
         core.startEmulation()
 

--- a/PVUI/Sources/PVUIBase/PVEmulatorVC/PVEmulatorViewController.swift
+++ b/PVUI/Sources/PVUIBase/PVEmulatorVC/PVEmulatorViewController.swift
@@ -583,7 +583,18 @@ final class PVEmulatorViewController: PVEmulatorViewControllerRootClass, PVEmual
 
         // Present JIT onboarding if JIT has not been acquired this session
         #if canImport(PVJIT) && os(iOS)
-        JITOnboardingManager.shared.presentOnboardingIfNeeded(from: self)
+        func presentJITOnboardingWhenReady() {
+            // Ensure the view controller is in the window hierarchy before presenting
+            guard view.window != nil else {
+                DispatchQueue.main.async { [weak self] in
+                    guard let self else { return }
+                    presentJITOnboardingWhenReady()
+                }
+                return
+            }
+            JITOnboardingManager.shared.presentOnboardingIfNeeded(from: self)
+        }
+        presentJITOnboardingWhenReady()
         #endif
 
         core.startEmulation()


### PR DESCRIPTION
## Summary
- Add `JITOnboardingManager` singleton in `PVJIT/Sources/JITManager/` that presents a non-blocking informational alert when JIT has not been acquired
- Wire the manager into `PVEmulatorViewController.createEmulator()` just before `core.startEmulation()`, guarded by `#if canImport(PVJIT) && os(iOS)`
- The alert fires at most once per app session and offers "Continue", "Try JITStreamer", and "Learn More" actions

## Details
The existing JIT infrastructure (`DOLJitManager`, `JitWaitScreenViewController`, `PVAppDelegate+JIT`) handles JIT acquisition at app startup, but there was no notification at game launch time when JIT was not acquired. Users launching cores that benefit from JIT (e.g., Dolphin, Flycast, Citra) would see degraded performance without understanding why.

`JITOnboardingManager.presentOnboardingIfNeeded(from:)` checks:
1. Whether onboarding was already shown this session (skip if so)
2. Whether JIT is already acquired (skip if so)  
3. Whether JIT type is `.notRestricted` (skip if so, e.g. simulator)

If none of those conditions are met, it presents an alert and marks the session as shown.

## Test plan
- [ ] Launch a game on iOS device without JIT acquired -- verify the alert appears once
- [ ] Dismiss the alert and launch another game -- verify it does NOT appear again
- [ ] Launch a game with JIT already acquired -- verify no alert appears
- [ ] Build for tvOS -- verify the JIT code is properly excluded via `#if`
- [ ] Build for simulator -- verify no alert (JIT type is `.notRestricted`)

Closes #2798

🤖 Generated with [Claude Code](https://claude.com/claude-code)