### PR TITLE
[Agent] feat(CI): alpha build pipeline with separate bundle ID and sideload feed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,6 +114,24 @@ jobs:
           echo "BUILD_NUMBER=${BUILD_NUMBER}" >> $GITHUB_ENV
           echo "MARKETING_VERSION=$(grep 'MARKETING_VERSION' Build.xcconfig | cut -d'=' -f2 | xargs)" >> $GITHUB_ENV
 
+      - name: Set Alpha Build Overrides
+        if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+        run: |
+          SHORT_SHA="${GITHUB_SHA:0:7}"
+          ALPHA_DATE=$(date -u +"%Y%m%d")
+          echo "IS_ALPHA=true" >> $GITHUB_ENV
+          echo "ALPHA_BUNDLE_SUFFIX=.alpha" >> $GITHUB_ENV
+          echo "ALPHA_DISPLAY_NAME_SUFFIX= Alpha" >> $GITHUB_ENV
+          echo "ALPHA_VERSION_SUFFIX=-alpha.${ALPHA_DATE}.${SHORT_SHA}" >> $GITHUB_ENV
+
+      - name: Set Stable Build Overrides
+        if: github.event_name != 'push' || github.ref != 'refs/heads/develop'
+        run: |
+          echo "IS_ALPHA=false" >> $GITHUB_ENV
+          echo "ALPHA_BUNDLE_SUFFIX=" >> $GITHUB_ENV
+          echo "ALPHA_DISPLAY_NAME_SUFFIX=" >> $GITHUB_ENV
+          echo "ALPHA_VERSION_SUFFIX=" >> $GITHUB_ENV
+
       - uses: actions/cache@v3
         with:
           path: |
@@ -134,12 +152,32 @@ jobs:
           rm -rf ./build
           mkdir -p ./build
 
+      - name: Patch Info.plist for Alpha (bundle ID + display name)
+        if: env.IS_ALPHA == 'true'
+        run: |
+          echo "Patching for alpha build: bundle suffix='${ALPHA_BUNDLE_SUFFIX}', display name suffix='${ALPHA_DISPLAY_NAME_SUFFIX}'"
+          # Patch all Info.plist files to add alpha display name
+          for plist in Provenance/Info.plist ProvenanceTV/Info.plist; do
+            if [ -f "$plist" ]; then
+              # Add CFBundleDisplayName if not present, or it will come from build settings
+              /usr/libexec/PlistBuddy -c "Add :CFBundleDisplayName string 'Provenance Alpha'" "$plist" 2>/dev/null || \
+              /usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName 'Provenance Alpha'" "$plist" 2>/dev/null || true
+            fi
+          done
+
       - name: Build Provenance
         id: build
         env:
           MARKETING_VERSION: ${{ env.MARKETING_VERSION }}
           BUILD_NUMBER: ${{ env.BUILD_NUMBER }}
         run: |
+          # For alpha builds, override bundle identifier to allow side-by-side install
+          EXTRA_BUILD_SETTINGS=""
+          if [ "$IS_ALPHA" = "true" ]; then
+            EXTRA_BUILD_SETTINGS="PRODUCT_BUNDLE_IDENTIFIER=org.provenance-emu.provenance${ALPHA_BUNDLE_SUFFIX}"
+            echo "Alpha build: overriding bundle ID to org.provenance-emu.provenance${ALPHA_BUNDLE_SUFFIX}"
+          fi
+
           start_time=$(date +%s)
           xcodebuild -configuration Release \
           -workspace Provenance.xcworkspace \
@@ -157,6 +195,7 @@ jobs:
           SWIFT_PACKAGE_ALLOW_WRITING_TO_DIRECTORY=${{ env.SWIFT_PACKAGE_ALLOW_WRITING_TO_DIRECTORY }} \
           DEVELOPMENT_TEAM=S32Z3HMYVQ \
           ORG_IDENTIFIER=org.provenance-emu \
+          $EXTRA_BUILD_SETTINGS \
           | xcbeautify
           end_time=$(date +%s)
           echo "duration=$((end_time - start_time))" >> $GITHUB_OUTPUT
@@ -253,11 +292,92 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      issues: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts
+
+      - name: Build Release Notes
+        id: release_notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          SHA="${{ github.sha }}"
+          SHORT_SHA="${SHA:0:7}"
+          DATE=$(date -u +"%Y-%m-%d %H:%M UTC")
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          # Get the previous alpha tag SHA (if it exists)
+          PREV_SHA=$(gh api "repos/${REPO}/git/refs/tags/alpha" --jq '.object.sha' 2>/dev/null || echo "")
+
+          # Build commit log since last alpha
+          COMMIT_LOG=""
+          if [ -n "$PREV_SHA" ] && [ "$PREV_SHA" != "$SHA" ]; then
+            COMMIT_LOG=$(git log --oneline --no-merges "${PREV_SHA}..${SHA}" 2>/dev/null | head -30 || echo "")
+          fi
+          if [ -z "$COMMIT_LOG" ]; then
+            COMMIT_LOG=$(git log --oneline --no-merges -10 2>/dev/null || echo "No commit history available")
+          fi
+
+          # Get merged PRs since last alpha
+          MERGED_PRS=""
+          if [ -n "$PREV_SHA" ]; then
+            # Extract PR numbers from merge commits
+            PR_NUMBERS=$(git log --oneline "${PREV_SHA}..${SHA}" 2>/dev/null | grep -oP '#\d+' | sort -u | head -15 || echo "")
+            for pr in $PR_NUMBERS; do
+              PR_NUM="${pr#\#}"
+              PR_TITLE=$(gh pr view "$PR_NUM" --repo "$REPO" --json title --jq '.title' 2>/dev/null || echo "")
+              if [ -n "$PR_TITLE" ]; then
+                MERGED_PRS="${MERGED_PRS}- ${pr}: ${PR_TITLE}"$'\n'
+              fi
+            done
+          fi
+
+          # Write release notes to file (avoids quoting issues)
+          cat > /tmp/release_notes.md << NOTESEOF
+          ## Alpha Build \`${SHORT_SHA}\`
+
+          **Automated alpha build from \`develop\` branch**
+
+          | | |
+          |---|---|
+          | **Commit** | [\`${SHORT_SHA}\`](https://github.com/${REPO}/commit/${SHA}) |
+          | **Built** | ${DATE} |
+          | **CI Run** | [View build log](${RUN_URL}) |
+          | **Bundle ID** | \`com.provenance-emu.provenance.alpha\` |
+
+          > **Note:** This alpha build uses a separate bundle ID so it can be installed alongside the stable release.
+
+          ### Commits since last alpha
+          \`\`\`
+          ${COMMIT_LOG}
+          \`\`\`
+          NOTESEOF
+
+          if [ -n "$MERGED_PRS" ]; then
+            cat >> /tmp/release_notes.md << PREOF
+
+          ### Merged PRs
+          ${MERGED_PRS}
+          PREOF
+          fi
+
+          cat >> /tmp/release_notes.md << FOOTEREOF
+
+          ---
+          These builds are unsigned and intended for sideloading via AltStore/SideStore.
+          Install the **Provenance Alpha** app (separate from stable) using the [sideload feed](https://provenance-emu.github.io/Provenance/altstore-source.json).
+
+          > This release is automatically updated on every successful develop push.
+          FOOTEREOF
 
       - name: Update alpha release
         env:
@@ -267,7 +387,6 @@ jobs:
           REPO="${{ github.repository }}"
           SHA="${{ github.sha }}"
           SHORT_SHA="${SHA:0:7}"
-          DATE=$(date -u +"%Y-%m-%d %H:%M UTC")
 
           # Create or update the alpha tag
           gh api repos/$REPO/git/refs/tags/$TAG \
@@ -284,19 +403,106 @@ jobs:
           # Create new pre-release with IPAs
           gh release create $TAG \
             --repo $REPO \
-            --title "Alpha Build ($SHORT_SHA)" \
-            --notes "$(cat <<EOF
-          **Automated alpha build from \`develop\` branch**
-
-          - Commit: $SHA
-          - Built: $DATE
-          - These builds are unsigned and intended for sideloading via AltStore/SideStore
-
-          > This release is automatically updated on every successful develop push.
-          EOF
-          )" \
+            --title "Provenance Alpha ($SHORT_SHA)" \
+            --notes-file /tmp/release_notes.md \
             --prerelease \
             *.ipa 2>/dev/null || echo "::warning::No IPA files to attach"
+
+      - name: Update Build Status Issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          SHORT_SHA="${{ github.sha }}"
+          SHORT_SHA="${SHORT_SHA:0:7}"
+          DATE=$(date -u +"%Y-%m-%d %H:%M UTC")
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          # Update issue #3163 with latest build status
+          ISSUE_BODY=$(cat << 'ISSUEEOF'
+          # Alpha & Beta Builds -- Download & Install Guide
+
+          ## Latest Alpha Build
+
+          | | |
+          |---|---|
+          ISSUEEOF
+          )
+
+          ISSUE_BODY="${ISSUE_BODY}
+          | **Status** | :white_check_mark: Build Passing |
+          | **Commit** | [\`${SHORT_SHA}\`](https://github.com/${REPO}/commit/${{ github.sha }}) |
+          | **Built** | ${DATE} |
+          | **CI Run** | [View build log](${RUN_URL}) |
+          | **Download** | [GitHub Release](https://github.com/${REPO}/releases/tag/alpha) |
+          | **Bundle ID** | \`com.provenance-emu.provenance.alpha\` |"
+
+          ISSUE_BODY="${ISSUE_BODY}
+
+          ---
+
+          ## Install via AltStore
+
+          1. Open AltStore on your device
+          2. Go to **Sources** (or **Browse** > **Sources**)
+          3. Tap **Add Source** and enter:
+             \`\`\`
+             https://provenance-emu.github.io/Provenance/altstore-source.json
+             \`\`\`
+          4. You will see **two** apps: **Provenance** (stable) and **Provenance Alpha** (latest dev builds)
+          5. Install either or both -- they use separate bundle IDs so both can be installed simultaneously
+
+          ## Install via SideStore
+
+          1. Open SideStore on your device
+          2. Go to **Sources**
+          3. Add the following source URL:
+             \`\`\`
+             https://provenance-emu.github.io/Provenance/sidestore-source.json
+             \`\`\`
+          4. Browse the source and install **Provenance** or **Provenance Alpha**
+
+          ## Direct IPA Download from GitHub Releases
+
+          - **Latest stable release:** [Releases page](https://github.com/${REPO}/releases/latest)
+          - **Latest alpha build:** [Alpha release](https://github.com/${REPO}/releases/tag/alpha)
+
+          ---
+
+          ## FAQ
+
+          ### What is the difference between stable and alpha builds?
+
+          | | Stable | Alpha |
+          |---|---|---|
+          | **Source** | Tagged releases on \`master\` | Automatic builds from \`develop\` branch |
+          | **Bundle ID** | \`com.provenance-emu.provenance\` | \`com.provenance-emu.provenance.alpha\` |
+          | **App Name** | Provenance | Provenance Alpha |
+          | **Side-by-side** | N/A | Yes -- install both at once |
+          | **Reliability** | Tested and ready for daily use | May contain bugs or incomplete features |
+          | **Updates** | Released periodically | Built on every successful \`develop\` CI run |
+
+          ### Can I install both stable and alpha at the same time?
+
+          **Yes!** Alpha builds use a different bundle ID (\`com.provenance-emu.provenance.alpha\`) so they install as a separate app called **Provenance Alpha**. Your stable install is not affected.
+
+          ### Are alpha builds safe to use?
+
+          Alpha builds pass all CI checks before being published, but they have not gone through the full QA process of a stable release. **Back up your save data** before switching to an alpha build.
+
+          ### How do I report bugs in alpha builds?
+
+          Please [open an issue](https://github.com/${REPO}/issues/new) and include:
+          - The build version (visible in Settings > About)
+          - Steps to reproduce
+          - Device model and iOS/tvOS version
+
+          ---
+
+          > **Note:** This issue is auto-updated by CI on every successful alpha build. Do not edit manually."
+
+          gh issue edit 3163 --repo "$REPO" --body "$ISSUE_BODY" 2>/dev/null || \
+            echo "::warning::Could not update issue #3163"
 
   # Post artifact download links to PR for workflow_dispatch builds (label / /build triggered)
   post-to-pr:

--- a/.github/workflows/sideload-feed.yml
+++ b/.github/workflows/sideload-feed.yml
@@ -1,15 +1,17 @@
 name: Update Sideload Feed
 
 # Regenerates AltStore + SideStore JSON source files and commits them
-# to the gh-pages branch whenever a release or alpha build is published.
+# to the docs/ folder whenever a release or alpha build is published.
 #
 # The JSON files are hosted at:
 #   https://provenance-emu.github.io/Provenance/altstore-source.json
 #   https://provenance-emu.github.io/Provenance/sidestore-source.json
-# (or via raw GitHub if gh-pages isn't configured — see below)
 #
-# IPAs are attached as GitHub Release assets — no login required to download.
-# AltStore/SideStore can fetch them directly with curl.
+# Stable releases appear as "Provenance" (com.provenance-emu.provenance).
+# Alpha builds appear as "Provenance Alpha" (com.provenance-emu.provenance.alpha)
+# — a SEPARATE app entry so AltStore/SideStore shows them as two distinct apps.
+#
+# Only the latest 3 alpha versions are kept in the feed.
 
 on:
   release:
@@ -49,25 +51,29 @@ jobs:
           RAW_BASE="https://github.com/${REPO}/releases/download"
 
           # ── Fetch all non-draft releases (stable + pre-release) ───────────
-          ALL_RELEASES=$(gh api "repos/${REPO}/releases?per_page=20" \
+          ALL_RELEASES=$(gh api "repos/${REPO}/releases?per_page=50" \
             --jq '[.[] | select(.draft == false)]' 2>/dev/null || echo "[]")
 
           STABLE_RELEASES=$(echo "$ALL_RELEASES" | \
             jq '[.[] | select(.prerelease == false and (.tag_name | test("^[0-9]+\\.[0-9]+\\.[0-9]+$")))]')
 
-          ALPHA_RELEASE=$(echo "$ALL_RELEASES" | \
-            jq 'map(select(.tag_name == "alpha")) | first // empty')
+          # Get all alpha-tagged releases (there is usually only one rolling release,
+          # but we also look for any with alpha in the tag for historical ones)
+          ALPHA_RELEASES=$(echo "$ALL_RELEASES" | \
+            jq '[.[] | select(.tag_name == "alpha" or (.tag_name | test("^alpha-")))]')
 
-          # ── Helper: build an app entry from a release ─────────────────────
-          build_app_entry() {
+          # ── Helper: extract version entries from a release ──────────────
+          # Returns a JSON array of AltStore version objects
+          build_version_entries() {
             local release_json="$1"
             local channel="$2"  # "stable" or "alpha"
 
             TAG=$(echo "$release_json" | jq -r '.tag_name')
-            NAME=$(echo "$release_json" | jq -r '.name // .tag_name')
             BODY=$(echo "$release_json" | jq -r '.body // ""')
             DATE=$(echo "$release_json" | jq -r '.published_at // .created_at')
             DATE_SHORT=$(echo "$DATE" | cut -c1-10)
+            SHA=$(echo "$release_json" | jq -r '.target_commitish // ""')
+            SHORT_SHA="${SHA:0:7}"
 
             # Find iOS and tvOS IPAs in release assets
             IOS_URL=$(echo "$release_json" | \
@@ -80,9 +86,11 @@ jobs:
             # Truncate changelog for JSON (AltStore has a 3000-char limit)
             CHANGELOG=$(echo "$BODY" | sed 's/\r//g' | head -c 2800 || echo "")
 
-            # Version for display (strip 'alpha' prefix if present)
+            # Version string
             if [ "$channel" = "alpha" ]; then
-              DISPLAY_VERSION="alpha-$(echo "$TAG" | cut -c1-7 2>/dev/null || echo "$TAG")"
+              # Use date + short SHA for alpha versioning: e.g. "3.3.1-alpha.20260315.abc1234"
+              MARKETING_VER=$(grep 'MARKETING_VERSION' Build.xcconfig 2>/dev/null | cut -d'=' -f2 | xargs || echo "0.0.0")
+              DISPLAY_VERSION="${MARKETING_VER}-alpha.${DATE_SHORT//-/}.${SHORT_SHA}"
               BUILD=$(date +%Y%m%d)
             else
               DISPLAY_VERSION="$TAG"
@@ -102,7 +110,6 @@ jobs:
                 --arg url "$IOS_URL" \
                 --arg size "$SIZE" \
                 --arg changelog "$CHANGELOG" \
-                --arg platform "iOS" \
                 '{
                   version: $version,
                   date: $date,
@@ -136,80 +143,113 @@ jobs:
             echo "$ENTRIES"
           }
 
-          # ── Build versions array from stable releases ─────────────────────
-          VERSIONS_JSON="[]"
-
+          # ── Build STABLE versions array ─────────────────────────────────
+          STABLE_VERSIONS="[]"
           while IFS= read -r release; do
-            ENTRY=$(build_app_entry "$release" "stable")
+            [ -z "$release" ] && continue
+            ENTRY=$(build_version_entries "$release" "stable")
             if [ "$ENTRY" != "[]" ]; then
-              VERSIONS_JSON=$(echo "$VERSIONS_JSON" | jq ". + $ENTRY")
+              STABLE_VERSIONS=$(echo "$STABLE_VERSIONS" | jq ". + $ENTRY")
             fi
           done < <(echo "$STABLE_RELEASES" | jq -c '.[]')
 
-          # Add alpha if available
-          if [ -n "$ALPHA_RELEASE" ] && [ "$ALPHA_RELEASE" != "null" ]; then
-            ALPHA_ENTRY=$(build_app_entry "$ALPHA_RELEASE" "alpha")
-            if [ "$ALPHA_ENTRY" != "[]" ]; then
-              VERSIONS_JSON=$(echo "$VERSIONS_JSON" | jq ". + $ALPHA_ENTRY")
+          # ── Build ALPHA versions array (limit to latest 3) ──────────────
+          ALPHA_VERSIONS="[]"
+          ALPHA_COUNT=0
+          while IFS= read -r release; do
+            [ -z "$release" ] && continue
+            [ "$ALPHA_COUNT" -ge 3 ] && break
+            ENTRY=$(build_version_entries "$release" "alpha")
+            if [ "$ENTRY" != "[]" ]; then
+              ALPHA_VERSIONS=$(echo "$ALPHA_VERSIONS" | jq ". + $ENTRY")
+              ALPHA_COUNT=$((ALPHA_COUNT + 1))
             fi
-          fi
+          done < <(echo "$ALPHA_RELEASES" | jq -c '.[]')
 
-          LATEST_VERSION=$(echo "$STABLE_RELEASES" | jq -r 'first.tag_name // "3.3.0"')
+          LATEST_STABLE_VERSION=$(echo "$STABLE_RELEASES" | jq -r 'first.tag_name // "3.3.0"')
           TODAY=$(date -u +"%Y-%m-%d")
 
-          # ── AltStore source JSON ──────────────────────────────────────────
-          cat > /tmp/altstore-source.json << JSONEOF
-          {
-            "name": "Provenance Emulator",
-            "identifier": "com.provenance-emu.provenance.altstore",
-            "sourceURL": "https://provenance-emu.github.io/Provenance/altstore-source.json",
-            "apps": [
-              {
-                "name": "Provenance",
-                "bundleIdentifier": "com.provenance-emu.provenance",
-                "developerName": "Provenance-EMU",
-                "subtitle": "Multi-system retro emulator for iOS & tvOS",
-                "localizedDescription": "Provenance supports 60+ retro gaming systems including NES, SNES, N64, Genesis, PlayStation, GBA, and many more. Features iCloud sync, controller skins, RetroAchievements, and a beautiful native UI.",
-                "iconURL": "https://raw.githubusercontent.com/Provenance-Emu/Provenance/develop/Provenance/Assets.xcassets/AppIcon.appiconset/appicon-1024.png",
-                "tintColor": "8A2BE2",
-                "screenshotURLs": [],
-                "versions": $VERSIONS_JSON,
-                "appPermissions": {
-                  "entitlements": [
-                    { "name": "com.apple.security.application-groups" },
-                    { "name": "com.apple.developer.icloud-services" },
-                    { "name": "com.apple.developer.icloud-container-identifiers" }
-                  ],
-                  "privacy": [
-                    { "name": "LocalNetwork", "usageDescription": "Used to discover and connect to local network game servers for netplay." },
-                    { "name": "Camera", "usageDescription": "Used to scan QR codes for importing game data." }
-                  ]
+          # ── AltStore source JSON ────────────────────────────────────────
+          # Two separate app entries: stable and alpha
+          jq -n \
+            --arg today "$TODAY" \
+            --argjson stable_versions "$STABLE_VERSIONS" \
+            --argjson alpha_versions "$ALPHA_VERSIONS" \
+            '{
+              name: "Provenance Emulator",
+              identifier: "com.provenance-emu.provenance.altstore",
+              sourceURL: "https://provenance-emu.github.io/Provenance/altstore-source.json",
+              apps: [
+                {
+                  name: "Provenance",
+                  bundleIdentifier: "com.provenance-emu.provenance",
+                  developerName: "Provenance-EMU",
+                  subtitle: "Multi-system retro emulator for iOS & tvOS",
+                  localizedDescription: "Provenance supports 60+ retro gaming systems including NES, SNES, N64, Genesis, PlayStation, GBA, and many more. Features iCloud sync, controller skins, RetroAchievements, and a beautiful native UI.",
+                  iconURL: "https://raw.githubusercontent.com/Provenance-Emu/Provenance/develop/Provenance/Assets.xcassets/AppIcon.appiconset/appicon-1024.png",
+                  tintColor: "8A2BE2",
+                  screenshotURLs: [],
+                  versions: $stable_versions,
+                  appPermissions: {
+                    entitlements: [
+                      { name: "com.apple.security.application-groups" },
+                      { name: "com.apple.developer.icloud-services" },
+                      { name: "com.apple.developer.icloud-container-identifiers" }
+                    ],
+                    privacy: [
+                      { name: "LocalNetwork", usageDescription: "Used to discover and connect to local network game servers for netplay." },
+                      { name: "Camera", usageDescription: "Used to scan QR codes for importing game data." }
+                    ]
+                  }
+                },
+                {
+                  name: "Provenance Alpha",
+                  bundleIdentifier: "com.provenance-emu.provenance.alpha",
+                  developerName: "Provenance-EMU",
+                  subtitle: "Latest dev builds - test new features early",
+                  localizedDescription: "Alpha builds of Provenance from the develop branch. These builds include the latest features and fixes but may contain bugs. Install alongside the stable version to test new features without losing your stable install.\n\nSupports 60+ retro gaming systems including NES, SNES, N64, Genesis, PlayStation, GBA, and many more.",
+                  iconURL: "https://raw.githubusercontent.com/Provenance-Emu/Provenance/develop/Provenance/Assets.xcassets/AppIcon.appiconset/appicon-1024.png",
+                  tintColor: "FF6B35",
+                  screenshotURLs: [],
+                  versions: $alpha_versions,
+                  appPermissions: {
+                    entitlements: [
+                      { name: "com.apple.security.application-groups" },
+                      { name: "com.apple.developer.icloud-services" },
+                      { name: "com.apple.developer.icloud-container-identifiers" }
+                    ],
+                    privacy: [
+                      { name: "LocalNetwork", usageDescription: "Used to discover and connect to local network game servers for netplay." },
+                      { name: "Camera", usageDescription: "Used to scan QR codes for importing game data." }
+                    ]
+                  }
                 }
-              }
-            ],
-            "news": []
-          }
-          JSONEOF
+              ],
+              news: []
+            }' > /tmp/altstore-source.json
 
-          # Substitute the versions array
-          jq --argjson versions "$VERSIONS_JSON" '.apps[0].versions = $versions' \
-            /tmp/altstore-source.json > /tmp/altstore-source-final.json
-
-          # ── SideStore source JSON (same schema, different sourceURL) ───────
+          # ── SideStore source JSON (same schema, different sourceURL) ────
           jq '.identifier = "com.provenance-emu.provenance.sidestore" |
               .sourceURL = "https://provenance-emu.github.io/Provenance/sidestore-source.json"' \
-            /tmp/altstore-source-final.json > /tmp/sidestore-source-final.json
+            /tmp/altstore-source.json > /tmp/sidestore-source.json
 
-          echo "Generated feed with $(echo "$VERSIONS_JSON" | jq 'length') version entries."
-          echo "versions_count=$(echo "$VERSIONS_JSON" | jq 'length')" >> "$GITHUB_OUTPUT"
+          # Validate JSON
+          jq empty /tmp/altstore-source.json && echo "altstore-source.json is valid JSON"
+          jq empty /tmp/sidestore-source.json && echo "sidestore-source.json is valid JSON"
+
+          STABLE_COUNT=$(echo "$STABLE_VERSIONS" | jq 'length')
+          ALPHA_COUNT=$(echo "$ALPHA_VERSIONS" | jq 'length')
+          echo "Generated feed: ${STABLE_COUNT} stable entries, ${ALPHA_COUNT} alpha entries (max 3)."
+          echo "stable_count=${STABLE_COUNT}" >> "$GITHUB_OUTPUT"
+          echo "alpha_count=${ALPHA_COUNT}" >> "$GITHUB_OUTPUT"
 
       - name: Commit feed to docs/ folder
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           mkdir -p docs
-          cp /tmp/altstore-source-final.json docs/altstore-source.json
-          cp /tmp/sidestore-source-final.json docs/sidestore-source.json
+          cp /tmp/altstore-source.json docs/altstore-source.json
+          cp /tmp/sidestore-source.json docs/sidestore-source.json
 
           # Also write a simple index pointing to the feeds
           cat > docs/sideload.md << 'MDEOF'
@@ -224,8 +264,18 @@ jobs:
 
           IPAs are hosted as GitHub Release assets and are publicly downloadable without a GitHub account.
 
-          > **Alpha / Develop builds** are included in the feed under the `alpha` channel.
-          > These are built from the `develop` branch on every successful CI run.
+          ## Two apps in the feed
+
+          The feed contains **two separate apps**:
+
+          | App | Bundle ID | Description |
+          |-----|-----------|-------------|
+          | **Provenance** | `com.provenance-emu.provenance` | Stable releases from tagged versions |
+          | **Provenance Alpha** | `com.provenance-emu.provenance.alpha` | Latest dev builds from `develop` branch |
+
+          Both can be installed simultaneously on the same device since they use different bundle identifiers.
+
+          > Only the latest 3 alpha builds are kept in the feed to avoid clutter.
           MDEOF
 
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
## Summary
- Alpha builds from `develop` now use a **separate bundle ID** (`com.provenance-emu.provenance.alpha`) and display name ("Provenance Alpha") so users can install both stable and alpha side-by-side
- **Sideload feed** (AltStore/SideStore JSON) updated to list stable and alpha as **two distinct app entries** with different `bundleIdentifier` values
- Alpha feed capped at **latest 3 versions** to reduce clutter; versions use `3.3.1-alpha.YYYYMMDD.SHA` format
- **Alpha release notes** now include commit log since last alpha, merged PRs, and CI run link
- **Issue #3163** auto-updates with latest alpha build status table on each successful develop push

## Changes

### `.github/workflows/build.yml`
- Added "Set Alpha Build Overrides" / "Set Stable Build Overrides" steps that set `IS_ALPHA`, `ALPHA_BUNDLE_SUFFIX`, etc. as env vars
- Added "Patch Info.plist for Alpha" step that injects `CFBundleDisplayName = Provenance Alpha` via PlistBuddy
- Build step now conditionally passes `PRODUCT_BUNDLE_IDENTIFIER=org.provenance-emu.provenance.alpha` to xcodebuild
- Alpha-release job now checks out repo with full history, builds rich release notes (commit log + merged PRs + CI link), and updates issue #3163 body
- Added `issues: write` permission to alpha-release job

### `.github/workflows/sideload-feed.yml`
- Rewrote feed generation to produce **two app entries** in the JSON: "Provenance" (stable, purple tint) and "Provenance Alpha" (alpha, orange tint)
- Alpha versions limited to latest 3 entries
- Alpha version strings use `MARKETING_VERSION-alpha.DATE.SHA` format
- Added JSON validation step (`jq empty`)
- Updated `docs/sideload.md` to document the two-app setup

## Test plan
- [ ] Verify the YAML is valid (no syntax errors) by checking the Actions tab after merge
- [ ] Trigger a manual workflow_dispatch on develop to test alpha build flow
- [ ] Confirm the sideload feed JSON validates with `jq empty`
- [ ] Verify AltStore/SideStore shows two separate app entries after feed regenerates
- [ ] Confirm alpha IPA has bundle ID `com.provenance-emu.provenance.alpha` in its Info.plist
- [ ] Confirm issue #3163 body updates after a successful alpha build

🤖 Generated with [Claude Code](https://claude.com/claude-code)