### PR TITLE
[Agent] fix(boot): optimize game importer initialization performance (#3015)

### DIFF
--- a/.changelog/3015.md
+++ b/.changelog/3015.md
@@ -1,2 +1,7 @@
 ### Fixed
-- **Boot step "Initializing game importer" disproportionately slow** — `CoreLoader.getCorePlists()` performed a synchronous filesystem scan of the Frameworks directory on the main actor, blocking all UI updates. It now runs in a detached task. Additionally, `updateCores` was triggering a redundant full `RomDatabase.reloadCache(force: true)` during boot that duplicated the dedicated reload at 70% progress; the redundant call is removed. Fine-grained sub-step progress labels ("Loading system definitions…" → "Initializing game importer…") are now reported so the boot progress bar visibly advances during this phase
+- **Boot step "Initializing game importer" disproportionately slow** — Multiple optimizations to the game importer initialization path:
+  1. `initCorePlists()` now has an idempotency guard so the redundant second call from `initSystems()` returns instantly when the background pre-fire has already completed.
+  2. Per-system directory creation (`createDefaultDirectories`) moved to a background `Task.detached` — filesystem I/O for 60+ system ROM folders no longer blocks the boot sequence.
+  3. `updateSystemToPathMap()` simplified from an async-reduce with actor hops to a synchronous loop, eliminating unnecessary context switches.
+  4. Removed unused `updateromExtensionToSystemsMap()` function that was dead code inside `initSystems()`.
+  5. `CoreLoader.getCorePlists()` runs in a detached task with full-result disk caching so subsequent launches skip the filesystem scan entirely.

--- a/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
+++ b/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
@@ -740,7 +740,13 @@ public final class GameImporter: GameImporting, ObservableObject {
         // race window between them.
         if let existing = corePlistsInitializationTask {
             ILOG("GameImporter: initCorePlists — awaiting in-flight/completed initialization")
-            try await existing.value
+            do {
+                try await existing.value
+            } catch {
+                // Clear the cached task so a future call can retry initialization.
+                corePlistsInitializationTask = nil
+                throw error
+            }
             return
         }
 
@@ -780,7 +786,13 @@ public final class GameImporter: GameImporting, ObservableObject {
             await PVEmulatorConfiguration.updateCores(fromPlists: corePlists)
         }
         corePlistsInitializationTask = task
-        try await task.value
+        do {
+            try await task.value
+        } catch {
+            // Clear the cached task so a future call can retry initialization.
+            corePlistsInitializationTask = nil
+            throw error
+        }
     }
 
     public func getArtwork(forGame game: PVGame) async -> PVGame {

--- a/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
+++ b/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
@@ -590,11 +590,12 @@ public final class GameImporter: GameImporting, ObservableObject {
     ///
     /// Accepts pre-fetched system identifiers so this method can run off the
     /// main actor without touching Realm (Realm objects are thread-confined).
-    private func createDefaultDirectories(fm: FileManager, systemIdentifiers: [String]) {
+    /// Static so `Task.detached` callers avoid capturing `self` (a non-Sendable class).
+    private static func createDefaultDirectories(fm: FileManager, systemIdentifiers: [String]) {
         // Core roots
-        createDefaultDirectory(fm, url: romsPath)
-        createDefaultDirectory(fm, url: romsImportPath)
-        createDefaultDirectory(fm, url: biosPath)
+        createDefaultDirectory(fm, url: Paths.romsPath)
+        createDefaultDirectory(fm, url: Paths.romsImportPath)
+        createDefaultDirectory(fm, url: Paths.biosesPath)
 
         // Additional roots
         createDefaultDirectory(fm, url: Paths.saveSavesPath)
@@ -613,7 +614,7 @@ public final class GameImporter: GameImporting, ObservableObject {
     }
 
     /// Creates a default directory at the given URL
-    fileprivate func createDefaultDirectory(_ fm: FileManager, url: URL) {
+    fileprivate static func createDefaultDirectory(_ fm: FileManager, url: URL) {
         if !FileManager.default.fileExists(atPath: url.path, isDirectory: nil) {
             ILOG("Path <\(url)> doesn't exist. Creating.")
             do {
@@ -652,7 +653,7 @@ public final class GameImporter: GameImporting, ObservableObject {
         // then do the actual filesystem work off the main thread.
         let systemIDs = PVSystem.all.map { $0.identifier }
         Task.detached(priority: .utility) {
-            await self.createDefaultDirectories(fm: FileManager.default, systemIdentifiers: systemIDs)
+            GameImporter.createDefaultDirectories(fm: FileManager.default, systemIdentifiers: systemIDs)
         }
 
         /// Builds a [systemIdentifier: romsDirectoryURL] map from Realm.
@@ -725,13 +726,20 @@ public final class GameImporter: GameImporting, ObservableObject {
         case systemsPlistNotFound(bundle: Bundle)
     }
 
-    /// Whether `initCorePlists()` has already completed successfully.
-    private var corePlistsInitialized = false
+    /// Caches the in-flight or already-completed initialization task.
+    /// Isolated to `@MainActor` so the nil-check and task assignment form a
+    /// single atomic step — preventing duplicate scans from concurrent callers.
+    private var corePlistsInitializationTask: Task<Void, Error>?
 
+    @MainActor
     public func initCorePlists() async throws {
-        // Fast path: if we've already run successfully, skip entirely.
-        guard !corePlistsInitialized else {
-            ILOG("GameImporter: initCorePlists — already initialized, skipping")
+        // If a task is already running or has completed, await it rather than
+        // launching a duplicate scan. Because this function is @MainActor, the
+        // check and assignment below are guaranteed to be an atomic step with no
+        // race window between them.
+        if let existing = corePlistsInitializationTask {
+            ILOG("GameImporter: initCorePlists — awaiting in-flight/completed initialization")
+            try await existing.value
             return
         }
 
@@ -741,31 +749,37 @@ public final class GameImporter: GameImporting, ObservableObject {
             ELOG("GameImporter: Failed to locate systems.plist in bundle \(bundle): \(error)")
             throw error
         }
-        await PVEmulatorConfiguration.updateSystems(fromPlists: [systemsPlistURL])
 
-        // Run filesystem I/O and the dynamic libretro scan on a background thread.
-        // Neither operation is MainActor-safe — calling either on the main thread
-        // blocks the UI and causes the watchdog-visible "app hang" symptoms.
-        //
-        // Full-result disk cache: on subsequent launches where nothing has changed
-        // (same app version + build + Frameworks directory mtime) the entire scan
-        // is skipped and the cached [EmulatorCoreInfoPlist] array is used directly.
-        // The cache is invalidated automatically on app update or when a core
-        // dylib/bundle is added or removed (Frameworks dir mtime changes).
-        let corePlists: [EmulatorCoreInfoPlist] = await Task.detached(priority: .userInitiated) {
-            if let cached = CorePlistResultCache.load() {
-                ILOG("GameImporter: initCorePlists — cache hit, skipping scan (\(cached.count) cores)")
-                return cached
-            }
-            ILOG("GameImporter: initCorePlists — cache miss, running full scan")
-            let plists = CoreLoader.getCorePlists()
-            let merged = CoreLoader.mergeDiscoveredLibretroCores(into: plists)
-            CorePlistResultCache.save(merged)
-            return merged
-        }.value
-        await PVEmulatorConfiguration.updateCores(fromPlists: corePlists)
+        // Create and store the task BEFORE the first `await` so any concurrent
+        // caller that arrives after this suspension point will see the in-flight
+        // task and await it instead of starting a second scan.
+        let task = Task<Void, Error> {
+            await PVEmulatorConfiguration.updateSystems(fromPlists: [systemsPlistURL])
 
-        corePlistsInitialized = true
+            // Run filesystem I/O and the dynamic libretro scan on a background thread.
+            // Neither operation is MainActor-safe — calling either on the main thread
+            // blocks the UI and causes the watchdog-visible "app hang" symptoms.
+            //
+            // Full-result disk cache: on subsequent launches where nothing has changed
+            // (same app version + build + Frameworks directory mtime) the entire scan
+            // is skipped and the cached [EmulatorCoreInfoPlist] array is used directly.
+            // The cache is invalidated automatically on app update or when a core
+            // dylib/bundle is added or removed (Frameworks dir mtime changes).
+            let corePlists: [EmulatorCoreInfoPlist] = await Task.detached(priority: .userInitiated) {
+                if let cached = CorePlistResultCache.load() {
+                    ILOG("GameImporter: initCorePlists — cache hit, skipping scan (\(cached.count) cores)")
+                    return cached
+                }
+                ILOG("GameImporter: initCorePlists — cache miss, running full scan")
+                let plists = CoreLoader.getCorePlists()
+                let merged = CoreLoader.mergeDiscoveredLibretroCores(into: plists)
+                CorePlistResultCache.save(merged)
+                return merged
+            }.value
+            await PVEmulatorConfiguration.updateCores(fromPlists: corePlists)
+        }
+        corePlistsInitializationTask = task
+        try await task.value
     }
 
     public func getArtwork(forGame game: PVGame) async -> PVGame {

--- a/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
+++ b/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
@@ -727,8 +727,9 @@ public final class GameImporter: GameImporting, ObservableObject {
     }
 
     /// Caches the in-flight or already-completed initialization task.
-    /// Isolated to `@MainActor` so the nil-check and task assignment form a
-    /// single atomic step — preventing duplicate scans from concurrent callers.
+    /// Accessed only from the `@MainActor`-isolated `initCorePlists()` so the
+    /// nil-check and task assignment form a single atomic step — preventing
+    /// duplicate scans from concurrent callers.
     private var corePlistsInitializationTask: Task<Void, Error>?
 
     @MainActor

--- a/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
+++ b/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
@@ -586,8 +586,11 @@ public final class GameImporter: GameImporting, ObservableObject {
     }
 
 
-    /// Creates default directories
-    private func createDefaultDirectories(fm: FileManager) {
+    /// Creates default directories.
+    ///
+    /// Accepts pre-fetched system identifiers so this method can run off the
+    /// main actor without touching Realm (Realm objects are thread-confined).
+    private func createDefaultDirectories(fm: FileManager, systemIdentifiers: [String]) {
         // Core roots
         createDefaultDirectory(fm, url: romsPath)
         createDefaultDirectory(fm, url: romsImportPath)
@@ -603,8 +606,8 @@ public final class GameImporter: GameImporting, ObservableObject {
         createDefaultDirectory(fm, url: deltaSkinsURL)
 
         // Per-system ROM subfolders
-        for system in PVSystem.all {
-            let systemDir = Paths.romsPath(forSystemIdentifier: system.identifier)
+        for identifier in systemIdentifiers {
+            let systemDir = Paths.romsPath(forSystemIdentifier: identifier)
             createDefaultDirectory(fm, url: systemDir)
         }
     }
@@ -642,34 +645,28 @@ public final class GameImporter: GameImporting, ObservableObject {
             initialized.leave()
             return
         }
-        let fm = FileManager.default
-        createDefaultDirectories(fm: fm)
 
-        /// Updates the system to path map
-        @MainActor
-        @Sendable func updateSystemToPathMap() async -> [String: URL] {
-            let systems = PVSystem.all.toArray()
-            return await systems.async.reduce(into: [String: URL]()) {partialResult, system in
-                partialResult[system.identifier] = system.romsDirectory
-            }
+        // Create default directories in the background — not required before the
+        // UI appears, so we avoid blocking the boot path with synchronous I/O.
+        // Gather system identifiers on the main actor (Realm is thread-confined),
+        // then do the actual filesystem work off the main thread.
+        let systemIDs = PVSystem.all.map { $0.identifier }
+        Task.detached(priority: .utility) {
+            await self.createDefaultDirectories(fm: FileManager.default, systemIdentifiers: systemIDs)
         }
 
-        /// Updates the ROM extension to systems map
+        /// Builds a [systemIdentifier: romsDirectoryURL] map from Realm.
+        /// Uses a simple synchronous iteration instead of the heavier
+        /// async-reduce that was creating unnecessary actor hops.
         @MainActor
-        @Sendable func updateromExtensionToSystemsMap() -> [String: [String]] {
-            return PVSystem.all.reduce([String: [String]](), { (dict, system) -> [String: [String]] in
-                let extensionsForSystem = system.supportedExtensions
-                // Make a new dict of [ext : systemID] for each ext in extions for that ID, then merge that dictionary with the current one,
-                // if the dictionary already has that key, the arrays are joined so you end up with a ext mapping to multpiple systemIDs
-                let extsToCurrentSystemID = extensionsForSystem.reduce([String: [String]](), { (dict, ext) -> [String: [String]] in
-                    var dict = dict
-                    dict[ext] = [system.identifier]
-                    return dict
-                })
-
-                return dict.merging(extsToCurrentSystemID, uniquingKeysWith: { var newArray = $0; newArray.append(contentsOf: $1); return newArray })
-
-            })
+        @Sendable func updateSystemToPathMap() -> [String: URL] {
+            let systems = PVSystem.all.toArray()
+            var map = [String: URL]()
+            map.reserveCapacity(systems.count)
+            for system in systems {
+                map[system.identifier] = system.romsDirectory
+            }
+            return map
         }
 
         let systems = PVSystem.all
@@ -679,7 +676,7 @@ public final class GameImporter: GameImporting, ObservableObject {
             case .initial:
                 Task { @MainActor in
                     ILOG("RealmCollection changed state to .initial")
-                    self.systemToPathMap = await updateSystemToPathMap()
+                    self.systemToPathMap = updateSystemToPathMap()
                     self.initialized.leave()
 
                     // Set up the queue subscription after all members are initialized
@@ -688,7 +685,7 @@ public final class GameImporter: GameImporting, ObservableObject {
             case .update:
                 Task { @MainActor in
                     ILOG("RealmCollection changed state to .update")
-                    self.systemToPathMap = await updateSystemToPathMap()
+                    self.systemToPathMap = updateSystemToPathMap()
                 }
             case let .error(error):
                 ELOG("RealmCollection changed state to .error")
@@ -728,7 +725,16 @@ public final class GameImporter: GameImporting, ObservableObject {
         case systemsPlistNotFound(bundle: Bundle)
     }
 
+    /// Whether `initCorePlists()` has already completed successfully.
+    private var corePlistsInitialized = false
+
     public func initCorePlists() async throws {
+        // Fast path: if we've already run successfully, skip entirely.
+        guard !corePlistsInitialized else {
+            ILOG("GameImporter: initCorePlists — already initialized, skipping")
+            return
+        }
+
         let bundle = ThisBundle
         guard let systemsPlistURL = bundle.url(forResource: "systems", withExtension: "plist") else {
             let error = CorePlistInitializationError.systemsPlistNotFound(bundle: bundle)
@@ -758,6 +764,8 @@ public final class GameImporter: GameImporting, ObservableObject {
             return merged
         }.value
         await PVEmulatorConfiguration.updateCores(fromPlists: corePlists)
+
+        corePlistsInitialized = true
     }
 
     public func getArtwork(forGame game: PVGame) async -> PVGame {

--- a/PVUI/Sources/PVUIBase/State Management/AppState.swift
+++ b/PVUI/Sources/PVUIBase/State Management/AppState.swift
@@ -471,8 +471,12 @@ public class AppState: ObservableObject {
         self.libraryUpdatesController = PVGameLibraryUpdatesController(gameImporter: self.gameImporter!)
         ILOG("AppState: LibraryUpdatesController initialized")
 
-        // Guard against a hung ROM cache reload — 30 s is ample for cache warm-up.
-        ILOG("AppState: Reloading RomDatabase cache")
+        // Warm up ROM database caches.
+        // updateCores(fromPlists:) already performed a forced cache reload when
+        // it registered cores, so a second forced reload is unnecessary.  We use
+        // the non-forced variant which short-circuits when the in-memory caches
+        // already have the correct number of entries.
+        ILOG("AppState: Reloading RomDatabase cache (non-forced, skips if already warm)")
         bootupStateManager.updateTaskProgress("Reloading ROM database cache…", fraction: 0.7)
         do {
             try await withTimeout(seconds: 30) {


### PR DESCRIPTION
## Summary
- **Adds idempotency guard to `initCorePlists()`** so the redundant second call from `initSystems()` returns instantly when the background pre-fire has already completed, eliminating duplicate plist parsing and core registration.
- **Moves per-system directory creation to a background task** — `createDefaultDirectories()` was synchronously checking/creating ~60+ system ROM folders on the boot path; now runs in a `Task.detached` since directories aren't needed before the UI appears.
- **Simplifies `updateSystemToPathMap()` from async-reduce to synchronous loop** — the original used `systems.async.reduce(into:)` which created an unnecessary actor hop per system; replaced with a simple `for` loop with pre-allocated capacity.
- **Removes dead code** — `updateromExtensionToSystemsMap()` was defined inside `initSystems()` but never called.

Fixes #3015

## Test plan
- [ ] Launch app and verify boot completes without hanging on "Initializing game importer"
- [ ] Verify ROM directories are created for all systems (check after boot completes)
- [ ] Verify importing games still works correctly after boot
- [ ] Verify system path map is populated (games can be launched)
- [ ] Test cold launch (first install) and warm launch (subsequent) paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)