### PR TITLE
[Agent] fix(doom): route PrBoom through Doom bridge, add strafe button (#3179)

### DIFF
--- a/CoresRetro/RetroArch/PVRetroArchCore/Core/PVRetroArchCore+Controls+DOS.m
+++ b/CoresRetro/RetroArch/PVRetroArchCore/Core/PVRetroArchCore+Controls+DOS.m
@@ -411,6 +411,10 @@ static void st_ra_update_mouse_rel(CGPoint point) {
             // so the automap button doesn't accidentally open the RetroArch menu.
             [touch_controller.extendedGamepad.buttonOptions setValue:v];
             break;
+        case PVDoomButtonStrafe:
+            // PrBoom Gamepad Classic: JOYPAD_X → Strafe (toggle) — buttonY (north)
+            [touch_controller.extendedGamepad.buttonY setValue:v];
+            break;
         case PVDoomButtonPause:
             // JOYPAD_START → buttonMenu
             [touch_controller.extendedGamepad.buttonMenu setValue:v];

--- a/CoresRetro/RetroArch/PVRetroArchCore/Swift/PVRetroArchCoreCore.swift
+++ b/CoresRetro/RetroArch/PVRetroArchCore/Swift/PVRetroArchCoreCore.swift
@@ -505,15 +505,15 @@ extension PVRetroArchCoreCore: PVSupervisionSystemResponderClient {
 }
 
 // MARK: Doom (PrBoom)
-// PVDoomSystemResponderClient maps Doom-specific button events through the DOS bridge.
-// This conformance allows PVDoomControllerViewController to be routed correctly via
-// PVCoreFactory for the .DOOM system identifier.
+// PVDoomSystemResponderClient forwards directly to the ObjC Doom bridge
+// (PVRetroArchCoreBridge (DoomControls)) which has correct PrBoom button mappings.
+// Previously this converted through asDOSButton → DOS bridge, causing wrong mappings.
 extension PVRetroArchCoreCore: PVDoomSystemResponderClient {
     public func didPush(_ button: PVCoreBridge.PVDoomButton, forPlayer player: Int) {
-        (_bridge as? PVDOSSystemResponderClient)?.didPush(button.asDOSButton, forPlayer: player)
+        (_bridge as? PVDoomSystemResponderClient)?.didPush(button, forPlayer: player)
     }
     public func didRelease(_ button: PVCoreBridge.PVDoomButton, forPlayer player: Int) {
-        (_bridge as? PVDOSSystemResponderClient)?.didRelease(button.asDOSButton, forPlayer: player)
+        (_bridge as? PVDoomSystemResponderClient)?.didRelease(button, forPlayer: player)
     }
 }
 

--- a/PVCoreBridge/Sources/PVCoreBridge/Features/Controls/PVDoomButton.swift
+++ b/PVCoreBridge/Sources/PVCoreBridge/Features/Controls/PVDoomButton.swift
@@ -41,6 +41,8 @@
     case weaponNext
     /// Automap / Map — JOYPAD_SELECT → buttonOptions
     case map
+    /// Strafe (toggle) — JOYPAD_X → north/buttonY
+    case strafe
     /// Pause / Menu — JOYPAD_START → buttonMenu
     case pause
     case count
@@ -58,7 +60,8 @@
         case "straferight", "sr", "r", "r1": self = .strafeRight
         case "weaponprev", "wp", "prevweapon", "l2", "prev": self = .weaponPrev
         case "weaponnext", "wn", "nextweapon", "r2", "next": self = .weaponNext
-        case "map", "automap", "select", "x": self = .map
+        case "map", "automap", "select": self = .map
+        case "strafe", "x": self = .strafe
         case "pause", "start", "menu": self = .pause
         case "count": self = .count
         default: self = .up
@@ -79,6 +82,7 @@
         case .weaponPrev: return "weaponprev"
         case .weaponNext: return "weaponnext"
         case .map: return "map"
+        case .strafe: return "strafe"
         case .pause: return "pause"
         case .count: return "count"
         }
@@ -101,6 +105,7 @@ extension PVDoomButton {
         case .weaponPrev: return .weaponPrev
         case .weaponNext: return .weaponNext
         case .map:        return .select
+        case .strafe:     return .run  // approximate; DOS has no strafe toggle
         case .pause:      return .pause
         case .count:      return .count
         }

--- a/PVCoreBridge/Sources/PVCoreBridge/Features/Controls/PVDoomButton.swift
+++ b/PVCoreBridge/Sources/PVCoreBridge/Features/Controls/PVDoomButton.swift
@@ -91,6 +91,7 @@
 
 extension PVDoomButton {
     /// Maps a Doom button to its equivalent PVDOSButton for forwarding through the DOS bridge.
+    /// Note: Doom now uses direct bridge routing, so this mapping is only a legacy fallback.
     public var asDOSButton: PVDOSButton {
         switch self {
         case .up:         return .up
@@ -105,7 +106,7 @@ extension PVDoomButton {
         case .weaponPrev: return .weaponPrev
         case .weaponNext: return .weaponNext
         case .map:        return .select
-        case .strafe:     return .run  // approximate; DOS has no strafe toggle
+        case .strafe:     return .fire1  // No DOS equivalent; Doom now uses direct bridge (unused codepath)
         case .pause:      return .pause
         case .count:      return .count
         }

--- a/PVCoreLoader/Sources/PVCoreLoader/Resources/systems.plist
+++ b/PVCoreLoader/Sources/PVCoreLoader/Resources/systems.plist
@@ -7752,6 +7752,16 @@
 						<key>PVControlType</key>
 						<string>PVButton</string>
 					</dict>
+					<dict>
+						<key>PVControlFrame</key>
+						<string>{{50,170},{80,70}}</string>
+						<key>PVControlTint</key>
+						<string>#f9c963</string>
+						<key>PVControlTitle</key>
+						<string>Strafe</string>
+						<key>PVControlType</key>
+						<string>PVButton</string>
+					</dict>
 				</array>
 			</dict>
 			<dict>

--- a/PVCoreLoader/Sources/PVCoreLoader/Resources/systems.plist
+++ b/PVCoreLoader/Sources/PVCoreLoader/Resources/systems.plist
@@ -7717,7 +7717,7 @@
 			</dict>
 			<dict>
 				<key>PVControlSize</key>
-				<string>{180,180}</string>
+				<string>{180,250}</string>
 				<key>PVControlType</key>
 				<string>PVButtonGroup</string>
 				<key>PVGroupedButtons</key>

--- a/PVLibrary/Sources/PVLibrary/Resources/systems.plist
+++ b/PVLibrary/Sources/PVLibrary/Resources/systems.plist
@@ -8705,6 +8705,16 @@
 						<key>PVControlType</key>
 						<string>PVButton</string>
 					</dict>
+					<dict>
+						<key>PVControlFrame</key>
+						<string>{{50,170},{80,70}}</string>
+						<key>PVControlTint</key>
+						<string>#f9c963</string>
+						<key>PVControlTitle</key>
+						<string>Strafe</string>
+						<key>PVControlType</key>
+						<string>PVButton</string>
+					</dict>
 				</array>
 			</dict>
 			<dict>

--- a/PVLibrary/Sources/PVLibrary/Resources/systems.plist
+++ b/PVLibrary/Sources/PVLibrary/Resources/systems.plist
@@ -8670,7 +8670,7 @@
 			</dict>
 			<dict>
 				<key>PVControlSize</key>
-				<string>{180,180}</string>
+				<string>{180,250}</string>
 				<key>PVControlType</key>
 				<string>PVButtonGroup</string>
 				<key>PVGroupedButtons</key>

--- a/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/Display/EmulatorWithSkinView+DefaultSkin.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/Display/EmulatorWithSkinView+DefaultSkin.swift
@@ -401,8 +401,9 @@ struct DefaultControllerSkinView: View {
             VStack {
                 Spacer()
                 VStack(spacing: 10) {
+                    let cachedFps = fpsButtonConfig
                     HStack(spacing: 30) {
-                        if let fps = fpsButtonConfig {
+                        if let fps = cachedFps {
                             VStack(spacing: 25) {
                                 circleButton(label: fps.tl.0, color: fps.tl.2, inputId: fps.tl.1)
                                 circleButton(label: fps.bl.0, color: fps.bl.2, inputId: fps.bl.1)
@@ -422,7 +423,7 @@ struct DefaultControllerSkinView: View {
                             }
                         }
                     }
-                    if let fps = fpsButtonConfig, let center = fps.center {
+                    if let center = cachedFps?.center {
                         circleButton(label: center.0, color: center.2, inputId: center.1)
                     }
                 }
@@ -828,8 +829,9 @@ struct DefaultControllerSkinView: View {
 
                 // Right side - Action buttons (constrained to prevent off-screen)
                 VStack(spacing: 10) {
+                    let cachedFps = fpsButtonConfig
                     HStack(spacing: 20) {
-                        if let fps = fpsButtonConfig {
+                        if let fps = cachedFps {
                             VStack(spacing: 20) {
                                 circleButton(label: fps.tl.0, color: fps.tl.2, inputId: fps.tl.1)
                                 circleButton(label: fps.bl.0, color: fps.bl.2, inputId: fps.bl.1)
@@ -849,7 +851,7 @@ struct DefaultControllerSkinView: View {
                             }
                         }
                     }
-                    if let fps = fpsButtonConfig, let center = fps.center {
+                    if let center = cachedFps?.center {
                         circleButton(label: center.0, color: center.2, inputId: center.1)
                     }
                 }

--- a/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/Display/EmulatorWithSkinView+DefaultSkin.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/Display/EmulatorWithSkinView+DefaultSkin.swift
@@ -423,7 +423,7 @@ struct DefaultControllerSkinView: View {
                             }
                         }
                     }
-                    if let center = cachedFps?.center {
+                    if let fps = cachedFps, let center = fps.center {
                         circleButton(label: center.0, color: center.2, inputId: center.1)
                     }
                 }
@@ -851,7 +851,7 @@ struct DefaultControllerSkinView: View {
                             }
                         }
                     }
-                    if let center = cachedFps?.center {
+                    if let fps = cachedFps, let center = fps.center {
                         circleButton(label: center.0, color: center.2, inputId: center.1)
                     }
                 }
@@ -1192,6 +1192,7 @@ struct DefaultControllerSkinView: View {
                                   tr: (String, String, Color), br: (String, String, Color),
                                   center: (String, String, Color)?)? {
         DLOG("fpsButtonConfig: systemId = \(String(describing: systemId))")
+        guard let systemId else { return nil }
         switch systemId {
         case .DOOM:
             return (tl: ("MAP", "map", .yellow), bl: ("RUN", "run", .blue),

--- a/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/Display/EmulatorWithSkinView+DefaultSkin.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/Display/EmulatorWithSkinView+DefaultSkin.swift
@@ -400,25 +400,30 @@ struct DefaultControllerSkinView: View {
             // Action buttons on the right side
             VStack {
                 Spacer()
-                HStack(spacing: 30) {
-                    if let fps = fpsButtonConfig {
-                        VStack(spacing: 25) {
-                            circleButton(label: fps.tl.0, color: fps.tl.2, inputId: fps.tl.1)
-                            circleButton(label: fps.bl.0, color: fps.bl.2, inputId: fps.bl.1)
+                VStack(spacing: 10) {
+                    HStack(spacing: 30) {
+                        if let fps = fpsButtonConfig {
+                            VStack(spacing: 25) {
+                                circleButton(label: fps.tl.0, color: fps.tl.2, inputId: fps.tl.1)
+                                circleButton(label: fps.bl.0, color: fps.bl.2, inputId: fps.bl.1)
+                            }
+                            VStack(spacing: 25) {
+                                circleButton(label: fps.tr.0, color: fps.tr.2, inputId: fps.tr.1)
+                                circleButton(label: fps.br.0, color: fps.br.2, inputId: fps.br.1)
+                            }
+                        } else {
+                            VStack(spacing: 25) {
+                                circleButton(label: "Y", color: .yellow)
+                                circleButton(label: "X", color: .blue)
+                            }
+                            VStack(spacing: 25) {
+                                circleButton(label: "B", color: .red)
+                                circleButton(label: "A", color: .green)
+                            }
                         }
-                        VStack(spacing: 25) {
-                            circleButton(label: fps.tr.0, color: fps.tr.2, inputId: fps.tr.1)
-                            circleButton(label: fps.br.0, color: fps.br.2, inputId: fps.br.1)
-                        }
-                    } else {
-                        VStack(spacing: 25) {
-                            circleButton(label: "Y", color: .yellow)
-                            circleButton(label: "X", color: .blue)
-                        }
-                        VStack(spacing: 25) {
-                            circleButton(label: "B", color: .red)
-                            circleButton(label: "A", color: .green)
-                        }
+                    }
+                    if let fps = fpsButtonConfig, let center = fps.center {
+                        circleButton(label: center.0, color: center.2, inputId: center.1)
                     }
                 }
                 Spacer()
@@ -822,7 +827,7 @@ struct DefaultControllerSkinView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
 
                 // Right side - Action buttons (constrained to prevent off-screen)
-                VStack(spacing: 20) {
+                VStack(spacing: 10) {
                     HStack(spacing: 20) {
                         if let fps = fpsButtonConfig {
                             VStack(spacing: 20) {
@@ -843,6 +848,9 @@ struct DefaultControllerSkinView: View {
                                 circleButton(label: "A", color: .green)
                             }
                         }
+                    }
+                    if let fps = fpsButtonConfig, let center = fps.center {
+                        circleButton(label: center.0, color: center.2, inputId: center.1)
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .trailing)
@@ -1176,20 +1184,25 @@ struct DefaultControllerSkinView: View {
     }
 
     /// Returns FPS-specific button labels/IDs for Doom/Wolf3D/Quake, or nil for other systems.
-    /// Layout: (topLeft, bottomLeft, topRight, bottomRight) matching the diamond pattern.
+    /// Layout: (topLeft, bottomLeft, topRight, bottomRight) matching the diamond pattern,
+    /// with an optional center button displayed between the two columns.
     private var fpsButtonConfig: (tl: (String, String, Color), bl: (String, String, Color),
-                                  tr: (String, String, Color), br: (String, String, Color))? {
+                                  tr: (String, String, Color), br: (String, String, Color),
+                                  center: (String, String, Color)?)? {
         DLOG("fpsButtonConfig: systemId = \(String(describing: systemId))")
         switch systemId {
         case .DOOM:
             return (tl: ("MAP", "map", .yellow), bl: ("RUN", "run", .blue),
-                    tr: ("USE", "use", .red), br: ("FIRE", "fire", .green))
+                    tr: ("USE", "use", .red), br: ("FIRE", "fire", .green),
+                    center: ("STRAFE", "strafe", .orange))
         case .Wolf3D:
             return (tl: ("STRAFE", "strafe", .yellow), bl: ("RUN", "run", .blue),
-                    tr: ("USE", "use", .red), br: ("FIRE", "fire", .green))
+                    tr: ("USE", "use", .red), br: ("FIRE", "fire", .green),
+                    center: nil)
         case .Quake, .Quake2:
             return (tl: ("JUMP", "jump", .yellow), bl: ("RUN", "run", .blue),
-                    tr: ("USE", "use", .red), br: ("FIRE", "fire", .green))
+                    tr: ("USE", "use", .red), br: ("FIRE", "fire", .green),
+                    center: nil)
         default:
             return nil
         }


### PR DESCRIPTION
## Summary
- Fixed button mapping: Doom was routing through DOS bridge causing Fire→Use, Use→Fire, Run→Strafe swaps
- Added dedicated strafe button to enum, ObjC bridge, default skin, and systems.plist
- Fire/Use/Run/Strafe all map correctly now

Closes #3179

## Test plan
- [ ] Load a Doom game with PBDoom/PrBoom core
- [ ] Verify Fire button shoots, Use button opens doors, Run button runs, Strafe button strafes
- [ ] Test with both default skin and custom skins

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>