### PR TITLE
[Agent] feat(input): sticky button toggle support (#2035)

### DIFF
--- a/PVSettings/Sources/PVSettings/Settings/Model/PVSettingsModel.swift
+++ b/PVSettings/Sources/PVSettings/Settings/Model/PVSettingsModel.swift
@@ -128,6 +128,17 @@ public extension Defaults.Keys {
     static let buttonPressEffect = Key<ButtonPressEffect>("buttonPressEffect", default: .glow)
     static let buttonSound = Key<ButtonSound>("buttonSound", default: .none)
 
+    /// Valid range for `controllerOverlayOpacity`: nearly invisible to fully opaque.
+    static let controllerOverlayOpacityRange: ClosedRange<Float> = 0.1...1.0
+
+    /// Global opacity for controller overlay / skin views.
+    /// Range 0.1 (nearly invisible) – 1.0 (fully opaque). Default 1.0.
+    static let controllerOverlayOpacity = Key<Float>("controllerOverlayOpacity", default: 1.0)
+
+    /// When enabled, double-tapping a button toggles "sticky" mode: the button stays
+    /// held down until tapped again. Useful for auto-run in platformers.
+    static let stickyButtonsEnabled = Key<Bool>("stickyButtonsEnabled", default: false)
+
 #if os(tvOS)
     /// Multiplier applied to Siri Remote touch-surface pan deltas when driving mouse input.
     /// Range 0.1 – 5.0; default is 1.0 (1:1 pixel mapping).

--- a/PVSettings/Sources/PVSettings/Settings/Model/PVSettingsModel.swift
+++ b/PVSettings/Sources/PVSettings/Settings/Model/PVSettingsModel.swift
@@ -128,13 +128,6 @@ public extension Defaults.Keys {
     static let buttonPressEffect = Key<ButtonPressEffect>("buttonPressEffect", default: .glow)
     static let buttonSound = Key<ButtonSound>("buttonSound", default: .none)
 
-    /// Valid range for `controllerOverlayOpacity`: nearly invisible to fully opaque.
-    static let controllerOverlayOpacityRange: ClosedRange<Float> = 0.1...1.0
-
-    /// Global opacity for controller overlay / skin views.
-    /// Range 0.1 (nearly invisible) – 1.0 (fully opaque). Default 1.0.
-    static let controllerOverlayOpacity = Key<Float>("controllerOverlayOpacity", default: 1.0)
-
     /// When enabled, double-tapping a button toggles "sticky" mode: the button stays
     /// held down until tapped again. Useful for auto-run in platformers.
     static let stickyButtonsEnabled = Key<Bool>("stickyButtonsEnabled", default: false)

--- a/PVUI/Sources/PVSwiftUI/Settings/SettingsSwiftUI.swift
+++ b/PVUI/Sources/PVSwiftUI/Settings/SettingsSwiftUI.swift
@@ -2118,7 +2118,6 @@ private struct AdvancedSection: View {
 
 private struct DeltaSkinsSection: View {
     @Default(.buttonPressEffect) var buttonPressEffect
-    @Default(.stickyButtonsEnabled) var stickyButtonsEnabled
     @Default(.buttonSound) var buttonSound
     @Default(.skinMode) var skinMode
 

--- a/PVUI/Sources/PVSwiftUI/Settings/SettingsSwiftUI.swift
+++ b/PVUI/Sources/PVSwiftUI/Settings/SettingsSwiftUI.swift
@@ -1879,6 +1879,7 @@ private struct OnScreenControllerSection: View {
     @Default(.buttonVibration) var buttonVibration
     @Default(.buttonSound) var buttonSound
     @Default(.buttonPressEffect) var buttonPressEffect
+    @Default(.stickyButtonsEnabled) var stickyButtonsEnabled
     @Default(.missingButtonsAlwaysOn) var missingButtonsAlwaysOn
     @Default(.onscreenJoypad) var onscreenJoypad
     @Default(.onscreenJoypadWithKeyboard) var onscreenJoypadWithKeyboard
@@ -1941,6 +1942,11 @@ private struct OnScreenControllerSection: View {
                 SettingsRow(title: "Movable Buttons",
                             subtitle: "Allow player to move on screen controller buttons. Tap with 3-fingers 3 times to toggle.",
                             icon: .sfSymbol("arrow.up.and.down.and.arrow.left.and.right"))
+            }
+            ThemedToggle(isOn: $stickyButtonsEnabled) {
+                SettingsRow(title: "Sticky Buttons",
+                            subtitle: "Double-tap a button to lock it held down. Double-tap again to release. Useful for auto-run in platformers.",
+                            icon: .sfSymbol("lock.rectangle"))
             }
 
         }
@@ -2112,6 +2118,7 @@ private struct AdvancedSection: View {
 
 private struct DeltaSkinsSection: View {
     @Default(.buttonPressEffect) var buttonPressEffect
+    @Default(.stickyButtonsEnabled) var stickyButtonsEnabled
     @Default(.buttonSound) var buttonSound
     @Default(.skinMode) var skinMode
 

--- a/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Models/DeltaSkinInputHandler.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Models/DeltaSkinInputHandler.swift
@@ -36,6 +36,8 @@ public class DeltaSkinInputHandler: ObservableObject {
     /// Turbo/autofire manager. Publicly accessible so views can read turbo state.
     /// Must be accessed from the main thread only.
     public let turboManager = TurboManager()
+    /// Manages sticky (toggle-hold) button state.
+    public let stickyManager = StickyButtonManager()
 
     /// Initialize with an emulator core and optional controller view controller
     public init(emulatorCore: PVEmulatorCore? = nil, controllerVC: (any ControllerVC)? = nil, emulatorController: (any PVEmualatorControllerProtocol)? = nil) {

--- a/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Models/StickyButtonManager.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Models/StickyButtonManager.swift
@@ -31,9 +31,6 @@ public final class StickyButtonManager: ObservableObject {
     /// Views can observe this to display a visual indicator (e.g. lock icon).
     @Published public private(set) var stickyButtons: Set<String> = []
 
-    /// The set of button IDs that are candidates for sticky toggle (double-tap detected).
-    @Published public private(set) var stickyTogglePending: Set<String> = []
-
     // MARK: - Private state
 
     /// Buttons currently physically held down by the user.
@@ -68,14 +65,13 @@ public final class StickyButtonManager: ObservableObject {
                 physicallyPressed.insert(buttonId)
                 return .release
             } else {
-                // Button was not sticky: make it sticky
+                // Button was not sticky: make it sticky.
+                // The first tap already sent press+release to the core, so we must
+                // send a new press now to actually hold the button down in the emulator.
                 DLOG("Sticky: toggling ON sticky for \(buttonId)")
                 stickyButtons.insert(buttonId)
                 physicallyPressed.insert(buttonId)
-                // The button is already pressed from the first tap;
-                // the emulator core already has a press event.
-                // We just mark it sticky so the release is suppressed.
-                return .ignore
+                return .press
             }
         }
 

--- a/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Models/StickyButtonManager.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Models/StickyButtonManager.swift
@@ -1,0 +1,131 @@
+import Foundation
+import Combine
+import PVLogging
+
+/// Manages "sticky" button state: when a button is toggled sticky, it stays
+/// held (pressed) until the user taps it a second time to release it.
+///
+/// Usage:
+/// - Call `handlePress(_:)` when a button touch begins.
+/// - Call `handleRelease(_:)` when a button touch ends.
+/// - The returned ``Action`` tells the caller whether to forward a real
+///   press/release to the emulator core, or to suppress it.
+@MainActor
+public final class StickyButtonManager: ObservableObject {
+
+    // MARK: - Types
+
+    /// Instruction returned to the caller after processing a touch event.
+    public enum Action {
+        /// Forward a press event to the emulator core.
+        case press
+        /// Forward a release event to the emulator core.
+        case release
+        /// Do nothing — the event was absorbed by the sticky logic.
+        case ignore
+    }
+
+    // MARK: - Published state
+
+    /// The set of button IDs that are currently locked in the "sticky-on" state.
+    /// Views can observe this to display a visual indicator (e.g. lock icon).
+    @Published public private(set) var stickyButtons: Set<String> = []
+
+    /// The set of button IDs that are candidates for sticky toggle (double-tap detected).
+    @Published public private(set) var stickyTogglePending: Set<String> = []
+
+    // MARK: - Private state
+
+    /// Buttons currently physically held down by the user.
+    private var physicallyPressed: Set<String> = []
+
+    /// Timestamps of last press per button, for double-tap detection.
+    private var lastPressTimestamps: [String: Date] = [:]
+
+    /// Maximum interval between two taps to count as a double-tap.
+    private let doubleTapInterval: TimeInterval = 0.35
+
+    // MARK: - Public API
+
+    /// Process a button press touch event.
+    ///
+    /// Returns the action the caller should take:
+    /// - `.press` — send a press to the emulator core.
+    /// - `.ignore` — the sticky system absorbed the event.
+    public func handlePress(_ buttonId: String) -> Action {
+        let now = Date()
+
+        // Check for double-tap
+        if let lastPress = lastPressTimestamps[buttonId],
+           now.timeIntervalSince(lastPress) < doubleTapInterval {
+            // Double-tap detected
+            lastPressTimestamps.removeValue(forKey: buttonId)
+
+            if stickyButtons.contains(buttonId) {
+                // Button was sticky-on: release it
+                DLOG("Sticky: releasing sticky button \(buttonId)")
+                stickyButtons.remove(buttonId)
+                physicallyPressed.insert(buttonId)
+                return .release
+            } else {
+                // Button was not sticky: make it sticky
+                DLOG("Sticky: toggling ON sticky for \(buttonId)")
+                stickyButtons.insert(buttonId)
+                physicallyPressed.insert(buttonId)
+                // The button is already pressed from the first tap;
+                // the emulator core already has a press event.
+                // We just mark it sticky so the release is suppressed.
+                return .ignore
+            }
+        }
+
+        lastPressTimestamps[buttonId] = now
+
+        // If the button is sticky-on and user presses again (single tap, first of potential double),
+        // we need to release it on this press.
+        if stickyButtons.contains(buttonId) {
+            // Don't release yet — wait to see if it's a double tap.
+            // For now, just track the press time. The release handler will decide.
+            physicallyPressed.insert(buttonId)
+            return .ignore
+        }
+
+        // Normal press
+        physicallyPressed.insert(buttonId)
+        return .press
+    }
+
+    /// Process a button release touch event.
+    ///
+    /// Returns the action the caller should take:
+    /// - `.release` — send a release to the emulator core.
+    /// - `.ignore` — the sticky system absorbed the event (button stays held).
+    public func handleRelease(_ buttonId: String) -> Action {
+        physicallyPressed.remove(buttonId)
+
+        if stickyButtons.contains(buttonId) {
+            // Button is sticky-on: suppress the release so it stays held.
+            DLOG("Sticky: suppressing release for sticky button \(buttonId)")
+            return .ignore
+        }
+
+        // Normal release
+        return .release
+    }
+
+    /// Release all sticky buttons at once (e.g. when pausing or leaving emulator).
+    /// Returns the set of button IDs that were released.
+    @discardableResult
+    public func releaseAll() -> Set<String> {
+        let released = stickyButtons
+        stickyButtons.removeAll()
+        physicallyPressed.removeAll()
+        lastPressTimestamps.removeAll()
+        return released
+    }
+
+    /// Check if a specific button is in the sticky-on state.
+    public func isSticky(_ buttonId: String) -> Bool {
+        stickyButtons.contains(buttonId)
+    }
+}

--- a/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/Components/Buttons/DeltaSkinStickyIndicator.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/Components/Buttons/DeltaSkinStickyIndicator.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+/// Visual indicator shown on buttons that are in "sticky" (toggle-held) mode.
+/// Displays an orange highlight and a small lock icon badge at the top-right corner.
+struct DeltaSkinStickyIndicator: View {
+    let frame: CGRect
+    let mappingSize: CGSize
+
+    var body: some View {
+        GeometryReader { geometry in
+            let scale = min(
+                geometry.size.width / mappingSize.width,
+                geometry.size.height / mappingSize.height
+            )
+
+            let scaledSkinWidth = mappingSize.width * scale
+            let scaledSkinHeight = mappingSize.height * scale
+            let xOffset = (geometry.size.width - scaledSkinWidth) / 2
+            let yOffset = (geometry.size.height - scaledSkinHeight) / 2
+
+            let scaledFrame = CGRect(
+                x: frame.minX * scale + xOffset,
+                y: yOffset + (frame.minY * scale),
+                width: frame.width * scale,
+                height: frame.height * scale
+            )
+
+            ZStack {
+                // Orange glow background to indicate sticky state
+                RoundedRectangle(cornerRadius: scaledFrame.width * 0.15)
+                    .fill(Color.orange.opacity(0.2))
+                    .frame(width: scaledFrame.width, height: scaledFrame.height)
+                    .position(x: scaledFrame.midX, y: scaledFrame.midY)
+
+                // Orange border highlight
+                RoundedRectangle(cornerRadius: scaledFrame.width * 0.15)
+                    .strokeBorder(Color.orange.opacity(0.6), lineWidth: 2)
+                    .frame(width: scaledFrame.width, height: scaledFrame.height)
+                    .position(x: scaledFrame.midX, y: scaledFrame.midY)
+
+                // Lock icon badge at top-right corner
+                let badgeSize: CGFloat = max(min(scaledFrame.width, scaledFrame.height) * 0.35, 16)
+                ZStack {
+                    Circle()
+                        .fill(Color.orange.opacity(0.85))
+                        .frame(width: badgeSize, height: badgeSize)
+
+                    Image(systemName: "lock.fill")
+                        .font(.system(size: badgeSize * 0.5, weight: .bold))
+                        .foregroundColor(.white)
+                }
+                .position(
+                    x: scaledFrame.maxX - badgeSize * 0.3,
+                    y: scaledFrame.minY + badgeSize * 0.3
+                )
+            }
+        }
+    }
+}

--- a/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/DeltaSkinView.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/DeltaSkinView.swift
@@ -77,6 +77,9 @@ public struct DeltaSkinView: View {
     @State private var lastButtonPressed: String?
     @State private var isButtonHapticEnabled = true  // Add this state
 
+    /// Buttons currently in "sticky" (toggle-held) mode — mirrors the sticky manager for SwiftUI updates.
+    @State private var stickyButtonIds: Set<String> = []
+
     /// State for skin loading
     @State private var skinImage: UIImage?
     @State private var thumbstickImage: UIImage?
@@ -676,6 +679,22 @@ public struct DeltaSkinView: View {
                                     .zIndex(6)
                                     .allowsHitTesting(false)
                                 }
+                            }
+                        }
+
+                        // Sticky button indicators
+                        if !stickyButtonIds.isEmpty,
+                           let buttons = skin.buttons(for: traits),
+                           let mappingSize = skin.mappingSize(for: traits) {
+                            ForEach(buttons.filter { stickyButtonIds.contains($0.id) }, id: \.id) { button in
+                                DeltaSkinStickyIndicator(
+                                    frame: button.frame,
+                                    mappingSize: mappingSize
+                                )
+                                .zIndex(3.5)
+                                .allowsHitTesting(false)
+                                .transition(.opacity)
+                                .animation(.easeInOut(duration: 0.2), value: stickyButtonIds)
                             }
                         }
 
@@ -2177,6 +2196,26 @@ public struct DeltaSkinView: View {
 
     private func handleButtonPress(_ buttonId: String) {
         DLOG("🔴 handleButtonPress called with buttonId: \(buttonId)")
+
+        // --- Sticky button logic ---
+        #if canImport(UIKit)
+        if Defaults[.stickyButtonsEnabled] {
+            let action = inputHandler.stickyManager.handlePress(buttonId)
+            stickyButtonIds = inputHandler.stickyManager.stickyButtons
+            switch action {
+            case .press:
+                break // continue with normal press below
+            case .release:
+                // Double-tap on a sticky button: release it
+                pressedButtons.remove(buttonId)
+                inputHandler.buttonReleased(buttonId)
+                return
+            case .ignore:
+                return
+            }
+        }
+        #endif
+
         // Safety check for duplicate press events
         if pressedButtons.contains(buttonId) {
             DLOG("⚠️ Button \(buttonId) already pressed, skipping press event")
@@ -2212,6 +2251,18 @@ public struct DeltaSkinView: View {
 
     private func handleButtonRelease(_ buttonId: String) {
         DLOG("🔵 handleButtonRelease called with buttonId: \(buttonId)")
+
+        // --- Sticky button logic ---
+        #if canImport(UIKit)
+        if Defaults[.stickyButtonsEnabled] {
+            let action = inputHandler.stickyManager.handleRelease(buttonId)
+            if action == .ignore {
+                DLOG("Sticky: suppressing release for \(buttonId)")
+                return
+            }
+        }
+        #endif
+
         // Safety check to prevent releasing buttons that weren't pressed
         if !pressedButtons.contains(buttonId) {
             DLOG("⚠️ Button \(buttonId) not pressed, skipping release event")
@@ -2401,6 +2452,16 @@ public struct DeltaSkinView: View {
     /// Release all pressed buttons
     private func releaseAllButtons() {
         DLOG("Releasing all pressed buttons in DeltaSkinView: \(pressedButtons)")
+
+        // Release any sticky buttons first so their releases are not suppressed
+        let releasedSticky = inputHandler.stickyManager.releaseAll()
+        stickyButtonIds.removeAll()
+        for buttonId in releasedSticky {
+            if !pressedButtons.contains(buttonId) {
+                // Sticky button that was not physically pressed — send release to core
+                inputHandler.buttonReleased(buttonId)
+            }
+        }
 
         // Ensure all D-pad buttons are released
         for direction in ["up", "down", "left", "right", "upleft", "upright", "downleft", "downright"] {


### PR DESCRIPTION
## Summary
- Adds "sticky buttons" feature: double-tap any on-screen button to lock it held down; double-tap again to release. Useful for auto-run in platformers and similar hold-to-act scenarios.
- New `StickyButtonManager` class tracks per-button toggle state with double-tap detection (0.35s window).
- Visual indicator: orange highlight + lock icon badge on sticky-active buttons.
- Global toggle in Settings > On-Screen Controller ("Sticky Buttons"), disabled by default.
- All sticky buttons are released automatically when the emulator pauses or exits.

Closes #2035

## Test plan
- [ ] Enable "Sticky Buttons" in Settings > On-Screen Controller
- [ ] Launch a game with on-screen controls (e.g. SNES platformer)
- [ ] Double-tap the "right" D-pad or a face button -- verify it stays held (orange lock icon appears)
- [ ] Double-tap the same button again -- verify it releases (lock icon disappears)
- [ ] Pause the game via menu -- verify all sticky buttons are released
- [ ] Disable "Sticky Buttons" in settings -- verify double-tap no longer toggles sticky mode
- [ ] Verify normal single-tap press/release behavior is unaffected when the setting is off

🤖 Generated with [Claude Code](https://claude.com/claude-code)