### PR TITLE
[Agent] fix(doom): correct default skin button labels for FPS systems (#3169)

### DIFF
--- a/PVCoreBridge/Sources/PVCoreBridge/Features/Controls/PVDOSButton.swift
+++ b/PVCoreBridge/Sources/PVCoreBridge/Features/Controls/PVDOSButton.swift
@@ -35,7 +35,7 @@
             case "right": self = .right
             case "fire1", "fire 1", "1", "i", "a", "fire", "shoot": self = .fire1
             case "fire2", "fire 2", "2", "ii", "b", "use": self = .fire2
-            case "select", "s": self = .select
+            case "select", "s", "map", "automap": self = .select
             case "pause", "p": self = .pause
             case "reset": self = .reset
             case "leftdiff": self = .leftDiff
@@ -43,7 +43,7 @@
             // Doom-specific: shoulder / trigger buttons
             case "strafeleft", "sl", "l", "l1": self = .strafeLeft
             case "straferight", "sr", "r", "r1": self = .strafeRight
-            case "run", "speed", "shift": self = .run
+            case "run", "speed", "shift", "y": self = .run
             case "weaponnext", "wn", "nextweapon", "r2": self = .weaponNext
             case "weaponprev", "wp", "prevweapon", "l2": self = .weaponPrev
             case "count": self = .count

--- a/PVCoreBridge/Sources/PVCoreBridge/Features/Controls/PVDoomButton.swift
+++ b/PVCoreBridge/Sources/PVCoreBridge/Features/Controls/PVDoomButton.swift
@@ -53,12 +53,12 @@
         case "right": self = .right
         case "fire", "fire1", "shoot", "1", "a": self = .fire
         case "use", "fire2", "interact", "open", "2", "b": self = .use
-        case "run", "speed", "shift": self = .run
+        case "run", "speed", "shift", "y": self = .run
         case "strafeleft", "sl", "l", "l1": self = .strafeLeft
         case "straferight", "sr", "r", "r1": self = .strafeRight
         case "weaponprev", "wp", "prevweapon", "l2", "prev": self = .weaponPrev
         case "weaponnext", "wn", "nextweapon", "r2", "next": self = .weaponNext
-        case "map", "automap", "select": self = .map
+        case "map", "automap", "select", "x": self = .map
         case "pause", "start", "menu": self = .pause
         case "count": self = .count
         default: self = .up

--- a/PVCoreBridge/Sources/PVCoreBridge/Features/Controls/PVWolf3DButton.swift
+++ b/PVCoreBridge/Sources/PVCoreBridge/Features/Controls/PVWolf3DButton.swift
@@ -53,10 +53,10 @@
         case "down": self = .down
         case "left": self = .left
         case "right": self = .right
-        case "fire", "shoot", "1": self = .fire
-        case "open", "use", "2": self = .open
-        case "strafeon", "strafe": self = .strafeOn
-        case "run", "speed": self = .run
+        case "fire", "shoot", "1", "a": self = .fire
+        case "open", "use", "2", "b": self = .open
+        case "strafeon", "strafe", "y": self = .strafeOn
+        case "run", "speed", "x": self = .run
         case "strafeleft", "sl", "l", "l1": self = .strafeLeft
         case "straferight", "sr", "r", "r1": self = .strafeRight
         case "weaponprev", "wp", "prevweapon", "l2", "prev": self = .weaponPrev

--- a/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Models/DeltaSkinInputHandler.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Models/DeltaSkinInputHandler.swift
@@ -2140,6 +2140,49 @@ public class DeltaSkinInputHandler: ObservableObject {
             if ["leftdiff", "l", "l1"].contains(s) { return "leftDiff" }
             if ["rightdiff", "r", "r1"].contains(s) { return "rightDiff" }
             return s
+        case .DOOM:
+            /// Doom button normalization -- pass FPS-specific IDs through to PVDoomButton
+            if ["up", "down", "left", "right"].contains(s) { return s }
+            if ["fire", "shoot", "a"].contains(s) { return "fire" }
+            if ["use", "open", "b"].contains(s) { return "use" }
+            if ["run", "speed", "y"].contains(s) { return "run" }
+            if ["map", "automap", "x"].contains(s) { return "map" }
+            if ["strafeleft", "sl", "l", "l1"].contains(s) { return "strafeleft" }
+            if ["straferight", "sr", "r", "r1"].contains(s) { return "straferight" }
+            if ["weaponprev", "l2"].contains(s) { return "weaponprev" }
+            if ["weaponnext", "r2"].contains(s) { return "weaponnext" }
+            if ["start", "pause"].contains(s) { return "pause" }
+            if ["select"].contains(s) { return "map" }
+            return s
+        case .Wolf3D:
+            /// Wolf3D button normalization -- pass FPS-specific IDs through to PVWolf3DButton
+            if ["up", "down", "left", "right"].contains(s) { return s }
+            if ["fire", "shoot", "a"].contains(s) { return "fire" }
+            if ["use", "open", "b"].contains(s) { return "open" }
+            if ["run", "speed", "x"].contains(s) { return "run" }
+            if ["strafeon", "strafe", "y"].contains(s) { return "strafeon" }
+            if ["map", "automap"].contains(s) { return "map" }
+            if ["strafeleft", "sl", "l", "l1"].contains(s) { return "strafeleft" }
+            if ["straferight", "sr", "r", "r1"].contains(s) { return "straferight" }
+            if ["weaponprev", "l2"].contains(s) { return "weaponprev" }
+            if ["weaponnext", "r2"].contains(s) { return "weaponnext" }
+            if ["start", "menu", "pause"].contains(s) { return "menu" }
+            if ["select"].contains(s) { return "map" }
+            return s
+        case .Quake, .Quake2:
+            /// Quake button normalization -- pass FPS-specific IDs through to PVDOSButton
+            if ["up", "down", "left", "right"].contains(s) { return s }
+            if ["fire", "shoot", "a"].contains(s) { return "fire" }
+            if ["use", "open", "b"].contains(s) { return "use" }
+            if ["run", "speed", "y"].contains(s) { return "run" }
+            if ["map", "automap", "x"].contains(s) { return "map" }
+            if ["strafeleft", "sl", "l", "l1"].contains(s) { return "strafeleft" }
+            if ["straferight", "sr", "r", "r1"].contains(s) { return "straferight" }
+            if ["weaponprev", "l2"].contains(s) { return "weaponprev" }
+            if ["weaponnext", "r2"].contains(s) { return "weaponnext" }
+            if ["start", "pause"].contains(s) { return "pause" }
+            if ["select"].contains(s) { return "select" }
+            return s
         default:
             break
         }

--- a/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/Display/EmulatorWithSkinView+DefaultSkin.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/Display/EmulatorWithSkinView+DefaultSkin.swift
@@ -400,17 +400,7 @@ struct DefaultControllerSkinView: View {
             // Action buttons on the right side
             VStack {
                 Spacer()
-                HStack(spacing: 30) {
-                    VStack(spacing: 25) {
-                        circleButton(label: "Y", color: .yellow)
-                        circleButton(label: "X", color: .blue)
-                    }
-
-                    VStack(spacing: 25) {
-                        circleButton(label: "B", color: .red)
-                        circleButton(label: "A", color: .green)
-                    }
-                }
+                faceButtonCluster(spacing: 25)
                 Spacer()
             }
             .frame(width: 150)
@@ -813,17 +803,7 @@ struct DefaultControllerSkinView: View {
 
                 // Right side - Action buttons (constrained to prevent off-screen)
                 VStack(spacing: 20) {
-                    HStack(spacing: 20) { // Reduced spacing to fit better
-                        VStack(spacing: 20) { // Reduced vertical spacing
-                            circleButton(label: "Y", color: .yellow)
-                            circleButton(label: "X", color: .blue)
-                        }
-
-                        VStack(spacing: 20) { // Reduced vertical spacing
-                            circleButton(label: "B", color: .red)
-                            circleButton(label: "A", color: .green)
-                        }
-                    }
+                    faceButtonCluster(spacing: 20)
                 }
                 .frame(maxWidth: .infinity, alignment: .trailing)
             }
@@ -1159,6 +1139,45 @@ struct DefaultControllerSkinView: View {
     private func joystickView() -> some View {
         DeltaJoystickView(inputHandler: inputHandler)
             .frame(width: 150, height: 150)
+    }
+
+    // MARK: - FPS System Button Labels
+
+    /// Whether the current system is an FPS game (Doom, Wolf3D, Quake, etc.)
+    private var isFPSSystem: Bool {
+        guard let systemId = systemId else { return false }
+        return [.DOOM, .Wolf3D, .Quake, .Quake2].contains(systemId)
+    }
+
+    /// Face button labels for the four ABXY positions, customized for FPS systems.
+    /// Returns (north, west, east, south) matching the 2x2 grid layout positions.
+    private var faceButtonLabels: (north: String, west: String, east: String, south: String) {
+        if isFPSSystem {
+            // FPS-specific labels that also serve as correct input IDs:
+            //   east  (B position) -> "FIRE"  -> PVDoomButton.fire  (JOYPAD_A)
+            //   south (A position) -> "USE"   -> PVDoomButton.use   (JOYPAD_B)
+            //   west  (Y position) -> "RUN"   -> PVDoomButton.run   (JOYPAD_Y)
+            //   north (X position) -> "MAP"   -> PVDoomButton.map   (JOYPAD_X)
+            return (north: "MAP", west: "RUN", east: "FIRE", south: "USE")
+        }
+        return (north: "X", west: "Y", east: "B", south: "A")
+    }
+
+    /// Generates the standard face button cluster (2x2 grid layout),
+    /// using system-appropriate labels for FPS games.
+    @ViewBuilder
+    private func faceButtonCluster(spacing: CGFloat = 20) -> some View {
+        let labels = faceButtonLabels
+        HStack(spacing: spacing) {
+            VStack(spacing: spacing) {
+                circleButton(label: labels.west, color: .yellow)
+                circleButton(label: labels.north, color: .blue)
+            }
+            VStack(spacing: spacing) {
+                circleButton(label: labels.east, color: .red)
+                circleButton(label: labels.south, color: .green)
+            }
+        }
     }
 
     /// Circle button view with retrowave styling
@@ -1508,17 +1527,7 @@ struct DefaultControllerSkinView: View {
                         }
                     } else {
                         // Fallback to generic ABXY layout with reduced spacing
-                        HStack(spacing: 20) {
-                            VStack(spacing: 20) {
-                                circleButton(label: "Y", color: .yellow)
-                                circleButton(label: "X", color: .blue)
-                            }
-
-                            VStack(spacing: 20) {
-                                circleButton(label: "B", color: .red)
-                                circleButton(label: "A", color: .green)
-                            }
-                        }
+                        faceButtonCluster(spacing: 20)
                     }
                     Spacer()
                 }
@@ -1712,17 +1721,7 @@ struct DefaultControllerSkinView: View {
                         }
                     } else {
                         // Fallback to generic ABXY layout with reduced spacing
-                        HStack(spacing: 20) {
-                            VStack(spacing: 20) {
-                                circleButton(label: "Y", color: .yellow)
-                                circleButton(label: "X", color: .blue)
-                            }
-
-                            VStack(spacing: 20) {
-                                circleButton(label: "B", color: .red)
-                                circleButton(label: "A", color: .green)
-                            }
-                        }
+                        faceButtonCluster(spacing: 20)
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .trailing)


### PR DESCRIPTION
## Summary
- Replace generic A/B/X/Y button labels with FPS-specific labels (FIRE, USE, RUN, MAP) in the default OSD skin for Doom, Wolf3D, Quake, and Quake2 systems
- Add `"x"`/`"y"` aliases to `PVDoomButton`, `PVWolf3DButton`, and `PVDOSButton` init so generic gamepad IDs map correctly instead of falling through to `.up`
- Add FPS system normalization cases in `DeltaSkinInputHandler.normalizeSkinButtonId` to ensure "fire", "use", "run", "map" pass through correctly

## Details
The default skin's `circleButton(label:)` uses `label.lowercased()` as the input ID. Previously, FPS games showed generic "A", "B", "X", "Y" labels which:
1. Were confusing (users didn't know which button fires vs opens doors)
2. Sent "x" and "y" as input IDs, which fell to `default: .up` in PVDoomButton/PVWolf3DButton — meaning those buttons did nothing

Now FPS systems show descriptive labels like "FIRE", "USE", "RUN", "MAP" that double as correct input IDs.

Refactored all 4 ABXY button clusters into a single `faceButtonCluster()` helper with `isFPSSystem` / `faceButtonLabels` computed properties for cleaner code.

Fixes #3169

## Test plan
- [ ] Launch a Doom ROM — verify face buttons show FIRE/USE/RUN/MAP instead of A/B/X/Y
- [ ] Verify FIRE button actually fires, USE opens doors, RUN speeds up, MAP toggles automap
- [ ] Launch a non-FPS game (e.g. SNES) — verify buttons still show standard A/B/X/Y
- [ ] Test both portrait and landscape orientations
- [ ] Test Wolf3D and Quake ROMs if available

🤖 Generated with [Claude Code](https://claude.com/claude-code)