### PR TITLE
[Agent] feat(UX): toast warning when device audio is muted or volume is zero

### DIFF
--- a/PVUI/Sources/PVUIBase/PVEmulatorVC/PVEmulatorViewController+AudioMuteWarning.swift
+++ b/PVUI/Sources/PVUIBase/PVEmulatorVC/PVEmulatorViewController+AudioMuteWarning.swift
@@ -27,11 +27,10 @@ extension PVEmulatorViewController {
     /// Call shortly after emulation starts to warn if the device audio
     /// is muted or volume is at zero. Only fires once per app session.
     func checkAudioMuteWarningAfterDelay() {
-        guard !Self.hasShownAudioMuteWarning else { return }
-
         // Delay so the game has time to load and the user sees the emulator first.
         DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
-            self?.showAudioMuteWarningIfNeeded()
+            guard let self = self, !Self.hasShownAudioMuteWarning else { return }
+            self.showAudioMuteWarningIfNeeded()
         }
     }
 

--- a/PVUI/Sources/PVUIBase/PVEmulatorVC/PVEmulatorViewController+AudioMuteWarning.swift
+++ b/PVUI/Sources/PVUIBase/PVEmulatorVC/PVEmulatorViewController+AudioMuteWarning.swift
@@ -1,0 +1,80 @@
+//
+//  PVEmulatorViewController+AudioMuteWarning.swift
+//  PVUIBase
+//
+//  Shows a one-time toast warning when the user starts a game with
+//  device volume at zero or silent mode potentially active.
+//  Helps users who think sound is broken when it is actually their
+//  iOS silent-mode switch or volume setting.
+//
+
+#if os(iOS)
+import AVFoundation
+import Defaults
+import Foundation
+import PVLogging
+import PVSettings
+
+// MARK: - Audio mute/volume warning at game start
+
+extension PVEmulatorViewController {
+
+    /// Tracks whether the audio-mute warning has already been shown this app session.
+    private static var hasShownAudioMuteWarning = false
+
+    /// Call shortly after emulation starts to warn if the device audio
+    /// is muted or volume is at zero. Only fires once per app session.
+    func checkAudioMuteWarningAfterDelay() {
+        guard !Self.hasShownAudioMuteWarning else { return }
+
+        // Delay so the game has time to load and the user sees the emulator first.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
+            self?.showAudioMuteWarningIfNeeded()
+        }
+    }
+
+    // MARK: - Private
+
+    private func showAudioMuteWarningIfNeeded() {
+        guard !Self.hasShownAudioMuteWarning else { return }
+
+        let session = AVAudioSession.sharedInstance()
+        let volume = session.outputVolume
+
+        if volume <= 0.01 {
+            // Volume is essentially zero
+            Self.hasShownAudioMuteWarning = true
+            ILOG("Device volume is zero — showing audio mute toast")
+            PVToastManager.post(
+                "Volume is at zero \u{2014} use the volume buttons to hear game audio",
+                type: .warning,
+                duration: 5.0,
+                icon: "speaker.slash.fill"
+            )
+            return
+        }
+
+        // Check if Respect Silent Mode is enabled — if so, the mute switch
+        // could be silencing audio without the user realizing.
+        if Defaults[.respectMuteSwitch] {
+            // When the audio session category respects the mute switch and
+            // the current route is only the built-in speaker, the mute switch
+            // may be silencing output. We cannot directly read the switch state,
+            // but we can hint users who have this setting enabled.
+            let outputs = session.currentRoute.outputs
+            let isBuiltInSpeakerOnly = outputs.allSatisfy { $0.portType == .builtInSpeaker }
+
+            if isBuiltInSpeakerOnly {
+                Self.hasShownAudioMuteWarning = true
+                ILOG("Respect Silent Mode is on and using built-in speaker — showing silent mode toast")
+                PVToastManager.post(
+                    "If audio is muted, flip the silent switch or disable \u{201C}Respect Silent Mode\u{201D} in Settings \u{2192} Audio",
+                    type: .warning,
+                    duration: 6.0,
+                    icon: "bell.slash.fill"
+                )
+            }
+        }
+    }
+}
+#endif

--- a/PVUI/Sources/PVUIBase/PVEmulatorVC/PVEmulatorViewController+AudioMuteWarning.swift
+++ b/PVUI/Sources/PVUIBase/PVEmulatorVC/PVEmulatorViewController+AudioMuteWarning.swift
@@ -8,10 +8,12 @@
 //  iOS silent-mode switch or volume setting.
 //
 
-#if os(iOS)
+// Exclude Mac Catalyst: the silent-switch and volume-button copy is iOS/iPadOS-only.
+#if os(iOS) && !targetEnvironment(macCatalyst)
 import AVFoundation
 import Defaults
 import Foundation
+import PVCoreAudio
 import PVLogging
 import PVSettings
 
@@ -56,17 +58,18 @@ extension PVEmulatorViewController {
 
         // Check if Respect Silent Mode is enabled — if so, the mute switch
         // could be silencing audio without the user realizing.
+        // Use AVAudioSession.isSilentModeEnabled (from PVCoreAudio) which
+        // combines the built-in speaker route check with
+        // secondaryAudioShouldBeSilencedHint for a reliable signal.
         if Defaults[.respectMuteSwitch] {
-            // When the audio session category respects the mute switch and
-            // the current route is only the built-in speaker, the mute switch
-            // may be silencing output. We cannot directly read the switch state,
-            // but we can hint users who have this setting enabled.
             let outputs = session.currentRoute.outputs
-            let isBuiltInSpeakerOnly = outputs.allSatisfy { $0.portType == .builtInSpeaker }
+            // Guard against an empty outputs list (allSatisfy returns true on empty).
+            let isBuiltInSpeakerOnly = !outputs.isEmpty &&
+                outputs.allSatisfy { $0.portType == .builtInSpeaker }
 
-            if isBuiltInSpeakerOnly {
+            if isBuiltInSpeakerOnly && session.isSilentModeEnabled {
                 Self.hasShownAudioMuteWarning = true
-                ILOG("Respect Silent Mode is on and using built-in speaker — showing silent mode toast")
+                ILOG("Silent mode detected with built-in speaker — showing silent mode toast")
                 PVToastManager.post(
                     "If audio is muted, flip the silent switch or disable \u{201C}Respect Silent Mode\u{201D} in Settings \u{2192} Audio",
                     type: .warning,

--- a/PVUI/Sources/PVUIBase/PVEmulatorVC/PVEmulatorViewController+AudioMuteWarning.swift
+++ b/PVUI/Sources/PVUIBase/PVEmulatorVC/PVEmulatorViewController+AudioMuteWarning.swift
@@ -70,7 +70,7 @@ extension PVEmulatorViewController {
                 Self.hasShownAudioMuteWarning = true
                 ILOG("Silent mode detected with built-in speaker — showing silent mode toast")
                 PVToastManager.post(
-                    "If audio is muted, flip the silent switch or disable \u{201C}Respect Silent Mode\u{201D} in Settings \u{2192} Audio",
+                    "If audio is muted, turn off Silent Mode or disable \u{201C}Respect Silent Mode\u{201D} in Settings \u{2192} Audio",
                     type: .warning,
                     duration: 6.0,
                     icon: "bell.slash.fill"

--- a/PVUI/Sources/PVUIBase/PVEmulatorVC/PVEmulatorViewController.swift
+++ b/PVUI/Sources/PVUIBase/PVEmulatorVC/PVEmulatorViewController.swift
@@ -843,6 +843,11 @@ final class PVEmulatorViewController: PVEmulatorViewControllerRootClass, PVEmual
 
         core.startEmulation()
 
+        // Warn if device audio is muted or volume is zero (iOS only, once per session).
+        #if os(iOS)
+        checkAudioMuteWarningAfterDelay()
+        #endif
+
         // Start RetroAchievements session if the user is logged in and the core supports it.
         startAchievementsIfNeeded()
 

--- a/PVUI/Sources/PVUIBase/PVEmulatorVC/PVEmulatorViewController.swift
+++ b/PVUI/Sources/PVUIBase/PVEmulatorVC/PVEmulatorViewController.swift
@@ -843,8 +843,8 @@ final class PVEmulatorViewController: PVEmulatorViewControllerRootClass, PVEmual
 
         core.startEmulation()
 
-        // Warn if device audio is muted or volume is zero (iOS only, once per session).
-        #if os(iOS)
+        // Warn if device audio is muted or volume is zero (iOS/iPadOS only, once per session).
+        #if os(iOS) && !targetEnvironment(macCatalyst)
         checkAudioMuteWarningAfterDelay()
         #endif
 


### PR DESCRIPTION
## Summary
- Adds a one-time toast warning when emulation starts if the device volume is at zero or the iOS silent mode switch may be silencing audio
- Uses `AVAudioSession.outputVolume` to detect zero volume and `Defaults[.respectMuteSwitch]` + built-in speaker route detection for silent mode
- Warning shows 2 seconds after `startEmulation()` to avoid interrupting game load, and only fires once per app session (static flag)
- iOS only (`#if os(iOS)`) -- tvOS has no silent switch

## Test plan
- [ ] Launch a game with device volume at zero -- should see "Volume is at zero" warning toast
- [ ] Launch a game with silent mode switch on and "Respect Silent Mode" enabled in Settings > Audio -- should see silent mode hint toast
- [ ] Launch a second game in the same session -- toast should NOT appear again
- [ ] Launch a game with volume up and silent mode off -- no toast should appear
- [ ] Verify tvOS builds are unaffected (code is gated behind `#if os(iOS)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)