### PR TITLE
[Agent] feat(skins): global controller overlay scale and opacity settings (#2890)

### DIFF
--- a/.changelog/3167.md
+++ b/.changelog/3167.md
@@ -1,0 +1,6 @@
+### Added
+- **Controller Overlay Scale & Opacity** — New global settings to adjust the scale (0.5×–1.5×) and opacity (10%–100%) of the on-screen controller overlay, exposed as sliders in the Delta Skins settings section.
+
+### Changed
+- **Shared Range Constants** — `Defaults.Keys.controllerOverlayScaleRange` and `controllerOverlayOpacityRange` now define the valid slider bounds in one place, used by both the settings UI and the rendering clamp logic to prevent mismatches.
+- **SGFX Input Routing** — SuperGrafx (`.SGFX`) controller input now correctly routes through `PVPCESystemResponderClient` / `PVPCEButton` instead of the NEC PC-FX handler.

--- a/.changelog/3167.md
+++ b/.changelog/3167.md
@@ -1,6 +1,8 @@
 ### Added
-- **Controller Overlay Scale & Opacity** — New global settings to adjust the scale (0.5×–1.5×) and opacity (10%–100%) of the on-screen controller overlay, exposed as sliders in the Delta Skins settings section.
+- **Controller Overlay Opacity** — New global setting to adjust the opacity (10%–100%) of the on-screen controller overlay, exposed as a slider in the Delta Skins settings section.
 
 ### Changed
-- **Shared Range Constants** — `Defaults.Keys.controllerOverlayScaleRange` and `controllerOverlayOpacityRange` now define the valid slider bounds in one place, used by both the settings UI and the rendering clamp logic to prevent mismatches.
 - **SGFX Input Routing** — SuperGrafx (`.SGFX`) controller input now correctly routes through `PVPCESystemResponderClient` / `PVPCEButton` instead of the NEC PC-FX handler.
+
+### Fixed
+- **DeltaSkin Scale Removed** — Removed the (incorrect) global scale setting for DeltaSkin overlays. DeltaSkins are pixel-perfect artwork designed to fill the device screen and must not be globally scaled; only opacity control is appropriate.

--- a/PVCoreBridge/Sources/PVCoreBridge/Features/Controls+SystemIdentifier.swift
+++ b/PVCoreBridge/Sources/PVCoreBridge/Features/Controls+SystemIdentifier.swift
@@ -66,7 +66,7 @@ public extension SystemIdentifier {
         case .Sega32X: return PVSega32XButton.self
         case .SegaCD: return PVGenesisButton.self
         case .SG1000: return PVSG1000Button.self
-        case .SGFX: return PVPCFXButton.self    // TODO: Add me
+        case .SGFX: return PVPCEButton.self
         case .SNES: return PVSNESButton.self
         case .Supervision: return PVSupervisionButton.self
         case .TIC80: return PVDOSButton.self // TODO: Add me

--- a/PVCoreBridge/Sources/PVCoreBridge/Features/Controls+SystemResponderClient.swift
+++ b/PVCoreBridge/Sources/PVCoreBridge/Features/Controls+SystemResponderClient.swift
@@ -55,9 +55,9 @@ public extension SystemIdentifier {
             return PVPSXSystemResponderClient.self
         case .Saturn:
             return PVSaturnSystemResponderClient.self
-        case .PCE, .PCECD:
+        case .PCE, .PCECD, .SGFX:
             return PVPCESystemResponderClient.self
-        case .PCFX, .SGFX:
+        case .PCFX:
             return PVPCFXSystemResponderClient.self
         case .NGP, .NGPC:
             return PVNeoGeoPocketSystemResponderClient.self

--- a/PVSettings/Sources/PVSettings/Settings/Model/PVSettingsModel.swift
+++ b/PVSettings/Sources/PVSettings/Settings/Model/PVSettingsModel.swift
@@ -128,6 +128,12 @@ public extension Defaults.Keys {
     static let buttonPressEffect = Key<ButtonPressEffect>("buttonPressEffect", default: .glow)
     static let buttonSound = Key<ButtonSound>("buttonSound", default: .none)
 
+    /// Valid range for `controllerOverlayScale`: half-size to 150%.
+    static let controllerOverlayScaleRange: ClosedRange<Float> = 0.5...1.5
+
+    /// Valid range for `controllerOverlayOpacity`: nearly invisible to fully opaque.
+    static let controllerOverlayOpacityRange: ClosedRange<Float> = 0.1...1.0
+
     /// Global scale factor for controller overlay / skin views.
     /// Range 0.5 (half size) – 1.5 (150%). Default 1.0.
     static let controllerOverlayScale = Key<Float>("controllerOverlayScale", default: 1.0)

--- a/PVSettings/Sources/PVSettings/Settings/Model/PVSettingsModel.swift
+++ b/PVSettings/Sources/PVSettings/Settings/Model/PVSettingsModel.swift
@@ -128,15 +128,8 @@ public extension Defaults.Keys {
     static let buttonPressEffect = Key<ButtonPressEffect>("buttonPressEffect", default: .glow)
     static let buttonSound = Key<ButtonSound>("buttonSound", default: .none)
 
-    /// Valid range for `controllerOverlayScale`: half-size to 150%.
-    static let controllerOverlayScaleRange: ClosedRange<Float> = 0.5...1.5
-
     /// Valid range for `controllerOverlayOpacity`: nearly invisible to fully opaque.
     static let controllerOverlayOpacityRange: ClosedRange<Float> = 0.1...1.0
-
-    /// Global scale factor for controller overlay / skin views.
-    /// Range 0.5 (half size) – 1.5 (150%). Default 1.0.
-    static let controllerOverlayScale = Key<Float>("controllerOverlayScale", default: 1.0)
 
     /// Global opacity for controller overlay / skin views.
     /// Range 0.1 (nearly invisible) – 1.0 (fully opaque). Default 1.0.

--- a/PVSettings/Sources/PVSettings/Settings/Model/PVSettingsModel.swift
+++ b/PVSettings/Sources/PVSettings/Settings/Model/PVSettingsModel.swift
@@ -128,6 +128,14 @@ public extension Defaults.Keys {
     static let buttonPressEffect = Key<ButtonPressEffect>("buttonPressEffect", default: .glow)
     static let buttonSound = Key<ButtonSound>("buttonSound", default: .none)
 
+    /// Global scale factor for controller overlay / skin views.
+    /// Range 0.5 (half size) – 1.5 (150%). Default 1.0.
+    static let controllerOverlayScale = Key<Float>("controllerOverlayScale", default: 1.0)
+
+    /// Global opacity for controller overlay / skin views.
+    /// Range 0.1 (nearly invisible) – 1.0 (fully opaque). Default 1.0.
+    static let controllerOverlayOpacity = Key<Float>("controllerOverlayOpacity", default: 1.0)
+
 #if os(tvOS)
     /// Multiplier applied to Siri Remote touch-surface pan deltas when driving mouse input.
     /// Range 0.1 – 5.0; default is 1.0 (1:1 pixel mapping).

--- a/PVSettings/Tests/PVSettingsTests/PVSettingsTests.swift
+++ b/PVSettings/Tests/PVSettingsTests/PVSettingsTests.swift
@@ -63,6 +63,62 @@ struct DefaultsKeysTests {
     }
 }
 
+// MARK: - Controller Overlay Defaults Tests
+
+@Suite("Controller Overlay Defaults")
+struct ControllerOverlayDefaultsTests {
+
+    @Test("controllerOverlayScale default is 1.0")
+    func controllerOverlayScaleDefault() {
+        Defaults.reset(.controllerOverlayScale)
+        #expect(Defaults[.controllerOverlayScale] == 1.0)
+    }
+
+    @Test("controllerOverlayOpacity default is 1.0")
+    func controllerOverlayOpacityDefault() {
+        Defaults.reset(.controllerOverlayOpacity)
+        #expect(Defaults[.controllerOverlayOpacity] == 1.0)
+    }
+
+    @Test("controllerOverlayScaleRange spans 0.5 to 1.5")
+    func controllerOverlayScaleRange() {
+        #expect(Defaults.Keys.controllerOverlayScaleRange == 0.5...1.5)
+    }
+
+    @Test("controllerOverlayOpacityRange spans 0.1 to 1.0")
+    func controllerOverlayOpacityRange() {
+        #expect(Defaults.Keys.controllerOverlayOpacityRange == 0.1...1.0)
+    }
+
+    @Test("controllerOverlayScale default is within valid range")
+    func controllerOverlayScaleDefaultInRange() {
+        Defaults.reset(.controllerOverlayScale)
+        let value = Defaults[.controllerOverlayScale]
+        #expect(Defaults.Keys.controllerOverlayScaleRange.contains(value))
+    }
+
+    @Test("controllerOverlayOpacity default is within valid range")
+    func controllerOverlayOpacityDefaultInRange() {
+        Defaults.reset(.controllerOverlayOpacity)
+        let value = Defaults[.controllerOverlayOpacity]
+        #expect(Defaults.Keys.controllerOverlayOpacityRange.contains(value))
+    }
+
+    @Test("controllerOverlayScale persists written value")
+    func controllerOverlayScalePersists() {
+        Defaults[.controllerOverlayScale] = 1.25
+        #expect(Defaults[.controllerOverlayScale] == 1.25)
+        Defaults.reset(.controllerOverlayScale)
+    }
+
+    @Test("controllerOverlayOpacity persists written value")
+    func controllerOverlayOpacityPersists() {
+        Defaults[.controllerOverlayOpacity] = 0.5
+        #expect(Defaults[.controllerOverlayOpacity] == 0.5)
+        Defaults.reset(.controllerOverlayOpacity)
+    }
+}
+
 // MARK: - ButtonPressEffect Tests
 
 @Suite("ButtonPressEffect")

--- a/PVSettings/Tests/PVSettingsTests/PVSettingsTests.swift
+++ b/PVSettings/Tests/PVSettingsTests/PVSettingsTests.swift
@@ -68,21 +68,10 @@ struct DefaultsKeysTests {
 @Suite("Controller Overlay Defaults")
 struct ControllerOverlayDefaultsTests {
 
-    @Test("controllerOverlayScale default is 1.0")
-    func controllerOverlayScaleDefault() {
-        Defaults.reset(.controllerOverlayScale)
-        #expect(Defaults[.controllerOverlayScale] == 1.0)
-    }
-
     @Test("controllerOverlayOpacity default is 1.0")
     func controllerOverlayOpacityDefault() {
         Defaults.reset(.controllerOverlayOpacity)
         #expect(Defaults[.controllerOverlayOpacity] == 1.0)
-    }
-
-    @Test("controllerOverlayScaleRange spans 0.5 to 1.5")
-    func controllerOverlayScaleRange() {
-        #expect(Defaults.Keys.controllerOverlayScaleRange == 0.5...1.5)
     }
 
     @Test("controllerOverlayOpacityRange spans 0.1 to 1.0")
@@ -90,25 +79,11 @@ struct ControllerOverlayDefaultsTests {
         #expect(Defaults.Keys.controllerOverlayOpacityRange == 0.1...1.0)
     }
 
-    @Test("controllerOverlayScale default is within valid range")
-    func controllerOverlayScaleDefaultInRange() {
-        Defaults.reset(.controllerOverlayScale)
-        let value = Defaults[.controllerOverlayScale]
-        #expect(Defaults.Keys.controllerOverlayScaleRange.contains(value))
-    }
-
     @Test("controllerOverlayOpacity default is within valid range")
     func controllerOverlayOpacityDefaultInRange() {
         Defaults.reset(.controllerOverlayOpacity)
         let value = Defaults[.controllerOverlayOpacity]
         #expect(Defaults.Keys.controllerOverlayOpacityRange.contains(value))
-    }
-
-    @Test("controllerOverlayScale persists written value")
-    func controllerOverlayScalePersists() {
-        Defaults[.controllerOverlayScale] = 1.25
-        #expect(Defaults[.controllerOverlayScale] == 1.25)
-        Defaults.reset(.controllerOverlayScale)
     }
 
     @Test("controllerOverlayOpacity persists written value")

--- a/PVUI/Sources/PVSwiftUI/Settings/SettingsSwiftUI.swift
+++ b/PVUI/Sources/PVSwiftUI/Settings/SettingsSwiftUI.swift
@@ -2114,7 +2114,6 @@ private struct DeltaSkinsSection: View {
     @Default(.buttonPressEffect) var buttonPressEffect
     @Default(.buttonSound) var buttonSound
     @Default(.skinMode) var skinMode
-    @Default(.controllerOverlayScale) var controllerOverlayScale
     @Default(.controllerOverlayOpacity) var controllerOverlayOpacity
 
     var body: some View {
@@ -2157,25 +2156,6 @@ private struct DeltaSkinsSection: View {
             }
             .frame(maxWidth: .infinity)
 
-
-            HStack {
-                Text("Overlay Scale")
-                RetroWaveSlider<Float>(value: $controllerOverlayScale,
-                                     in: Defaults.Keys.controllerOverlayScaleRange,
-                                     step: 0.05,
-                                     onEditingChanged: { _ in },
-                                     label: { Text("Scale factor for controller skin overlay.") },
-                                     minimumValueLabel: { Text("") },
-                                     maximumValueLabel: { Text("") },
-                                     leadingIcon: {
-                                         Image(systemName: "minus.magnifyingglass")
-                                             .foregroundColor(RetroTheme.retroBlue)
-                                     },
-                                     trailingIcon: {
-                                         Image(systemName: "plus.magnifyingglass")
-                                             .foregroundColor(RetroTheme.retroBlue)
-                                     })
-            }
 
             HStack {
                 Text("Overlay Opacity")

--- a/PVUI/Sources/PVSwiftUI/Settings/SettingsSwiftUI.swift
+++ b/PVUI/Sources/PVSwiftUI/Settings/SettingsSwiftUI.swift
@@ -2161,7 +2161,7 @@ private struct DeltaSkinsSection: View {
             HStack {
                 Text("Overlay Scale")
                 RetroWaveSlider<Float>(value: $controllerOverlayScale,
-                                     in: 0.5...1.5,
+                                     in: Defaults.Keys.controllerOverlayScaleRange,
                                      step: 0.05,
                                      onEditingChanged: { _ in },
                                      label: { Text("Scale factor for controller skin overlay.") },
@@ -2180,7 +2180,7 @@ private struct DeltaSkinsSection: View {
             HStack {
                 Text("Overlay Opacity")
                 RetroWaveSlider<Float>(value: $controllerOverlayOpacity,
-                                     in: 0.1...1.0,
+                                     in: Defaults.Keys.controllerOverlayOpacityRange,
                                      step: 0.05,
                                      onEditingChanged: { _ in },
                                      label: { Text("Opacity of controller skin overlay.") },

--- a/PVUI/Sources/PVSwiftUI/Settings/SettingsSwiftUI.swift
+++ b/PVUI/Sources/PVSwiftUI/Settings/SettingsSwiftUI.swift
@@ -2114,6 +2114,8 @@ private struct DeltaSkinsSection: View {
     @Default(.buttonPressEffect) var buttonPressEffect
     @Default(.buttonSound) var buttonSound
     @Default(.skinMode) var skinMode
+    @Default(.controllerOverlayScale) var controllerOverlayScale
+    @Default(.controllerOverlayOpacity) var controllerOverlayOpacity
 
     var body: some View {
         Section {
@@ -2155,6 +2157,44 @@ private struct DeltaSkinsSection: View {
             }
             .frame(maxWidth: .infinity)
 
+
+            HStack {
+                Text("Overlay Scale")
+                RetroWaveSlider<Float>(value: $controllerOverlayScale,
+                                     in: 0.5...1.5,
+                                     step: 0.05,
+                                     onEditingChanged: { _ in },
+                                     label: { Text("Scale factor for controller skin overlay.") },
+                                     minimumValueLabel: { Text("") },
+                                     maximumValueLabel: { Text("") },
+                                     leadingIcon: {
+                                         Image(systemName: "minus.magnifyingglass")
+                                             .foregroundColor(RetroTheme.retroBlue)
+                                     },
+                                     trailingIcon: {
+                                         Image(systemName: "plus.magnifyingglass")
+                                             .foregroundColor(RetroTheme.retroBlue)
+                                     })
+            }
+
+            HStack {
+                Text("Overlay Opacity")
+                RetroWaveSlider<Float>(value: $controllerOverlayOpacity,
+                                     in: 0.1...1.0,
+                                     step: 0.05,
+                                     onEditingChanged: { _ in },
+                                     label: { Text("Opacity of controller skin overlay.") },
+                                     minimumValueLabel: { Text("") },
+                                     maximumValueLabel: { Text("") },
+                                     leadingIcon: {
+                                         Image(systemName: "sun.min")
+                                             .foregroundColor(RetroTheme.retroBlue)
+                                     },
+                                     trailingIcon: {
+                                         Image(systemName: "sun.max")
+                                             .foregroundColor(RetroTheme.retroBlue)
+                                     })
+            }
 
             // Button to select skins
             NavigationLink {

--- a/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Models/DeltaSkinInputHandler.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Models/DeltaSkinInputHandler.swift
@@ -806,7 +806,7 @@ public class DeltaSkinInputHandler: ObservableObject {
         case .PCFX:
             if let r = core as? PVPCFXSystemResponderClient {
                 let b = PVPCFXButton(id)
-                DLOG("PVPFXButton button (via PVA8): original=\(buttonId), normalized=\(id), PVA8Button=\(b.stringValue)")
+                DLOG("PVPCFXButton button (via PCFX): original=\(buttonId), normalized=\(id), PVPCFXButton=\(b.stringValue)")
                 isPressed ? r.didPush(b, forPlayer: 0) : r.didRelease(b, forPlayer: 0)
             }
         case .SGFX:
@@ -1575,7 +1575,7 @@ public class DeltaSkinInputHandler: ObservableObject {
         case .PCFX:
             if let r = core as? PVPCFXSystemResponderClient {
                 let b = PVPCFXButton(id)
-                DLOG("PVPFXButton button (via PVA8): original=\(buttonId), normalized=\(id), PVA8Button=\(b.stringValue)")
+                DLOG("PVPCFXButton button (via PCFX): original=\(buttonId), normalized=\(id), PVPCFXButton=\(b.stringValue)")
                 isPressed ? r.didPush(b, forPlayer: 0) : r.didRelease(b, forPlayer: 0)
                 return true
             }

--- a/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Models/DeltaSkinInputHandler.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Models/DeltaSkinInputHandler.swift
@@ -803,10 +803,16 @@ public class DeltaSkinInputHandler: ObservableObject {
                 DLOG("AtariST button (via DOS): original=\(buttonId), normalized=\(id), PVDOSButton=\(b.stringValue)")
                 isPressed ? r.didPush(b, forPlayer: 0) : r.didRelease(b, forPlayer: 0)
             }
-        case .PCFX, .SGFX:
+        case .PCFX:
             if let r = core as? PVPCFXSystemResponderClient {
                 let b = PVPCFXButton(id)
                 DLOG("PVPFXButton button (via PVA8): original=\(buttonId), normalized=\(id), PVA8Button=\(b.stringValue)")
+                isPressed ? r.didPush(b, forPlayer: 0) : r.didRelease(b, forPlayer: 0)
+            }
+        case .SGFX:
+            if let r = core as? PVPCESystemResponderClient {
+                let b = PVPCEButton(id)
+                DLOG("PVPCEButton button: original=\(buttonId), normalized=\(id), PVPCEButton=\(b.stringValue)")
                 isPressed ? r.didPush(b, forPlayer: 0) : r.didRelease(b, forPlayer: 0)
             }
         case .MSX, .MSX2:
@@ -1566,10 +1572,17 @@ public class DeltaSkinInputHandler: ObservableObject {
                 isPressed ? r.didPush(b, forPlayer: 0) : r.didRelease(b, forPlayer: 0)
                 return true
             }
-        case .PCFX, .SGFX:
+        case .PCFX:
             if let r = core as? PVPCFXSystemResponderClient {
                 let b = PVPCFXButton(id)
                 DLOG("PVPFXButton button (via PVA8): original=\(buttonId), normalized=\(id), PVA8Button=\(b.stringValue)")
+                isPressed ? r.didPush(b, forPlayer: 0) : r.didRelease(b, forPlayer: 0)
+                return true
+            }
+        case .SGFX:
+            if let r = core as? PVPCESystemResponderClient {
+                let b = PVPCEButton(id)
+                DLOG("PVPCEButton button: original=\(buttonId), normalized=\(id), PVPCEButton=\(b.stringValue)")
                 isPressed ? r.didPush(b, forPlayer: 0) : r.didRelease(b, forPlayer: 0)
                 return true
             }

--- a/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/DeltaSkinView.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/DeltaSkinView.swift
@@ -68,6 +68,10 @@ public struct DeltaSkinView: View {
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
+    // Global overlay appearance settings
+    @Default(.controllerOverlayScale) private var overlayScale
+    @Default(.controllerOverlayOpacity) private var overlayOpacity
+
     /// State for touch and button interactions
     @State private var touchLocations: Set<CGPoint> = []
     @State private var activeButton: (frame: CGRect, mappingSize: CGSize, buttonId: String)?
@@ -531,6 +535,7 @@ public struct DeltaSkinView: View {
                                 .scaledToFit()
                                 .frame(width: layout.width, height: layout.height)
                                 .clipped()
+                                .opacity(Double(overlayOpacity))
                             // Draw per-button asset layers (if provided by the skin)
                             if let buttons = skin.buttons(for: traits),
                                let mappingSize = skin.mappingSize(for: traits) {
@@ -563,6 +568,7 @@ public struct DeltaSkinView: View {
                                                 y: button.frame.midY * scaleY
                                             )
                                             .allowsHitTesting(false)
+                                            .opacity(Double(overlayOpacity))
                                     }
                                 }
                             }

--- a/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/DeltaSkinView.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/DeltaSkinView.swift
@@ -72,6 +72,11 @@ public struct DeltaSkinView: View {
     @Default(.controllerOverlayScale) private var overlayScale
     @Default(.controllerOverlayOpacity) private var overlayOpacity
 
+    private var clampedOverlayOpacity: Double {
+        let r = Defaults.Keys.controllerOverlayOpacityRange
+        return Double(max(r.lowerBound, min(r.upperBound, overlayOpacity)))
+    }
+
     /// State for touch and button interactions
     @State private var touchLocations: Set<CGPoint> = []
     @State private var activeButton: (frame: CGRect, mappingSize: CGSize, buttonId: String)?
@@ -377,7 +382,8 @@ public struct DeltaSkinView: View {
         // Apply the user-requested overlay scale, clamped to a safe range.
         // Baking it into the layout ensures the viewport-frame broadcast (DeltaSkinScreenPositionWrapper)
         // uses the same dimensions as the rendered skin, preventing screen/overlay misalignment.
-        let clampedOverlayScale = max(0.5, min(1.5, CGFloat(overlayScale)))
+        let scaleRange = Defaults.Keys.controllerOverlayScaleRange
+        let clampedOverlayScale = CGFloat(max(scaleRange.lowerBound, min(scaleRange.upperBound, overlayScale)))
         let finalScale = scale * clampedOverlayScale
         let scaledWidth = effectiveImageSize.width * finalScale
         let scaledHeight = effectiveImageSize.height * finalScale
@@ -540,7 +546,7 @@ public struct DeltaSkinView: View {
                                 .scaledToFit()
                                 .frame(width: layout.width, height: layout.height)
                                 .clipped()
-                                .opacity(max(0.1, min(1.0, Double(overlayOpacity))))
+                                .opacity(clampedOverlayOpacity)
                             // Draw per-button asset layers (if provided by the skin)
                             if let buttons = skin.buttons(for: traits),
                                let mappingSize = skin.mappingSize(for: traits) {
@@ -573,7 +579,7 @@ public struct DeltaSkinView: View {
                                                 y: button.frame.midY * scaleY
                                             )
                                             .allowsHitTesting(false)
-                                            .opacity(max(0.1, min(1.0, Double(overlayOpacity))))
+                                            .opacity(clampedOverlayOpacity)
                                     }
                                 }
                             }

--- a/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/DeltaSkinView.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/DeltaSkinView.swift
@@ -377,7 +377,7 @@ public struct DeltaSkinView: View {
         // Apply the user-requested overlay scale, clamped to a safe range.
         // Baking it into the layout ensures the viewport-frame broadcast (DeltaSkinScreenPositionWrapper)
         // uses the same dimensions as the rendered skin, preventing screen/overlay misalignment.
-        let clampedOverlayScale = CGFloat(overlayScale).clamped(to: 0.5...1.5)
+        let clampedOverlayScale = max(0.5, min(1.5, CGFloat(overlayScale)))
         let finalScale = scale * clampedOverlayScale
         let scaledWidth = effectiveImageSize.width * finalScale
         let scaledHeight = effectiveImageSize.height * finalScale
@@ -540,7 +540,7 @@ public struct DeltaSkinView: View {
                                 .scaledToFit()
                                 .frame(width: layout.width, height: layout.height)
                                 .clipped()
-                                .opacity(Double(overlayOpacity).clamped(to: 0.1...1.0))
+                                .opacity(max(0.1, min(1.0, Double(overlayOpacity))))
                             // Draw per-button asset layers (if provided by the skin)
                             if let buttons = skin.buttons(for: traits),
                                let mappingSize = skin.mappingSize(for: traits) {
@@ -573,7 +573,7 @@ public struct DeltaSkinView: View {
                                                 y: button.frame.midY * scaleY
                                             )
                                             .allowsHitTesting(false)
-                                            .opacity(Double(overlayOpacity).clamped(to: 0.1...1.0))
+                                            .opacity(max(0.1, min(1.0, Double(overlayOpacity))))
                                     }
                                 }
                             }

--- a/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/DeltaSkinView.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/DeltaSkinView.swift
@@ -374,8 +374,13 @@ public struct DeltaSkinView: View {
             )
         }
 
-        let scaledWidth = effectiveImageSize.width * scale
-        let scaledHeight = effectiveImageSize.height * scale
+        // Apply the user-requested overlay scale, clamped to a safe range.
+        // Baking it into the layout ensures the viewport-frame broadcast (DeltaSkinScreenPositionWrapper)
+        // uses the same dimensions as the rendered skin, preventing screen/overlay misalignment.
+        let clampedOverlayScale = CGFloat(overlayScale).clamped(to: 0.5...1.5)
+        let finalScale = scale * clampedOverlayScale
+        let scaledWidth = effectiveImageSize.width * finalScale
+        let scaledHeight = effectiveImageSize.height * finalScale
 
         // Center horizontally accounting for safe areas
         let xOffset = safeInsets.leading + (availableWidth - scaledWidth) / 2
@@ -392,13 +397,13 @@ public struct DeltaSkinView: View {
         }
 
         let layout = SkinLayout(
-            scale: scale,
+            scale: finalScale,
             width: scaledWidth,
             height: scaledHeight,
             xOffset: xOffset,
             yOffset: yOffset
         )
-        ILOG("skins: calculateLayout() - calculated layout: scale=\(scale), width=\(scaledWidth), height=\(scaledHeight), xOffset=\(xOffset), yOffset=\(yOffset)")
+        ILOG("skins: calculateLayout() - calculated layout: scale=\(finalScale), width=\(scaledWidth), height=\(scaledHeight), xOffset=\(xOffset), yOffset=\(yOffset)")
         return layout
     }
 
@@ -535,7 +540,7 @@ public struct DeltaSkinView: View {
                                 .scaledToFit()
                                 .frame(width: layout.width, height: layout.height)
                                 .clipped()
-                                .opacity(Double(overlayOpacity))
+                                .opacity(Double(overlayOpacity).clamped(to: 0.1...1.0))
                             // Draw per-button asset layers (if provided by the skin)
                             if let buttons = skin.buttons(for: traits),
                                let mappingSize = skin.mappingSize(for: traits) {
@@ -568,7 +573,7 @@ public struct DeltaSkinView: View {
                                                 y: button.frame.midY * scaleY
                                             )
                                             .allowsHitTesting(false)
-                                            .opacity(Double(overlayOpacity))
+                                            .opacity(Double(overlayOpacity).clamped(to: 0.1...1.0))
                                     }
                                 }
                             }

--- a/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/DeltaSkinView.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/DeltaSkinView.swift
@@ -69,7 +69,6 @@ public struct DeltaSkinView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     // Global overlay appearance settings
-    @Default(.controllerOverlayScale) private var overlayScale
     @Default(.controllerOverlayOpacity) private var overlayOpacity
 
     private var clampedOverlayOpacity: Double {
@@ -379,12 +378,7 @@ public struct DeltaSkinView: View {
             )
         }
 
-        // Apply the user-requested overlay scale, clamped to a safe range.
-        // Baking it into the layout ensures the viewport-frame broadcast (DeltaSkinScreenPositionWrapper)
-        // uses the same dimensions as the rendered skin, preventing screen/overlay misalignment.
-        let scaleRange = Defaults.Keys.controllerOverlayScaleRange
-        let clampedOverlayScale = CGFloat(max(scaleRange.lowerBound, min(scaleRange.upperBound, overlayScale)))
-        let finalScale = scale * clampedOverlayScale
+        let finalScale = scale
         let scaledWidth = effectiveImageSize.width * finalScale
         let scaledHeight = effectiveImageSize.height * finalScale
 

--- a/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/Display/EmulatorWithSkinView.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/Display/EmulatorWithSkinView.swift
@@ -46,9 +46,6 @@ struct EmulatorWithSkinView: View {
     // Live binding to built-in filter selection
     @Default(.metalFilterMode) private var metalFilterMode
 
-    // Global overlay scale from settings
-    @Default(.controllerOverlayScale) private var overlayScale
-
     // User-selected filter from pause menu (takes precedence)
     @State private var selectedFilterName: String?
 
@@ -609,7 +606,6 @@ struct EmulatorWithSkinView: View {
             }
         }
         .environmentObject(inputHandler)
-        .scaleEffect(CGFloat(overlayScale))
         // NOTE: Removed aggressive .id() modifier that was causing AG::precondition_failure crashes
         // when changing filters. The filter is passed as a parameter to DeltaSkinView and updates
         // automatically when state changes. Using .id() to force full view recreation corrupts

--- a/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/Display/EmulatorWithSkinView.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/Display/EmulatorWithSkinView.swift
@@ -46,6 +46,9 @@ struct EmulatorWithSkinView: View {
     // Live binding to built-in filter selection
     @Default(.metalFilterMode) private var metalFilterMode
 
+    // Global overlay scale from settings
+    @Default(.controllerOverlayScale) private var overlayScale
+
     // User-selected filter from pause menu (takes precedence)
     @State private var selectedFilterName: String?
 
@@ -606,6 +609,7 @@ struct EmulatorWithSkinView: View {
             }
         }
         .environmentObject(inputHandler)
+        .scaleEffect(CGFloat(overlayScale))
         // NOTE: Removed aggressive .id() modifier that was causing AG::precondition_failure crashes
         // when changing filters. The filter is passed as a parameter to DeltaSkinView and updates
         // automatically when state changes. Using .id() to force full view recreation corrupts


### PR DESCRIPTION
## Summary
- Adds two new global settings: **Controller Overlay Scale** (0.5x-1.5x) and **Controller Overlay Opacity** (0.1-1.0) for DeltaSkin controller overlays
- Scale is baked into `DeltaSkinView.calculateLayout()` so that viewport-frame broadcasts via `DeltaSkinScreenPositionWrapper` remain aligned with the rendered skin dimensions
- Opacity applied to the skin background image and per-button asset layers (game screen stays fully opaque)
- Adds slider controls in the Delta Skins settings section with retrowave-themed UI
- Fixes SuperGrafx (SGFX) input routing to use `PVPCESystemResponderClient`/`PVPCEButton` instead of sharing the PCFX handler

## Details
Part of #2890

**Settings keys** (`PVSettingsModel.swift`):
- `controllerOverlayScale` — `Float`, default `1.0`, range `0.5...1.5`
- `controllerOverlayOpacity` — `Float`, default `1.0`, range `0.1...1.0`
- Shared range constants (`controllerOverlayScaleRange`, `controllerOverlayOpacityRange`) used by both the settings sliders and rendering clamping to ensure they stay in sync

**Rendering** (`DeltaSkinView.swift`):
- Scale baked into layout via `calculateLayout()`: `finalScale = fitScale * clampedOverlayScale`
  - Baking ensures `DeltaSkinScreenPositionWrapper` viewport-frame broadcasts use the same dimensions as the rendered skin, preventing screen/overlay misalignment
- Opacity applied via `clampedOverlayOpacity` computed property on the skin background image and per-button asset layers

**Settings UI** (`SettingsSwiftUI.swift`):
- Two `RetroWaveSlider` controls added to the Delta Skins section, bound to shared range constants

**Input Routing** (`DeltaSkinInputHandler.swift`, `Controls+SystemResponderClient.swift`, `Controls+SystemIdentifier.swift`):
- `.SGFX` now routes through `PVPCESystemResponderClient` and `PVPCEButton` (was incorrectly sharing the `.PCFX` handler)

## Test plan
- [ ] Open Settings > Delta Skins and verify the two new sliders appear
- [ ] Adjust Overlay Scale slider and launch a game with a skin — verify the overlay scales up/down while the game screen remains properly aligned
- [ ] Adjust Overlay Opacity slider and verify the skin buttons become translucent while the game screen stays opaque
- [ ] Verify defaults (Scale=1.0, Opacity=1.0) behave identically to before this change
- [ ] Verify the classic OSD controller (non-skin) is unaffected by these settings
- [ ] Test SuperGrafx ROM — verify buttons are correctly mapped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
