### PR TITLE
[Agent] feat(input): turbo / autofire button support (#2819)

### DIFF
--- a/PVSettings/Sources/PVSettings/Settings/Model/PVSettingsModel.swift
+++ b/PVSettings/Sources/PVSettings/Settings/Model/PVSettingsModel.swift
@@ -134,6 +134,12 @@ public extension Defaults.Keys {
     static let tvOSSiriRemoteMouseSensitivity = Key<Double>("tvOSSiriRemoteMouseSensitivity", default: 1.0)
 #endif
 
+    /// Enable turbo/autofire: when a button has turbo active, it rapidly toggles press/release.
+    static let turboEnabled = Key<Bool>("turboEnabled", default: true)
+
+    /// Turbo fire rate in Hz (presses per second). Range 2-30, default 10.
+    static let turboRateHz = Key<Double>("turboRateHz", default: 10.0)
+
     /// Universal analog-stick deadzone applied by the shared input path.
     /// Range 0.0 (no deadzone) – 0.5 (50 % of axis range).  Default 0.0.
     /// This value is applied additively on top of any hardware-level deadzoning

--- a/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Models/DeltaSkinInputHandler.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Models/DeltaSkinInputHandler.swift
@@ -33,6 +33,10 @@ public class DeltaSkinInputHandler: ObservableObject {
     /// Track previous joystick state for D-pad conversion
     private var previousJoystickState: (x: Float, y: Float)? = nil
 
+    /// Turbo/autofire manager. Publicly accessible so views can read turbo state.
+    /// Must be accessed from the main thread only.
+    public let turboManager = TurboManager()
+
     /// Initialize with an emulator core and optional controller view controller
     public init(emulatorCore: PVEmulatorCore? = nil, controllerVC: (any ControllerVC)? = nil, emulatorController: (any PVEmualatorControllerProtocol)? = nil) {
         self.emulatorCore = emulatorCore
@@ -44,6 +48,10 @@ public class DeltaSkinInputHandler: ObservableObject {
 
         // Set up notification observers
         setupNotificationObservers()
+
+        // Wire turbo manager's button action to forward presses/releases through this handler.
+        // This runs on the main actor since TurboManager is @MainActor.
+        setupTurboCallback()
     }
 
     deinit {
@@ -64,6 +72,15 @@ public class DeltaSkinInputHandler: ObservableObject {
     /// Set the emulator controller
     func setEmulatorController(_ controller: (any PVEmualatorControllerProtocol)?) {
         self.emulatorController = controller
+    }
+
+    /// Wires TurboManager's buttonAction callback so turbo-driven presses/releases
+    /// are forwarded through the normal input path.
+    private func setupTurboCallback() {
+        turboManager.buttonAction = { [weak self] buttonId, isPressed in
+            guard let self else { return }
+            self.forwardButtonPress(buttonId, isPressed: isPressed)
+        }
     }
 
     /// Handle button press
@@ -120,6 +137,12 @@ public class DeltaSkinInputHandler: ObservableObject {
         let normalizedId = buttonId.lowercased()
         DLOG("Normalized button ID: \(normalizedId)")
 
+        // If this button has turbo enabled, let TurboManager drive the press/release cycle
+        if turboManager.isTurboActive(for: normalizedId) {
+            turboManager.buttonDown(normalizedId)
+            return
+        }
+
         // Prefer core/system-specific mapping; it will fall back to controllerVC or generic if needed
         if emulatorCore != nil {
             forwardButtonPress(normalizedId, isPressed: true)
@@ -162,6 +185,12 @@ public class DeltaSkinInputHandler: ObservableObject {
         // Normalize the button ID
         let normalizedId = buttonId.lowercased()
         DLOG("Normalized button ID for release: \(normalizedId)")
+
+        // If turbo is active for this button, let TurboManager handle the release
+        if turboManager.isTurboActive(for: normalizedId) {
+            turboManager.buttonUp(normalizedId)
+            return
+        }
 
         // Prefer core/system-specific mapping; it will fall back to controllerVC or generic if needed
         if emulatorCore != nil {

--- a/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Models/TurboManager.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Models/TurboManager.swift
@@ -1,0 +1,156 @@
+import Foundation
+import Combine
+import PVSettings
+import PVLogging
+import Defaults
+#if canImport(QuartzCore)
+import QuartzCore
+#endif
+
+/// Manages turbo/autofire state for skin buttons.
+///
+/// When turbo is enabled for a button, the manager rapidly toggles
+/// press/release at the rate configured in ``Defaults.Keys.turboRateHz``.
+/// The caller provides a press/release callback; the manager drives timing.
+///
+/// All public API must be called from the main thread (CADisplayLink fires on
+/// the main run-loop).
+public final class TurboManager: ObservableObject, @unchecked Sendable {
+
+    // MARK: - Published state
+
+    /// The set of button IDs that currently have turbo enabled.
+    @Published public private(set) var turboButtons: Set<String> = []
+
+    // MARK: - Callback
+
+    /// Called by the timer to press (true) or release (false) a button.
+    public var buttonAction: ((_ buttonId: String, _ isPressed: Bool) -> Void)?
+
+    // MARK: - Internal state
+
+    /// Buttons that the user is currently *holding down* (finger on screen).
+    /// Turbo only fires while the button is held.
+    private var heldButtons: Set<String> = []
+
+    /// Display-link timer that drives the turbo toggling.
+    private var displayLink: CADisplayLink?
+
+    /// Tracks the current on/off phase per button so we can alternate.
+    private var buttonPhase: [String: Bool] = [:]
+
+    /// Timestamp of the last toggle per button, used to throttle to the configured rate.
+    private var lastToggle: [String: CFTimeInterval] = [:]
+
+    // MARK: - Lifecycle
+
+    public init() {}
+
+    deinit {
+        displayLink?.invalidate()
+    }
+
+    // MARK: - Public API
+
+    /// Toggle turbo mode for the given button ID.
+    /// Returns `true` if turbo is now active, `false` if it was turned off.
+    @discardableResult
+    public func toggleTurbo(for buttonId: String) -> Bool {
+        if turboButtons.contains(buttonId) {
+            turboButtons.remove(buttonId)
+            buttonPhase.removeValue(forKey: buttonId)
+            lastToggle.removeValue(forKey: buttonId)
+            DLOG("Turbo OFF for \(buttonId)")
+            updateTimer()
+            return false
+        } else {
+            turboButtons.insert(buttonId)
+            buttonPhase[buttonId] = false
+            DLOG("Turbo ON for \(buttonId)")
+            updateTimer()
+            return true
+        }
+    }
+
+    /// Returns whether the given button currently has turbo enabled.
+    public func isTurboActive(for buttonId: String) -> Bool {
+        turboButtons.contains(buttonId)
+    }
+
+    /// Call when the user presses down on a button (finger touches screen).
+    public func buttonDown(_ buttonId: String) {
+        heldButtons.insert(buttonId)
+        if turboButtons.contains(buttonId) {
+            // Start in the "pressed" phase immediately
+            buttonPhase[buttonId] = true
+            buttonAction?(buttonId, true)
+            lastToggle[buttonId] = CACurrentMediaTime()
+            updateTimer()
+        }
+    }
+
+    /// Call when the user lifts their finger from a button.
+    public func buttonUp(_ buttonId: String) {
+        heldButtons.remove(buttonId)
+        if turboButtons.contains(buttonId) {
+            // Ensure the button is released
+            buttonPhase[buttonId] = false
+            buttonAction?(buttonId, false)
+            updateTimer()
+        }
+    }
+
+    /// Remove all turbo assignments.
+    public func clearAll() {
+        turboButtons.removeAll()
+        buttonPhase.removeAll()
+        lastToggle.removeAll()
+        heldButtons.removeAll()
+        updateTimer()
+    }
+
+    // MARK: - Timer management
+
+    private func updateTimer() {
+        let needsTimer = !turboButtons.isEmpty && !heldButtons.isDisjoint(with: turboButtons)
+        if needsTimer && displayLink == nil {
+            let link = CADisplayLink(target: TurboDisplayLinkTarget(handler: { [weak self] in
+                self?.tick()
+            }), selector: #selector(TurboDisplayLinkTarget.step))
+            link.preferredFrameRateRange = CAFrameRateRange(minimum: 30, maximum: 120, preferred: 60)
+            link.add(to: .main, forMode: .common)
+            displayLink = link
+        } else if !needsTimer && displayLink != nil {
+            displayLink?.invalidate()
+            displayLink = nil
+        }
+    }
+
+    private func tick() {
+        guard Defaults[.turboEnabled] else { return }
+        let rateHz = max(2.0, min(30.0, Defaults[.turboRateHz]))
+        let interval: CFTimeInterval = 1.0 / (rateHz * 2.0) // half-period (press + release = 1 full cycle)
+        let now = CACurrentMediaTime()
+
+        for buttonId in turboButtons where heldButtons.contains(buttonId) {
+            let last = lastToggle[buttonId] ?? 0
+            if now - last >= interval {
+                let currentPhase = buttonPhase[buttonId] ?? false
+                let newPhase = !currentPhase
+                buttonPhase[buttonId] = newPhase
+                lastToggle[buttonId] = now
+                buttonAction?(buttonId, newPhase)
+            }
+        }
+    }
+}
+
+// MARK: - CADisplayLink target (prevents retain cycle)
+
+/// A small helper that forwards CADisplayLink callbacks without creating a
+/// retain cycle between the display link and TurboManager.
+private final class TurboDisplayLinkTarget: NSObject {
+    let handler: () -> Void
+    init(handler: @escaping () -> Void) { self.handler = handler }
+    @objc func step() { handler() }
+}

--- a/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/Components/Buttons/DeltaSkinTurboBadge.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/Components/Buttons/DeltaSkinTurboBadge.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+/// A small pulsing "T" badge overlay shown on buttons that have turbo/autofire enabled.
+struct DeltaSkinTurboBadge: View {
+    /// The frame of the button this badge belongs to, in the skin's coordinate space.
+    let buttonFrame: CGRect
+    /// The mapping size of the skin (used to scale the badge appropriately).
+    let mappingSize: CGSize
+
+    @State private var isPulsing = false
+
+    var body: some View {
+        let badgeSize: CGFloat = max(14, min(buttonFrame.width, buttonFrame.height) * 0.3)
+
+        ZStack {
+            // Background circle with pulsing glow
+            Circle()
+                .fill(Color.orange)
+                .frame(width: badgeSize, height: badgeSize)
+                .shadow(color: .orange.opacity(isPulsing ? 0.8 : 0.3), radius: isPulsing ? 6 : 2)
+                .scaleEffect(isPulsing ? 1.15 : 1.0)
+
+            // "T" label
+            Text("T")
+                .font(.system(size: badgeSize * 0.6, weight: .heavy, design: .rounded))
+                .foregroundColor(.white)
+        }
+        .position(
+            x: buttonFrame.maxX - badgeSize * 0.4,
+            y: buttonFrame.minY + badgeSize * 0.4
+        )
+        .onAppear {
+            withAnimation(.easeInOut(duration: 0.6).repeatForever(autoreverses: true)) {
+                isPulsing = true
+            }
+        }
+    }
+}

--- a/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/DeltaSkinView.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/DeltaSkinView.swift
@@ -66,6 +66,9 @@ public struct DeltaSkinView: View {
     let inputHandler: DeltaSkinInputHandler
     let core: PVEmulatorCore?  // Core for protocol-based viewport updates
 
+    /// Observed so the view re-renders when turbo buttons change.
+    @ObservedObject var turboManager: TurboManager
+
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     /// State for touch and button interactions
@@ -145,6 +148,13 @@ public struct DeltaSkinView: View {
     @State private var buttonMappings: [DeltaSkinButtonMapping]?
 
     @State private var pressedButtons: Set<String> = []
+
+    // MARK: - Turbo long-press state
+    /// Timer used to detect a long-press for turbo toggle (fires after 0.6s)
+    @State private var turboLongPressTimers: [ObjectIdentifier: Timer] = [:]
+    /// Tracks buttons whose turbo was just toggled in this touch so we skip the normal release
+    @State private var turboToggledThisTouch: Set<ObjectIdentifier> = []
+
     // Cache of per-button asset images (normal/pressed) keyed by button id
     @State private var buttonAssetImages: [String: (normal: UIImage, pressed: UIImage?)] = [:]
 
@@ -281,6 +291,7 @@ public struct DeltaSkinView: View {
         self.core = core
         self.isInEmulator = isInEmulator
         self.inputHandler = inputHandler
+        self._turboManager = ObservedObject(wrappedValue: inputHandler.turboManager)
 
         ILOG("skins: DeltaSkinView init - skin: \(skin.name), device: \(traits.device.rawValue), displayType: \(traits.displayType.rawValue), orientation: \(traits.orientation.rawValue), iPadModel: \(traits.iPadModel?.rawValue ?? "nil")")
     }
@@ -637,6 +648,38 @@ public struct DeltaSkinView: View {
                             .allowsHitTesting(false)
                         }
 
+                        // Turbo badges for buttons with turbo enabled
+                        if Defaults[.turboEnabled] {
+                            let turboButtons = turboManager.turboButtons
+                            if !turboButtons.isEmpty,
+                               let buttons = skin.buttons(for: traits),
+                               let mappingSize = skin.mappingSize(for: traits) {
+                                let scale = min(
+                                    geometry.size.width / mappingSize.width,
+                                    geometry.size.height / mappingSize.height
+                                )
+                                let scaledSkinWidth = mappingSize.width * scale
+                                let scaledSkinHeight = mappingSize.height * scale
+                                let xOff = (geometry.size.width - scaledSkinWidth) / 2
+                                let yOff = (geometry.size.height - scaledSkinHeight) / 2
+
+                                ForEach(buttons.filter { turboButtons.contains($0.id) }) { button in
+                                    let scaledFrame = CGRect(
+                                        x: button.frame.minX * scaledSkinWidth + xOff,
+                                        y: button.frame.minY * scaledSkinHeight + yOff,
+                                        width: button.frame.width * scaledSkinWidth,
+                                        height: button.frame.height * scaledSkinHeight
+                                    )
+                                    DeltaSkinTurboBadge(
+                                        buttonFrame: scaledFrame,
+                                        mappingSize: mappingSize
+                                    )
+                                    .zIndex(6)
+                                    .allowsHitTesting(false)
+                                }
+                            }
+                        }
+
                         // Thumbstick layer - should be on top
                         ForEach(activeThumbsticks) { thumbstick in
                             DeltaSkinThumbstick(
@@ -766,6 +809,28 @@ public struct DeltaSkinView: View {
 
                                 // Handle this touch location
                                 handleTouchAtLocation(location, in: geometry.size, touchId: touch.id)
+
+                                // Start a long-press timer for turbo toggle (0.6s hold)
+                                if Defaults[.turboEnabled] {
+                                    let touchId = touch.id
+                                    let timer = Timer.scheduledTimer(withTimeInterval: 0.6, repeats: false) { _ in
+                                        Task { @MainActor in
+                                            // Determine which button this touch is on
+                                            if let buttonId = touchToButtonMap[touchId] {
+                                                let wasEnabled = inputHandler.turboManager.toggleTurbo(for: buttonId)
+                                                turboToggledThisTouch.insert(touchId)
+                                                DLOG("Turbo toggled via long-press for \(buttonId): \(wasEnabled ? "ON" : "OFF")")
+                                                #if canImport(UIKit) && !os(tvOS)
+                                                if !ProcessInfo.processInfo.isiOSAppOnMac {
+                                                    let generator = UINotificationFeedbackGenerator()
+                                                    generator.notificationOccurred(wasEnabled ? .success : .warning)
+                                                }
+                                                #endif
+                                            }
+                                        }
+                                    }
+                                    turboLongPressTimers[touchId] = timer
+                                }
                             }
                             DLOG("Current touch points: \(touchLocations.count)")
 
@@ -794,6 +859,12 @@ public struct DeltaSkinView: View {
 
                                 // Process if: D-pad touch (always needs updates) OR has moved significantly
                                 if isDPadTouch || hasMoved {
+                                    // Cancel turbo long-press timer if touch moved
+                                    if hasMoved {
+                                        turboLongPressTimers[touch.id]?.invalidate()
+                                        turboLongPressTimers.removeValue(forKey: touch.id)
+                                    }
+
                                     if isDPadTouch {
                                         DLOG("Processing D-PAD touch: \(touch.id) at \(location)")
                                     } else {
@@ -815,6 +886,11 @@ public struct DeltaSkinView: View {
                             // Process ended touches
                             for touch in touches {
                                 DLOG("Ending touch: \(touch.id)")
+
+                                // Cancel any pending turbo long-press timer
+                                turboLongPressTimers[touch.id]?.invalidate()
+                                turboLongPressTimers.removeValue(forKey: touch.id)
+                                turboToggledThisTouch.remove(touch.id)
 
                                 // Remove this touch point from visualization
                                 touchLocations.remove(touch.location)


### PR DESCRIPTION
## Summary
- Adds turbo/autofire functionality: long-press (0.6s) any skin button to toggle rapid-fire mode
- When turbo is active on a button, holding it rapidly toggles press/release at a configurable rate (default 10Hz)
- Pulsing orange "T" badge overlays turbo-enabled buttons for clear visual feedback
- New settings: `turboEnabled` (bool) and `turboRateHz` (2-30Hz) in PVSettings

## Implementation
- **TurboManager** (`PVUI`): CADisplayLink-driven engine that alternates press/release at the configured frequency. Only runs while at least one turbo button is held down.
- **PVSettings**: Two new `Defaults.Keys` — `turboEnabled` (default true) and `turboRateHz` (default 10.0)
- **DeltaSkinInputHandler**: Intercepts press/release for turbo-active buttons and delegates to TurboManager. Wires TurboManager's callback back through `forwardButtonPress`.
- **DeltaSkinView**: Starts a 0.6s timer on touch-began; if the finger stays put, turbo is toggled for that button with haptic feedback. Timer cancelled on move or lift.
- **DeltaSkinTurboBadge**: Small pulsing "T" circle positioned at the top-right corner of turbo-enabled buttons.

## Test plan
- [ ] Build Provenance-Lite scheme for iOS Simulator
- [ ] Launch a game with a Delta skin
- [ ] Long-press a face button (A/B) — verify orange "T" badge appears and haptic fires
- [ ] Hold the turbo button — verify rapid press/release in the emulator (visible in shoot-em-ups or rapid-fire games)
- [ ] Release the button — verify rapid fire stops
- [ ] Long-press the same button again — verify badge disappears (turbo off)
- [ ] Verify normal button press still works for non-turbo buttons

Closes #2819

🤖 Generated with [Claude Code](https://claude.com/claude-code)