### PR TITLE
[Agent] feat(input): controller assignment UX polish — toast feedback and conflict warnings (#2775)

### DIFF
--- a/PVUI/Sources/PVSwiftUI/Settings/Views/ControllerSettingsView.swift
+++ b/PVUI/Sources/PVSwiftUI/Settings/Views/ControllerSettingsView.swift
@@ -30,6 +30,8 @@ struct ControllerSettingsView: View {
     @State private var selectedPlayer: Int?
     /// State for the action sheet presentation
     @State private var showingActionSheet = false
+    /// Confirmation for resetting all slot preferences
+    @State private var showingResetConfirmation = false
     /// Animation state for controller connection
     @State private var connectionAnimation = false
     /// Current window for iCade setup
@@ -302,6 +304,34 @@ struct ControllerSettingsView: View {
 //            }
 
             Section {
+                Button(action: {
+                    showingResetConfirmation = true
+                }) {
+                    HStack {
+                        Image(systemName: "arrow.counterclockwise")
+                        Text("Reset All Slot Preferences")
+                    }
+                    .foregroundColor(.red)
+                }
+                #if os(tvOS)
+                .buttonStyle(.card)
+                #endif
+            } header: {
+                HStack {
+                    Image(systemName: "gearshape.2")
+                    Text("Preferences")
+                }
+                .font(.headline)
+                #if os(tvOS)
+                .foregroundColor(.retroPink)
+                #endif
+            } footer: {
+                Text("Clears all saved controller-to-player slot assignments and reverts to automatic assignment.")
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+            }
+
+            Section {
                 NavigationLink(destination: WikiPageView(path: "info/controllers-and-controls/README.md", title: "Controllers & Controls")) {
                     Label("Full Controller Guide", systemImage: "books.vertical.fill")
                 }
@@ -453,6 +483,20 @@ struct ControllerSettingsView: View {
             }
         } message: {
             Text("or press a button on your iCade controller")
+        }
+        .confirmationDialog(
+            "Reset All Slot Preferences?",
+            isPresented: $showingResetConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Reset All", role: .destructive) {
+                withAnimation {
+                    controllerManager.resetAllSlotPreferences()
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This will clear all saved controller-to-player assignments and revert to automatic assignment.")
         }
         .onAppear {
             #if canImport(UIKit)

--- a/PVUI/Sources/PVUIBase/Controller/PVControllerManager.swift
+++ b/PVUI/Sources/PVUIBase/Controller/PVControllerManager.swift
@@ -554,6 +554,7 @@ public final class PVControllerManager: NSObject, ObservableObject {
             if self.controller(forPlayer: slot) == nil {
                 ILOG("Controller [\(id)] assigned to preferred slot \(slot)")
                 setController(controller, toPlayer: slot)
+                PVToastManager.post("\(id) assigned to Player \(slot)", type: .info, duration: 2.5, icon: "gamecontroller.fill")
                 NotificationCenter.default.post(name: .PVControllerManagerControllerReassigned, object: self)
                 return true
             } else {
@@ -566,16 +567,26 @@ public final class PVControllerManager: NSObject, ObservableObject {
             if let occupant = occupant {
                 let occupantID = controllerIdentifier(for: occupant)
                 if case .always(let occupantSlot) = slotMode(for: occupant), occupantSlot == slot {
-                    WLOG("⚠️ Controller slot conflict: both \"\(id)\" and \"\(occupantID)\" have .always(\(slot)). Last-connected (\"\(id)\") wins.")
+                    WLOG("Controller slot conflict: both \"\(id)\" and \"\(occupantID)\" have .always(\(slot)). Last-connected (\"\(id)\") wins.")
+                    PVToastManager.post("Slot \(slot) conflict: \(id) displaced \(occupantID)", type: .warning, duration: 4.0, icon: "exclamationmark.triangle.fill")
                 }
                 // Evict occupant before claiming the slot.
                 setController(nil, toPlayer: slot)
             }
             ILOG("Controller [\(id)] claimed slot \(slot) (always mode)")
             setController(controller, toPlayer: slot)
+            PVToastManager.post("\(id) assigned to Player \(slot)", type: .info, duration: 2.5, icon: "gamecontroller.fill")
             if let occupant = occupant {
-                ILOG("Bumping evicted controller [\(controllerIdentifier(for: occupant))] from slot \(slot)")
-                _ = assignAuto(occupant)
+                let evictedName = controllerIdentifier(for: occupant)
+                ILOG("Bumping evicted controller [\(evictedName)] from slot \(slot)")
+                let newSlot = assignAuto(occupant)
+                if newSlot {
+                    if let newIndex = index(forController: occupant) {
+                        PVToastManager.post("\(evictedName) moved to Player \(newIndex)", type: .info, duration: 3.0, icon: "arrow.right.circle.fill")
+                    }
+                } else {
+                    PVToastManager.post("\(evictedName) was unassigned (no free slot)", type: .warning, duration: 3.5, icon: "xmark.circle.fill")
+                }
             }
             NotificationCenter.default.post(name: .PVControllerManagerControllerReassigned, object: self)
             return true
@@ -601,10 +612,14 @@ public final class PVControllerManager: NSObject, ObservableObject {
             }
 
             if previouslyAssignedController == nil || (newGamepadNotRemote && !previousGamepadNotRemote) {
+                let controllerName = controllerIdentifier(for: controller)
                 setController(controller, toPlayer: i)
+                PVToastManager.post("\(controllerName) assigned to Player \(i)", type: .info, duration: 2.5, icon: "gamecontroller.fill")
                 // Move the previously assigned controller to another player
                 if let previouslyAssignedController = previouslyAssignedController {
-                    ILOG("Controller #\(i) \(previouslyAssignedController.vendorName ?? "nil") being reassigned")
+                    let displacedName = controllerIdentifier(for: previouslyAssignedController)
+                    ILOG("Controller #\(i) \(displacedName) being reassigned")
+                    PVToastManager.post("\(displacedName) displaced from Player \(i)", type: .info, duration: 3.0, icon: "arrow.right.circle.fill")
                     assign(previouslyAssignedController)
                 }
                 NotificationCenter.default.post(name: NSNotification.Name.PVControllerManagerControllerReassigned, object: self)
@@ -1050,6 +1065,15 @@ public extension PVControllerManager {
     /// Removes any saved slot mode for the given controller ID, reverting to `.auto`.
     func clearSlotMode(forId id: String) {
         setSlotMode(.auto, forId: id)
+    }
+
+    /// Removes all saved controller slot preferences, reverting every controller to `.auto`.
+    /// After clearing, re-assigns all connected controllers using auto-assignment.
+    func resetAllSlotPreferences() {
+        Defaults[.controllerSlotModes] = [:]
+        ILOG("All controller slot preferences have been reset")
+        reapplyPreferences()
+        PVToastManager.post("All controller preferences reset", type: .success, duration: 3.0, icon: "arrow.counterclockwise")
     }
 
     // MARK: Convenience Int-based API (kept for backward compatibility)


### PR DESCRIPTION
## Summary
- Added PVToastManager notifications when controllers are assigned to player slots, evicted by higher-priority controllers, or when two controllers conflict on the same `.always` slot
- Added `resetAllSlotPreferences()` method to PVControllerManager that clears all persisted slot modes and re-runs auto-assignment
- Added "Reset All Slot Preferences" button with confirmation dialog in ControllerSettingsView under a new "Preferences" section

## Test plan
- [ ] Connect multiple controllers and verify toast appears briefly when each is assigned to a player slot
- [ ] Configure two controllers with `.always` mode on the same slot; verify warning toast describes the conflict
- [ ] Verify evicted controller shows toast with its new slot assignment
- [ ] Open Controller Settings > Preferences > "Reset All Slot Preferences" and confirm the confirmation dialog appears
- [ ] Tap "Reset All" and verify all controllers revert to auto-assignment with success toast
- [ ] Verify tvOS styling (`.card` button style) renders correctly for the reset button

Closes #2775

🤖 Generated with [Claude Code](https://claude.com/claude-code)