### PR TITLE
[Agent] fix(skins): correct shoulder button order - L2/R2 on outer edge (#3180)

### DIFF
--- a/.changelog/3192.md
+++ b/.changelog/3192.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Shoulder Button Order & Label Consistency** — Corrected L2/R2 to appear on outer edges in both static and dynamic fallback controller skins. Dynamic skins now recognize both "L1"/"L" and "R1"/"R" control titles, ensuring buttons display and dispatch the correct input IDs for all systems (e.g., PSX, PSP). Caches repeated `hasControl` layout lookups to avoid redundant O(n) scans during SwiftUI re-renders.

--- a/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/Display/EmulatorWithSkinView+DefaultSkin.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/Display/EmulatorWithSkinView+DefaultSkin.swift
@@ -340,10 +340,10 @@ struct DefaultControllerSkinView: View {
                 // Top row with shoulder buttons, menu and turbo buttons
                 VStack {
                     HStack {
-                        // Left shoulder buttons
+                        // Left shoulder buttons (L2 on outer/left edge)
                         HStack(spacing: 15) {
-                            shoulderButton(label: "L", color: .gray)
                             shoulderButton(label: "L2", color: .gray)
+                            shoulderButton(label: "L", color: .gray)
                             shoulderButton(label: "L3", color: .gray)
                         }
                         .padding(.leading, 20)
@@ -358,11 +358,11 @@ struct DefaultControllerSkinView: View {
 
                         Spacer()
 
-                        // Right shoulder buttons
+                        // Right shoulder buttons (R2 on outer/right edge)
                         HStack(spacing: 15) {
                             shoulderButton(label: "R3", color: .gray)
-                            shoulderButton(label: "R2", color: .gray)
                             shoulderButton(label: "R", color: .gray)
+                            shoulderButton(label: "R2", color: .gray)
                         }
                         .padding(.trailing, 20)
                     }
@@ -770,11 +770,11 @@ struct DefaultControllerSkinView: View {
         VStack(spacing: 15) {
             // Top row - L/R buttons and menu/turbo
             HStack(spacing: 15) {
-                // L buttons
+                // L buttons (L2 on outer/left edge)
                 VStack(spacing: 5) {
                     HStack(spacing: 5) {
-                        shoulderButton(label: "L", color: .gray)
                         shoulderButton(label: "L2", color: .gray)
+                        shoulderButton(label: "L", color: .gray)
                     }
                     shoulderButton(label: "L3", color: .gray)
                 }
@@ -789,7 +789,7 @@ struct DefaultControllerSkinView: View {
 
                 Spacer()
 
-                // R buttons
+                // R buttons (R2 on outer/right edge)
                 VStack(spacing: 5) {
                     HStack(spacing: 5) {
                         shoulderButton(label: "R", color: .gray)
@@ -1378,13 +1378,13 @@ struct DefaultControllerSkinView: View {
                     Spacer().frame(height: 5)
 
                     HStack {
-                        // Left shoulder buttons
+                        // Left shoulder buttons (L2 on outer/left edge)
                         HStack(spacing: 15) {
-                            if hasControl(type: "PVLeftShoulderButton", title: "L", in: layout) {
-                                shoulderButton(label: "L", color: .gray)
-                            }
                             if hasControl(type: "PVLeftShoulderButton", title: "L2", in: layout) {
                                 shoulderButton(label: "L2", color: .gray)
+                            }
+                            if hasControl(type: "PVLeftShoulderButton", title: "L", in: layout) {
+                                shoulderButton(label: "L", color: .gray)
                             }
                             if hasControl(type: "PVLeftAnalogButton", title: "L3", in: layout) {
                                 shoulderButton(label: "L3", color: .gray)
@@ -1402,16 +1402,16 @@ struct DefaultControllerSkinView: View {
 
                         Spacer()
 
-                        // Right shoulder buttons
+                        // Right shoulder buttons (R2 on outer/right edge)
                         HStack(spacing: 15) {
                             if hasControl(type: "PVRightAnalogButton", title: "R3", in: layout) {
                                 shoulderButton(label: "R3", color: .gray)
                             }
-                            if hasControl(type: "PVRightShoulderButton", title: "R2", in: layout) {
-                                shoulderButton(label: "R2", color: .gray)
-                            }
                             if hasControl(type: "PVRightShoulderButton", title: "R", in: layout) {
                                 shoulderButton(label: "R", color: .gray)
+                            }
+                            if hasControl(type: "PVRightShoulderButton", title: "R2", in: layout) {
+                                shoulderButton(label: "R2", color: .gray)
                             }
                         }
                         .padding(.trailing, 20)
@@ -1596,17 +1596,17 @@ struct DefaultControllerSkinView: View {
         VStack(spacing: 8) {
             // Top row - utility buttons and system-specific shoulder buttons
             HStack(spacing: 10) {
-                // L buttons
+                // L buttons (L2 on outer/left edge)
                 VStack(spacing: 5) {
                     HStack(spacing: 5) {
+                        // Check if L2 buttons are in the layout (outer edge first)
+                        if hasControl(type: "PVLeftShoulderButton", title: "L2", in: layout) {
+                            shoulderButton(label: "L2", color: .gray)
+                        }
                         // Check if L1/L buttons are in the layout
                         if hasControl(type: "PVLeftShoulderButton", title: "L1", in: layout) ||
                             hasControl(type: "PVLeftShoulderButton", title: "L", in: layout) {
                             shoulderButton(label: "L", color: .gray)
-                        }
-                        // Check if L2 buttons are in the layout
-                        if hasControl(type: "PVLeftShoulderButton", title: "L2", in: layout) {
-                            shoulderButton(label: "L2", color: .gray)
                         }
                     }
                     // Check if L3 buttons are in the layout
@@ -1625,7 +1625,7 @@ struct DefaultControllerSkinView: View {
 
                 Spacer()
 
-                // R buttons
+                // R buttons (R2 on outer/right edge)
                 VStack(spacing: 5) {
                     HStack(spacing: 5) {
                         // Check if R1/R buttons are in the layout
@@ -1633,7 +1633,7 @@ struct DefaultControllerSkinView: View {
                             hasControl(type: "PVRightShoulderButton", title: "R", in: layout) {
                             shoulderButton(label: "R", color: .gray)
                         }
-                        // Check if R2 buttons are in the layout
+                        // Check if R2 buttons are in the layout (outer edge last)
                         if hasControl(type: "PVRightShoulderButton", title: "R2", in: layout) {
                             shoulderButton(label: "R2", color: .gray)
                         }

--- a/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/Display/EmulatorWithSkinView+DefaultSkin.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/Display/EmulatorWithSkinView+DefaultSkin.swift
@@ -1383,9 +1383,10 @@ struct DefaultControllerSkinView: View {
                             if hasControl(type: "PVLeftShoulderButton", title: "L2", in: layout) {
                                 shoulderButton(label: "L2", color: .gray)
                             }
-                            if hasControl(type: "PVLeftShoulderButton", title: "L1", in: layout) ||
-                                hasControl(type: "PVLeftShoulderButton", title: "L", in: layout) {
-                                shoulderButton(label: hasControl(type: "PVLeftShoulderButton", title: "L1", in: layout) ? "L1" : "L", color: .gray)
+                            let hasL1 = hasControl(type: "PVLeftShoulderButton", title: "L1", in: layout)
+                            let hasL = hasControl(type: "PVLeftShoulderButton", title: "L", in: layout)
+                            if hasL1 || hasL {
+                                shoulderButton(label: hasL1 ? "L1" : "L", color: .gray)
                             }
                             if hasControl(type: "PVLeftAnalogButton", title: "L3", in: layout) {
                                 shoulderButton(label: "L3", color: .gray)
@@ -1408,9 +1409,10 @@ struct DefaultControllerSkinView: View {
                             if hasControl(type: "PVRightAnalogButton", title: "R3", in: layout) {
                                 shoulderButton(label: "R3", color: .gray)
                             }
-                            if hasControl(type: "PVRightShoulderButton", title: "R1", in: layout) ||
-                                hasControl(type: "PVRightShoulderButton", title: "R", in: layout) {
-                                shoulderButton(label: hasControl(type: "PVRightShoulderButton", title: "R1", in: layout) ? "R1" : "R", color: .gray)
+                            let hasR1 = hasControl(type: "PVRightShoulderButton", title: "R1", in: layout)
+                            let hasR = hasControl(type: "PVRightShoulderButton", title: "R", in: layout)
+                            if hasR1 || hasR {
+                                shoulderButton(label: hasR1 ? "R1" : "R", color: .gray)
                             }
                             if hasControl(type: "PVRightShoulderButton", title: "R2", in: layout) {
                                 shoulderButton(label: "R2", color: .gray)
@@ -1606,9 +1608,10 @@ struct DefaultControllerSkinView: View {
                             shoulderButton(label: "L2", color: .gray)
                         }
                         // Check if L1/L buttons are in the layout
-                        if hasControl(type: "PVLeftShoulderButton", title: "L1", in: layout) ||
-                            hasControl(type: "PVLeftShoulderButton", title: "L", in: layout) {
-                            shoulderButton(label: "L", color: .gray)
+                        let hasL1 = hasControl(type: "PVLeftShoulderButton", title: "L1", in: layout)
+                        let hasL = hasControl(type: "PVLeftShoulderButton", title: "L", in: layout)
+                        if hasL1 || hasL {
+                            shoulderButton(label: hasL1 ? "L1" : "L", color: .gray)
                         }
                     }
                     // Check if L3 buttons are in the layout
@@ -1631,9 +1634,10 @@ struct DefaultControllerSkinView: View {
                 VStack(spacing: 5) {
                     HStack(spacing: 5) {
                         // Check if R1/R buttons are in the layout
-                        if hasControl(type: "PVRightShoulderButton", title: "R1", in: layout) ||
-                            hasControl(type: "PVRightShoulderButton", title: "R", in: layout) {
-                            shoulderButton(label: "R", color: .gray)
+                        let hasR1 = hasControl(type: "PVRightShoulderButton", title: "R1", in: layout)
+                        let hasR = hasControl(type: "PVRightShoulderButton", title: "R", in: layout)
+                        if hasR1 || hasR {
+                            shoulderButton(label: hasR1 ? "R1" : "R", color: .gray)
                         }
                         // Check if R2 buttons are in the layout (outer edge last)
                         if hasControl(type: "PVRightShoulderButton", title: "R2", in: layout) {

--- a/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/Display/EmulatorWithSkinView+DefaultSkin.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/Display/EmulatorWithSkinView+DefaultSkin.swift
@@ -1383,8 +1383,9 @@ struct DefaultControllerSkinView: View {
                             if hasControl(type: "PVLeftShoulderButton", title: "L2", in: layout) {
                                 shoulderButton(label: "L2", color: .gray)
                             }
-                            if hasControl(type: "PVLeftShoulderButton", title: "L", in: layout) {
-                                shoulderButton(label: "L", color: .gray)
+                            if hasControl(type: "PVLeftShoulderButton", title: "L1", in: layout) ||
+                                hasControl(type: "PVLeftShoulderButton", title: "L", in: layout) {
+                                shoulderButton(label: hasControl(type: "PVLeftShoulderButton", title: "L1", in: layout) ? "L1" : "L", color: .gray)
                             }
                             if hasControl(type: "PVLeftAnalogButton", title: "L3", in: layout) {
                                 shoulderButton(label: "L3", color: .gray)
@@ -1407,8 +1408,9 @@ struct DefaultControllerSkinView: View {
                             if hasControl(type: "PVRightAnalogButton", title: "R3", in: layout) {
                                 shoulderButton(label: "R3", color: .gray)
                             }
-                            if hasControl(type: "PVRightShoulderButton", title: "R", in: layout) {
-                                shoulderButton(label: "R", color: .gray)
+                            if hasControl(type: "PVRightShoulderButton", title: "R1", in: layout) ||
+                                hasControl(type: "PVRightShoulderButton", title: "R", in: layout) {
+                                shoulderButton(label: hasControl(type: "PVRightShoulderButton", title: "R1", in: layout) ? "R1" : "R", color: .gray)
                             }
                             if hasControl(type: "PVRightShoulderButton", title: "R2", in: layout) {
                                 shoulderButton(label: "R2", color: .gray)


### PR DESCRIPTION
## Summary
- Swapped L1/L2 and R1/R2 order in all 4 layout functions (landscape/portrait, static/dynamic)
- L2 now on outer-left edge, R2 on outer-right edge, matching real controller muscle memory

Closes #3180

## Test plan
- [ ] Load a game with L1/L2/R1/R2 shoulder buttons on default skin
- [ ] Verify layout is `[L2 | L1] ---- [R1 | R2]`
- [ ] Test in both portrait and landscape orientations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>