### PR TITLE
[Agent] fix(atari800): infinite recursion crash on joystick input (#3182)

### DIFF
--- a/Cores/Atari800/Sources/PVAtari800Bridge/PVAtari800Bridge.m
+++ b/Cores/Atari800/Sources/PVAtari800Bridge/PVAtari800Bridge.m
@@ -575,6 +575,7 @@ __weak static PVAtari800Bridge * _currentCore;
 }
 
 - (void)didMove5200JoystickDirection:(PV5200Button)button withValue:(CGFloat)value forPlayer:(NSUInteger)player {
+    if (player >= 4) return;
     static const CGFloat kDeadzone = 0.5;
     switch (button) {
         case PV5200ButtonUp:
@@ -1079,10 +1080,12 @@ void PLATFORM_SoundUnlock(void){}
 }
 
 - (void)didRelease:(NSInteger)button forPlayer:(NSInteger)player {
-    [self didRelease5200Button:button forPlayer:player];
+    if (player < 0 || player >= 4) return;
+    [self didRelease5200Button:(PV5200Button)button forPlayer:(NSUInteger)player];
 }
 
 - (void)didMoveJoystick:(NSInteger)button withXValue:(CGFloat)xValue withYValue:(CGFloat)yValue forPlayer:(NSInteger)player {
+    if (player < 0 || player >= 4) return;
     static const CGFloat kDeadzone = 0.5;
     self.controllerStates[player].up    = (yValue > kDeadzone);
     self.controllerStates[player].down  = (yValue < -kDeadzone);

--- a/Cores/Atari800/Sources/PVAtari800Bridge/PVAtari800Bridge.m
+++ b/Cores/Atari800/Sources/PVAtari800Bridge/PVAtari800Bridge.m
@@ -575,7 +575,7 @@ __weak static PVAtari800Bridge * _currentCore;
 }
 
 /// Shared deadzone threshold for analog-to-digital joystick conversion.
-static const CGFloat kJoystickJoystickDeadzone = 0.5;
+static const CGFloat kJoystickDeadzone = 0.5;
 
 - (void)didMove5200JoystickDirection:(PV5200Button)button withValue:(CGFloat)value forPlayer:(NSUInteger)player {
     if (player >= 4) return;

--- a/Cores/Atari800/Sources/PVAtari800Bridge/PVAtari800Bridge.m
+++ b/Cores/Atari800/Sources/PVAtari800Bridge/PVAtari800Bridge.m
@@ -981,7 +981,7 @@ int PLATFORM_Exit(int run_monitor)
 
 int PLATFORM_PORT(int num)
 {
-    if(num < kMaxPlayers && num >= 0) {
+    if (num >= 0 && num < (int)kMaxPlayers) {
         ATR5200ControllerState state = [_currentCore controllerStateForPlayer:num];
         if(state.up == 1 && state.left == 1) {
             return INPUT_STICK_UL;

--- a/Cores/Atari800/Sources/PVAtari800Bridge/PVAtari800Bridge.m
+++ b/Cores/Atari800/Sources/PVAtari800Bridge/PVAtari800Bridge.m
@@ -577,16 +577,16 @@ __weak static PVAtari800Bridge * _currentCore;
 - (void)didMove5200JoystickDirection:(PV5200Button)button withValue:(CGFloat)value forPlayer:(NSUInteger)player {
     static const CGFloat kDeadzone = 0.5;
     switch (button) {
-        case PV5200ButtonAnalogUp:
+        case PV5200ButtonUp:
             self.controllerStates[player].up = (value > kDeadzone);
             break;
-        case PV5200ButtonAnalogDown:
+        case PV5200ButtonDown:
             self.controllerStates[player].down = (value > kDeadzone);
             break;
-        case PV5200ButtonAnalogLeft:
+        case PV5200ButtonLeft:
             self.controllerStates[player].left = (value > kDeadzone);
             break;
-        case PV5200ButtonAnalogRight:
+        case PV5200ButtonRight:
             self.controllerStates[player].right = (value > kDeadzone);
             break;
         default:

--- a/Cores/Atari800/Sources/PVAtari800Bridge/PVAtari800Bridge.m
+++ b/Cores/Atari800/Sources/PVAtari800Bridge/PVAtari800Bridge.m
@@ -576,9 +576,11 @@ __weak static PVAtari800Bridge * _currentCore;
 
 /// Shared deadzone threshold for analog-to-digital joystick conversion.
 static const CGFloat kJoystickDeadzone = 0.5;
+/// Maximum number of supported controller slots.
+static const NSInteger kMaxPlayers = 4;
 
 - (void)didMove5200JoystickDirection:(PV5200Button)button withValue:(CGFloat)value forPlayer:(NSUInteger)player {
-    if (player >= 4) return;
+    if (player >= kMaxPlayers) return;
     switch (button) {
         case PV5200ButtonUp:
             self.controllerStates[player].up = (value > kJoystickDeadzone);
@@ -755,10 +757,10 @@ static const CGFloat kJoystickDeadzone = 0.5;
             GCControllerDirectionPad *dpad = [gamepad dpad];
             
             // DPAD
-            self.controllerStates[playerIndex].up    = dpad.up.value > 0.5;
-            self.controllerStates[playerIndex].down  = dpad.down.value > 0.5;
-            self.controllerStates[playerIndex].left  = dpad.left.value > 0.5;
-            self.controllerStates[playerIndex].right = dpad.right.value > 0.5;
+            self.controllerStates[playerIndex].up    = dpad.up.value > kJoystickDeadzone;
+            self.controllerStates[playerIndex].down  = dpad.down.value > kJoystickDeadzone;
+            self.controllerStates[playerIndex].left  = dpad.left.value > kJoystickDeadzone;
+            self.controllerStates[playerIndex].right = dpad.right.value > kJoystickDeadzone;
             
             //Fire
             self.controllerStates[playerIndex].fire = gamepad.buttonA.isPressed;
@@ -1082,13 +1084,13 @@ void PLATFORM_SoundUnlock(void){}
 }
 
 - (void)didRelease:(NSInteger)button forPlayer:(NSInteger)player {
-    if (player < 0 || player >= 4) return;
+    if (player < 0 || player >= kMaxPlayers) return;
     [self didRelease5200Button:(PV5200Button)button forPlayer:(NSUInteger)player];
 }
 
 - (void)didMoveJoystick:(NSInteger)button withXValue:(CGFloat)xValue withYValue:(CGFloat)yValue forPlayer:(NSInteger)player {
     (void)button; // unused — joystick maps all axes regardless of button ID
-    if (player < 0 || player >= 4) return;
+    if (player < 0 || player >= kMaxPlayers) return;
     self.controllerStates[player].up    = (yValue > kJoystickDeadzone);
     self.controllerStates[player].down  = (yValue < -kJoystickDeadzone);
     self.controllerStates[player].left  = (xValue < -kJoystickDeadzone);

--- a/Cores/Atari800/Sources/PVAtari800Bridge/PVAtari800Bridge.m
+++ b/Cores/Atari800/Sources/PVAtari800Bridge/PVAtari800Bridge.m
@@ -575,27 +575,23 @@ __weak static PVAtari800Bridge * _currentCore;
 }
 
 - (void)didMove5200JoystickDirection:(PV5200Button)button withValue:(CGFloat)value forPlayer:(NSUInteger)player {
-    //    if (self.dualJoystickOption && player == 0) {
-    //        player = 1;
-    //    }
-    //    switch (button) {
-    //        case PV5200ButtonAnalogUp:
-    ////            NSLog(@"Up: %f", round(value * N64_ANALOG_MAX));
-    //            yAxis[player] = round(value * N64_ANALOG_MAX);
-    //            break;
-    //        case PV5200ButtonAnalogDown:
-    ////            NSLog(@"Down: %f", value * -N64_ANALOG_MAX);
-    //            yAxis[player] = value * -N64_ANALOG_MAX;
-    //            break;
-    //        case PV5200ButtonAnalogLeft:
-    //            xAxis[player] = value * -N64_ANALOG_MAX;
-    //            break;
-    //        case PV5200ButtonAnalogRight:
-    //            xAxis[player] = value * N64_ANALOG_MAX;
-    //            break;
-    //        default:
-    //            break;
-    //    }
+    static const CGFloat kDeadzone = 0.5;
+    switch (button) {
+        case PV5200ButtonAnalogUp:
+            self.controllerStates[player].up = (value > kDeadzone);
+            break;
+        case PV5200ButtonAnalogDown:
+            self.controllerStates[player].down = (value > kDeadzone);
+            break;
+        case PV5200ButtonAnalogLeft:
+            self.controllerStates[player].left = (value > kDeadzone);
+            break;
+        case PV5200ButtonAnalogRight:
+            self.controllerStates[player].right = (value > kDeadzone);
+            break;
+        default:
+            break;
+    }
 }
 
 
@@ -1082,12 +1078,16 @@ void PLATFORM_SoundUnlock(void){}
     [self didPush5200Button:button forPlayer:player];
 }
 
-- (void)didRelease:(NSInteger)button forPlayer:(NSInteger)player { 
-    [self didRelease:button forPlayer:player];
+- (void)didRelease:(NSInteger)button forPlayer:(NSInteger)player {
+    [self didRelease5200Button:button forPlayer:player];
 }
 
-- (void)didMoveJoystick:(NSInteger)button withXValue:(CGFloat)xValue withYValue:(CGFloat)yValue forPlayer:(NSInteger)player { 
-    [self didMoveJoystick:button withXValue:xValue withYValue:yValue forPlayer:player];
+- (void)didMoveJoystick:(NSInteger)button withXValue:(CGFloat)xValue withYValue:(CGFloat)yValue forPlayer:(NSInteger)player {
+    static const CGFloat kDeadzone = 0.5;
+    self.controllerStates[player].up    = (yValue > kDeadzone);
+    self.controllerStates[player].down  = (yValue < -kDeadzone);
+    self.controllerStates[player].left  = (xValue < -kDeadzone);
+    self.controllerStates[player].right = (xValue > kDeadzone);
 }
 
 @end

--- a/Cores/Atari800/Sources/PVAtari800Bridge/PVAtari800Bridge.m
+++ b/Cores/Atari800/Sources/PVAtari800Bridge/PVAtari800Bridge.m
@@ -979,7 +979,7 @@ int PLATFORM_Exit(int run_monitor)
 
 int PLATFORM_PORT(int num)
 {
-    if(num < 4 && num >= 0) {
+    if(num < kMaxPlayers && num >= 0) {
         ATR5200ControllerState state = [_currentCore controllerStateForPlayer:num];
         if(state.up == 1 && state.left == 1) {
             return INPUT_STICK_UL;

--- a/Cores/Atari800/Sources/PVAtari800Bridge/PVAtari800Bridge.m
+++ b/Cores/Atari800/Sources/PVAtari800Bridge/PVAtari800Bridge.m
@@ -63,6 +63,11 @@ __weak static PVAtari800Bridge * _currentCore;
 @end
 
 
+/// Shared deadzone threshold for analog-to-digital joystick conversion.
+static const CGFloat kJoystickDeadzone = 0.5;
+/// Maximum number of supported controller slots.
+static const NSUInteger kMaxPlayers = 4;
+
 @implementation PVAtari800Bridge
 
 - (uint8_t *)atariVideoBuffer {
@@ -499,7 +504,7 @@ __weak static PVAtari800Bridge * _currentCore;
 
 - (void)didPush5200Button:(PV5200Button)button forPlayer:(NSUInteger)player
 {
-    if (player >= (NSUInteger)kMaxPlayers) return;
+    if (player >= kMaxPlayers) return;
     switch (button)
     {
         case PV5200ButtonFire1:
@@ -575,11 +580,6 @@ __weak static PVAtari800Bridge * _currentCore;
     }
 }
 
-/// Shared deadzone threshold for analog-to-digital joystick conversion.
-static const CGFloat kJoystickDeadzone = 0.5;
-/// Maximum number of supported controller slots.
-static const NSInteger kMaxPlayers = 4;
-
 - (void)didMove5200JoystickDirection:(PV5200Button)button withValue:(CGFloat)value forPlayer:(NSUInteger)player {
     if (player >= kMaxPlayers) return;
     switch (button) {
@@ -603,7 +603,7 @@ static const NSInteger kMaxPlayers = 4;
 
 - (void)didRelease5200Button:(PV5200Button)button forPlayer:(NSUInteger)player
 {
-    if (player >= (NSUInteger)kMaxPlayers) return;
+    if (player >= kMaxPlayers) return;
     switch (button)
     {
         case PV5200ButtonFire1:
@@ -801,7 +801,7 @@ static const NSInteger kMaxPlayers = 4;
 
 - (ATR5200ControllerState)controllerStateForPlayer:(NSUInteger)playerNum {
     ATR5200ControllerState state = {0,0,0,0,0,0,0,0};
-    if(playerNum < (NSUInteger)kMaxPlayers) {
+    if(playerNum < kMaxPlayers) {
         state = self.controllerStates[playerNum];
     }
     return state;

--- a/Cores/Atari800/Sources/PVAtari800Bridge/PVAtari800Bridge.m
+++ b/Cores/Atari800/Sources/PVAtari800Bridge/PVAtari800Bridge.m
@@ -574,21 +574,23 @@ __weak static PVAtari800Bridge * _currentCore;
     }
 }
 
+/// Shared deadzone threshold for analog-to-digital joystick conversion.
+static const CGFloat kJoystickJoystickDeadzone = 0.5;
+
 - (void)didMove5200JoystickDirection:(PV5200Button)button withValue:(CGFloat)value forPlayer:(NSUInteger)player {
     if (player >= 4) return;
-    static const CGFloat kDeadzone = 0.5;
     switch (button) {
         case PV5200ButtonUp:
-            self.controllerStates[player].up = (value > kDeadzone);
+            self.controllerStates[player].up = (value > kJoystickDeadzone);
             break;
         case PV5200ButtonDown:
-            self.controllerStates[player].down = (value > kDeadzone);
+            self.controllerStates[player].down = (value > kJoystickDeadzone);
             break;
         case PV5200ButtonLeft:
-            self.controllerStates[player].left = (value > kDeadzone);
+            self.controllerStates[player].left = (value > kJoystickDeadzone);
             break;
         case PV5200ButtonRight:
-            self.controllerStates[player].right = (value > kDeadzone);
+            self.controllerStates[player].right = (value > kJoystickDeadzone);
             break;
         default:
             break;
@@ -1085,12 +1087,12 @@ void PLATFORM_SoundUnlock(void){}
 }
 
 - (void)didMoveJoystick:(NSInteger)button withXValue:(CGFloat)xValue withYValue:(CGFloat)yValue forPlayer:(NSInteger)player {
+    (void)button; // unused — joystick maps all axes regardless of button ID
     if (player < 0 || player >= 4) return;
-    static const CGFloat kDeadzone = 0.5;
-    self.controllerStates[player].up    = (yValue > kDeadzone);
-    self.controllerStates[player].down  = (yValue < -kDeadzone);
-    self.controllerStates[player].left  = (xValue < -kDeadzone);
-    self.controllerStates[player].right = (xValue > kDeadzone);
+    self.controllerStates[player].up    = (yValue > kJoystickDeadzone);
+    self.controllerStates[player].down  = (yValue < -kJoystickDeadzone);
+    self.controllerStates[player].left  = (xValue < -kJoystickDeadzone);
+    self.controllerStates[player].right = (xValue > kJoystickDeadzone);
 }
 
 @end

--- a/Cores/Atari800/Sources/PVAtari800Bridge/PVAtari800Bridge.m
+++ b/Cores/Atari800/Sources/PVAtari800Bridge/PVAtari800Bridge.m
@@ -499,6 +499,7 @@ __weak static PVAtari800Bridge * _currentCore;
 
 - (void)didPush5200Button:(PV5200Button)button forPlayer:(NSUInteger)player
 {
+    if (player >= (NSUInteger)kMaxPlayers) return;
     switch (button)
     {
         case PV5200ButtonFire1:
@@ -602,6 +603,7 @@ static const NSInteger kMaxPlayers = 4;
 
 - (void)didRelease5200Button:(PV5200Button)button forPlayer:(NSUInteger)player
 {
+    if (player >= (NSUInteger)kMaxPlayers) return;
     switch (button)
     {
         case PV5200ButtonFire1:
@@ -799,7 +801,7 @@ static const NSInteger kMaxPlayers = 4;
 
 - (ATR5200ControllerState)controllerStateForPlayer:(NSUInteger)playerNum {
     ATR5200ControllerState state = {0,0,0,0,0,0,0,0};
-    if(playerNum < 4) {
+    if(playerNum < (NSUInteger)kMaxPlayers) {
         state = self.controllerStates[playerNum];
     }
     return state;
@@ -1079,8 +1081,9 @@ void PLATFORM_SoundUnlock(void){}
 //    free(newBuffer);
 //}
 
-- (void)didPush:(NSInteger)button forPlayer:(NSInteger)player { 
-    [self didPush5200Button:button forPlayer:player];
+- (void)didPush:(NSInteger)button forPlayer:(NSInteger)player {
+    if (player < 0 || player >= kMaxPlayers) return;
+    [self didPush5200Button:(PV5200Button)button forPlayer:(NSUInteger)player];
 }
 
 - (void)didRelease:(NSInteger)button forPlayer:(NSInteger)player {

--- a/Cores/Atari800/Sources/PVAtari800Bridge/PVAtari800Bridge.m
+++ b/Cores/Atari800/Sources/PVAtari800Bridge/PVAtari800Bridge.m
@@ -66,7 +66,7 @@ __weak static PVAtari800Bridge * _currentCore;
 /// Shared deadzone threshold for analog-to-digital joystick conversion.
 static const CGFloat kJoystickDeadzone = 0.5;
 /// Maximum number of supported controller slots.
-static const NSUInteger kMaxPlayers = 4;
+static const NSInteger kMaxPlayers = 4;
 
 @implementation PVAtari800Bridge
 


### PR DESCRIPTION
## Summary
- Fixed `didRelease:forPlayer:` calling itself instead of `didRelease5200Button:forPlayer:`
- Fixed `didMoveJoystick:withXValue:withYValue:forPlayer:` calling itself (stack overflow)
- Implemented analog-to-digital joystick conversion with 0.5 deadzone threshold
- Un-commented and implemented `didMove5200JoystickDirection:withValue:forPlayer:`

Closes #3182

## Test plan
- [ ] Load an Atari 800/5200 game with skin joystick controls
- [ ] Move virtual joystick — should no longer crash
- [ ] Verify directional input works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>