### PR TITLE
[Agent] fix(crash): fix Realm thread-safety crashes in pause menu cheats and save states

### DIFF
--- a/.changelog/3162.md
+++ b/.changelog/3162.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Realm thread-safety crashes in pause menu** — cheats and save states views no longer crash when accessed via a `@ThreadSafe` game reference; cheats now re-query Realm on reload so newly added codes are visible without dismissing the view.

--- a/PVUI/Sources/PVUIBase/Cheats/TVOSCheatsView.swift
+++ b/PVUI/Sources/PVUIBase/Cheats/TVOSCheatsView.swift
@@ -373,7 +373,15 @@ public struct TVOSCheatsView: View {
     }
 
     private func loadCheats() {
-        let valid = cheats.filter { !$0.isInvalidated }
+        // Re-query Realm when gameMD5 is available so newly added/imported cheats
+        // (written after this view was presented) are reflected on reload.
+        let source: [PVCheats]
+        if let md5 = gameMD5, let realm = try? Realm() {
+            source = Array(realm.objects(PVCheats.self).filter("game.md5Hash == %@", md5))
+        } else {
+            source = cheats
+        }
+        let valid = source.filter { !$0.isInvalidated }
         let filtered: [PVCheats]
         if let coreID = coreID {
             filtered = valid.filter { $0.core?.identifier == coreID }

--- a/PVUI/Sources/PVUIBase/Cheats/TVOSCheatsView.swift
+++ b/PVUI/Sources/PVUIBase/Cheats/TVOSCheatsView.swift
@@ -376,7 +376,7 @@ public struct TVOSCheatsView: View {
         // Re-query Realm when gameMD5 is available so newly added/imported cheats
         // (written after this view was presented) are reflected on reload.
         let source: [PVCheats]
-        if let md5 = gameMD5, let realm = try? Realm() {
+        if let md5 = gameMD5, !md5.isEmpty, let realm = try? Realm() {
             source = Array(realm.objects(PVCheats.self).filter("game.md5Hash == %@", md5))
         } else {
             source = cheats

--- a/PVUI/Sources/PVUIBase/Cheats/TVOSCheatsView.swift
+++ b/PVUI/Sources/PVUIBase/Cheats/TVOSCheatsView.swift
@@ -101,7 +101,7 @@ public struct TVOSCheatsView: View {
     @Environment(\.dismiss) private var dismiss
     @ObservedObject private var themeManager = ThemeManager.shared
 
-    let cheats: LinkingObjects<PVCheats>
+    let cheats: [PVCheats]
     let coreID: String?
     let cheatTypes: [String]
     let gameMD5: String?
@@ -134,7 +134,7 @@ public struct TVOSCheatsView: View {
     }
 
     public init(
-        cheats: LinkingObjects<PVCheats>,
+        cheats: [PVCheats],
         coreID: String?,
         cheatTypes: [String],
         gameMD5: String? = nil,
@@ -373,18 +373,14 @@ public struct TVOSCheatsView: View {
     }
 
     private func loadCheats() {
+        let valid = cheats.filter { !$0.isInvalidated }
+        let filtered: [PVCheats]
         if let coreID = coreID {
-            let predicate = NSPredicate(format: "core.identifier == %@", coreID)
-            allCheats = cheats.filter(predicate)
-                .sorted(byKeyPath: "date", ascending: true)
-                .filter { !$0.isInvalidated }
-                .map { $0 }
+            filtered = valid.filter { $0.core?.identifier == coreID }
         } else {
-            allCheats = cheats
-                .sorted(byKeyPath: "date", ascending: true)
-                .filter { !$0.isInvalidated }
-                .map { $0 }
+            filtered = valid
         }
+        allCheats = filtered.sorted { $0.date < $1.date }
     }
 
     private func toggleCheat(_ cheat: PVCheats, at index: Int) {
@@ -989,7 +985,7 @@ struct TVOSEditCheatView: View {
 
 public class TVOSCheatsHostingController: UIHostingController<TVOSCheatsView> {
     public init(
-        cheats: LinkingObjects<PVCheats>,
+        cheats: [PVCheats],
         coreID: String?,
         cheatTypes: [String],
         gameMD5: String? = nil,

--- a/PVUI/Sources/PVUIBase/Cheats/iOSCheatsView.swift
+++ b/PVUI/Sources/PVUIBase/Cheats/iOSCheatsView.swift
@@ -199,7 +199,15 @@ public struct iOSCheatsView: View {
     }
 
     private func loadCheats() {
-        let valid = cheats.filter { !$0.isInvalidated }
+        // Re-query Realm when gameMD5 is available so newly added/imported cheats
+        // (written after this view was presented) are reflected on reload.
+        let source: [PVCheats]
+        if let md5 = gameMD5, let realm = try? Realm() {
+            source = Array(realm.objects(PVCheats.self).filter("game.md5Hash == %@", md5))
+        } else {
+            source = cheats
+        }
+        let valid = source.filter { !$0.isInvalidated }
         let filtered: [PVCheats]
         if let coreID = coreID {
             filtered = valid.filter { $0.core?.identifier == coreID }

--- a/PVUI/Sources/PVUIBase/Cheats/iOSCheatsView.swift
+++ b/PVUI/Sources/PVUIBase/Cheats/iOSCheatsView.swift
@@ -20,7 +20,7 @@ import PVFeatureFlags
 public struct iOSCheatsView: View {
     @Environment(\.dismiss) private var dismiss
 
-    let cheats: LinkingObjects<PVCheats>
+    let cheats: [PVCheats]
     let coreID: String?
     let cheatTypes: [String]
     let gameMD5: String?
@@ -43,7 +43,7 @@ public struct iOSCheatsView: View {
     }
 
     public init(
-        cheats: LinkingObjects<PVCheats>,
+        cheats: [PVCheats],
         coreID: String?,
         cheatTypes: [String],
         gameMD5: String? = nil,
@@ -199,18 +199,14 @@ public struct iOSCheatsView: View {
     }
 
     private func loadCheats() {
+        let valid = cheats.filter { !$0.isInvalidated }
+        let filtered: [PVCheats]
         if let coreID = coreID {
-            let predicate = NSPredicate(format: "core.identifier == %@", coreID)
-            allCheats = cheats.filter(predicate)
-                .sorted(byKeyPath: "date", ascending: true)
-                .filter { !$0.isInvalidated }
-                .map { $0 }
+            filtered = valid.filter { $0.core?.identifier == coreID }
         } else {
-            allCheats = cheats
-                .sorted(byKeyPath: "date", ascending: true)
-                .filter { !$0.isInvalidated }
-                .map { $0 }
+            filtered = valid
         }
+        allCheats = filtered.sorted { $0.date < $1.date }
     }
 
     private func toggleCheat(_ cheat: PVCheats, at index: Int) {
@@ -820,7 +816,7 @@ struct iOSEditCheatView: View {
 /// from UIKit code in `PVEmulatorViewController`.
 public class iOSCheatsHostingController: UIHostingController<iOSCheatsView> {
     public init(
-        cheats: LinkingObjects<PVCheats>,
+        cheats: [PVCheats],
         coreID: String?,
         cheatTypes: [String],
         gameMD5: String? = nil,

--- a/PVUI/Sources/PVUIBase/Cheats/iOSCheatsView.swift
+++ b/PVUI/Sources/PVUIBase/Cheats/iOSCheatsView.swift
@@ -202,7 +202,7 @@ public struct iOSCheatsView: View {
         // Re-query Realm when gameMD5 is available so newly added/imported cheats
         // (written after this view was presented) are reflected on reload.
         let source: [PVCheats]
-        if let md5 = gameMD5, let realm = try? Realm() {
+        if let md5 = gameMD5, !md5.isEmpty, let realm = try? Realm() {
             source = Array(realm.objects(PVCheats.self).filter("game.md5Hash == %@", md5))
         } else {
             source = cheats

--- a/PVUI/Sources/PVUIBase/Game Library/CollectionViewController/PVGameLibraryViewController.swift
+++ b/PVUI/Sources/PVUIBase/Game Library/CollectionViewController/PVGameLibraryViewController.swift
@@ -1240,7 +1240,7 @@ public final class PVGameLibraryViewController: GCEventViewController, UITextFie
                 }
 
                 if let saveStatesViewController = saveStatesNavController.viewControllers.first as? PVSaveStatesViewController {
-                    saveStatesViewController.saveStates = game.saveStates
+                    saveStatesViewController.saveStates = AnyRealmCollection(game.saveStates)
                     saveStatesViewController.delegate = self
                 }
 

--- a/PVUI/Sources/PVUIBase/PVEmulatorVC/PVEmulatorViewController+Cheats.swift
+++ b/PVUI/Sources/PVUIBase/PVEmulatorVC/PVEmulatorViewController+Cheats.swift
@@ -156,7 +156,7 @@ extension PVEmulatorViewController {
         #if os(tvOS)
         // Use SwiftUI-based cheats view on tvOS for reliability
         let cheatsVC = TVOSCheatsHostingController(
-            cheats: game.cheats,
+            cheats: Array(game.cheats),
             coreID: core.coreIdentifier,
             cheatTypes: getCheatTypes(),
             gameMD5: game.md5Hash,
@@ -204,7 +204,7 @@ extension PVEmulatorViewController {
 
         #if os(iOS)
         let cheatsVC = iOSCheatsHostingController(
-            cheats: game.cheats,
+            cheats: Array(game.cheats),
             coreID: core.coreIdentifier,
             cheatTypes: getCheatTypes(),
             gameMD5: game.md5Hash,

--- a/PVUI/Sources/PVUIBase/PVEmulatorVC/PVEmulatorViewController+Saves.swift
+++ b/PVUI/Sources/PVUIBase/PVEmulatorVC/PVEmulatorViewController+Saves.swift
@@ -230,7 +230,9 @@ public extension PVEmulatorViewController {
         let image = captureScreenshot()
 
         if let saveStatesViewController = saveStatesNavController.viewControllers.first as? PVSaveStatesViewController {
-            saveStatesViewController.saveStates = game.saveStates
+            // Wrap in AnyRealmCollection to decouple from the @ThreadSafe game's
+            // LinkingObjects, preventing Realm thread-safety crashes.
+            saveStatesViewController.saveStates = AnyRealmCollection(game.saveStates)
             saveStatesViewController.delegate = self
             saveStatesViewController.screenshot = image
             saveStatesViewController.coreID = core.coreIdentifier

--- a/PVUI/Sources/PVUIBase/SaveStates/PVSaveStatesViewController.swift
+++ b/PVUI/Sources/PVUIBase/SaveStates/PVSaveStatesViewController.swift
@@ -35,7 +35,7 @@ public final class PVSaveStatesViewController: UICollectionViewController {
 
     weak var delegate: PVSaveStatesViewControllerDelegate?
 
-    var saveStates: LinkingObjects<PVSaveState>!
+    var saveStates: AnyRealmCollection<PVSaveState>!
     var screenshot: UIImage?
 
     var coreID: String?


### PR DESCRIPTION
## Summary
- **Cheats crash**: `game.cheats` returns a live `LinkingObjects<PVCheats>` which becomes invalid when accessed across threads or after a delay from the `@ThreadSafe` game property. Changed cheats view types (iOS + tvOS) from `LinkingObjects<PVCheats>` to `[PVCheats]` and pass `Array(game.cheats)` at the call site. Updated `loadCheats()` to use Swift array operations instead of Realm query methods.
- **Save states crash**: Same pattern with `game.saveStates`. Changed `PVSaveStatesViewController.saveStates` from `LinkingObjects<PVSaveState>` to `AnyRealmCollection<PVSaveState>` and wrap with `AnyRealmCollection()` at the call site, which preserves the Realm filtering/sorting/observation capabilities while decoupling from the `@ThreadSafe` game's Realm instance.

## Test plan
- [ ] Open a game, pause, open Cheat Codes menu -- should not crash
- [ ] Open a game, pause, open Save States menu -- should not crash
- [ ] Add/toggle/delete cheats from the cheats menu -- should work as before
- [ ] Create/load/delete save states from the save states menu -- should work as before
- [ ] Verify cheats are filtered by core ID when applicable
- [ ] Verify cheats are sorted by date (ascending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)