### PR TITLE
[Agent] fix(audio): flush ring buffer on pause to prevent looping (#3183)

### DIFF
--- a/.changelog/3195.md
+++ b/.changelog/3195.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Audio looping on pause** — ring buffers are now drained via a non-reallocating `clear()` call after the audio consumer stops, preventing stale samples from replaying when the pause menu opens and eliminating a potential use-after-free from the previous `reset()` path.

--- a/PVAudio/Sources/Ring Buffers/OERingBuffer/OERingBuffer.h
+++ b/PVAudio/Sources/Ring Buffers/OERingBuffer/OERingBuffer.h
@@ -68,4 +68,8 @@
 /// Resets the RingBuffer to empty size
 /// Note: Does not erase any memory
 - (void)reset;
+
+/// Drains all pending bytes without deallocating or reinitialising the backing
+/// buffer. Safer than `reset` when the producer thread may still be running.
+- (void)clear;
 @end

--- a/PVAudio/Sources/Ring Buffers/OERingBuffer/OERingBuffer.m
+++ b/PVAudio/Sources/Ring Buffers/OERingBuffer/OERingBuffer.m
@@ -147,6 +147,15 @@ __attribute__((objc_direct_members))
     atomic_thread_fence(memory_order_release);
 }
 
+- (void)clear {
+    /// Drain without reallocating the backing buffer.
+    /// TPCircularBufferClear advances the tail pointer, making the buffer appear
+    /// empty to the consumer without freeing any memory — safe when the consumer
+    /// is paused but the producer may still be active.
+    TPCircularBufferClear(&buffer);
+    atomic_thread_fence(memory_order_release);
+}
+
 - (BufferSize)availableBytes {
     return [self availableBytesForReading];
 }

--- a/PVAudio/Sources/Ring Buffers/PVRingBuffer/PVRingBuffer.swift
+++ b/PVAudio/Sources/Ring Buffers/PVRingBuffer/PVRingBuffer.swift
@@ -214,6 +214,14 @@ public final class PVRingBuffer: NSObject, RingBufferProtocol, @unchecked Sendab
         _bytesInBuffer.store(0, ordering: .releasing)
     }
 
+    /// Drain without reallocating — equivalent to `reset` for this implementation
+    /// since all state is held in atomics (no memory is freed or reallocated).
+    public func clear() {
+        _readPosition.store(0, ordering: .releasing)
+        _writePosition.store(0, ordering: .releasing)
+        _bytesInBuffer.store(0, ordering: .releasing)
+    }
+
     /// Fast power of 2 check
     private func isPowerOf2(_ value: Int) -> Bool {
         return value > 0 && (value & (value - 1)) == 0

--- a/PVAudio/Sources/RingBuffer/RingBufferProtocol.swift
+++ b/PVAudio/Sources/RingBuffer/RingBufferProtocol.swift
@@ -24,5 +24,22 @@ public protocol RingBufferProtocol {
 
     func reset()
 
+    /// Drains all pending bytes without reallocating the backing buffer.
+    /// Safe to call while a consumer is paused; prefer this over `reset()` when
+    /// the producer (emulator core) may still be running.
+    func clear()
+
     var availableBytes: RingBufferSize { get }
+}
+
+public extension RingBufferProtocol {
+    /// Default implementation: drain by consuming all available bytes via `read`.
+    /// Concrete types should override with a more efficient implementation.
+    func clear() {
+        let bytes = availableBytesForReading
+        guard bytes > 0 else { return }
+        let scratch = UnsafeMutableRawPointer.allocate(byteCount: bytes, alignment: 1)
+        defer { scratch.deallocate() }
+        read(scratch, preferredSize: bytes)
+    }
 }

--- a/PVCoreAudio/Sources/PVCoreAudio/Engines/AVAudioEngineGameAudioEngine.swift
+++ b/PVCoreAudio/Sources/PVCoreAudio/Engines/AVAudioEngineGameAudioEngine.swift
@@ -568,8 +568,10 @@ final public class AVAudioEngineGameAudioEngine: AudioEngineProtocol {
         guard isRunning else { return }
         engine.pause()
         isRunning = false
-        // Flush stale audio data after stopping the consumer (#3183).
-        gameCore?.ringBuffer(atIndex: 0)?.reset()
+        // Drain stale audio data after stopping the consumer (#3183).
+        // Use clear() instead of reset() to avoid deallocating/reinitialising
+        // the backing buffer while the emulator core may still be writing.
+        gameCore?.ringBuffer(atIndex: 0)?.clear()
     }
 
     /// Enhanced error handling

--- a/PVCoreAudio/Sources/PVCoreAudio/Engines/AVAudioEngineGameAudioEngine.swift
+++ b/PVCoreAudio/Sources/PVCoreAudio/Engines/AVAudioEngineGameAudioEngine.swift
@@ -568,10 +568,13 @@ final public class AVAudioEngineGameAudioEngine: AudioEngineProtocol {
         guard isRunning else { return }
         engine.pause()
         isRunning = false
-        // Flush ring buffer after pausing engine and before emulator resumes (#3183).
-        // Safe because the emulator core's frame loop is also paused when the pause menu opens,
-        // so neither the producer (core) nor consumer (render callback) should be active.
-        gameCore?.ringBuffer(atIndex: 0)?.reset()
+        // Flush ring buffer after pausing engine (#3183).
+        // Precondition: emulator core frame loop must also be paused so the producer
+        // is not writing concurrently. OERingBuffer.reset() reinitializes the backing
+        // TPCircularBuffer and is not thread-safe against concurrent writes.
+        if let core = gameCore, core.isEmulationPaused {
+            core.ringBuffer(atIndex: 0)?.reset()
+        }
     }
 
     /// Enhanced error handling

--- a/PVCoreAudio/Sources/PVCoreAudio/Engines/AVAudioEngineGameAudioEngine.swift
+++ b/PVCoreAudio/Sources/PVCoreAudio/Engines/AVAudioEngineGameAudioEngine.swift
@@ -568,13 +568,8 @@ final public class AVAudioEngineGameAudioEngine: AudioEngineProtocol {
         guard isRunning else { return }
         engine.pause()
         isRunning = false
-        // Flush ring buffer after pausing engine (#3183).
-        // Precondition: emulator core frame loop must also be paused so the producer
-        // is not writing concurrently. OERingBuffer.reset() reinitializes the backing
-        // TPCircularBuffer and is not thread-safe against concurrent writes.
-        if let core = gameCore, core.isEmulationPaused {
-            core.ringBuffer(atIndex: 0)?.reset()
-        }
+        // Flush stale audio data after stopping the consumer (#3183).
+        gameCore?.ringBuffer(atIndex: 0)?.reset()
     }
 
     /// Enhanced error handling

--- a/PVCoreAudio/Sources/PVCoreAudio/Engines/AVAudioEngineGameAudioEngine.swift
+++ b/PVCoreAudio/Sources/PVCoreAudio/Engines/AVAudioEngineGameAudioEngine.swift
@@ -566,6 +566,8 @@ final public class AVAudioEngineGameAudioEngine: AudioEngineProtocol {
 
     public func pauseAudio() {
         guard isRunning else { return }
+        // Flush ring buffer before pausing to prevent stale audio from looping (#3183)
+        gameCore?.ringBuffer(atIndex: 0)?.reset()
         engine.pause()
         isRunning = false
     }

--- a/PVCoreAudio/Sources/PVCoreAudio/Engines/AVAudioEngineGameAudioEngine.swift
+++ b/PVCoreAudio/Sources/PVCoreAudio/Engines/AVAudioEngineGameAudioEngine.swift
@@ -568,7 +568,9 @@ final public class AVAudioEngineGameAudioEngine: AudioEngineProtocol {
         guard isRunning else { return }
         engine.pause()
         isRunning = false
-        // Flush ring buffer after pausing to prevent race with render callback (#3183)
+        // Flush ring buffer after pausing engine and before emulator resumes (#3183).
+        // Safe because the emulator core's frame loop is also paused when the pause menu opens,
+        // so neither the producer (core) nor consumer (render callback) should be active.
         gameCore?.ringBuffer(atIndex: 0)?.reset()
     }
 

--- a/PVCoreAudio/Sources/PVCoreAudio/Engines/AVAudioEngineGameAudioEngine.swift
+++ b/PVCoreAudio/Sources/PVCoreAudio/Engines/AVAudioEngineGameAudioEngine.swift
@@ -566,10 +566,10 @@ final public class AVAudioEngineGameAudioEngine: AudioEngineProtocol {
 
     public func pauseAudio() {
         guard isRunning else { return }
-        // Flush ring buffer before pausing to prevent stale audio from looping (#3183)
-        gameCore?.ringBuffer(atIndex: 0)?.reset()
         engine.pause()
         isRunning = false
+        // Flush ring buffer after pausing to prevent race with render callback (#3183)
+        gameCore?.ringBuffer(atIndex: 0)?.reset()
     }
 
     /// Enhanced error handling

--- a/PVCoreAudio/Sources/PVCoreAudio/Engines/AudioUnitGameAudioEngine.swift
+++ b/PVCoreAudio/Sources/PVCoreAudio/Engines/AudioUnitGameAudioEngine.swift
@@ -297,6 +297,10 @@ public final class AudioUnitGameAudioEngine: NSObject, AudioEngineProtocol {
 
     /// Audio control methods
     @objc public func pauseAudio() {
+        // Flush ring buffers before stopping to prevent stale audio from looping (#3183)
+        for context in _contexts {
+            context.buffer?.reset()
+        }
         stopAudio()
         running = false
     }

--- a/PVCoreAudio/Sources/PVCoreAudio/Engines/AudioUnitGameAudioEngine.swift
+++ b/PVCoreAudio/Sources/PVCoreAudio/Engines/AudioUnitGameAudioEngine.swift
@@ -299,7 +299,9 @@ public final class AudioUnitGameAudioEngine: NSObject, AudioEngineProtocol {
     @objc public func pauseAudio() {
         stopAudio()
         running = false
-        // Flush ring buffers after stopping to prevent race with render callback (#3183)
+        // Flush ring buffers after stopping engine and before emulator resumes (#3183).
+        // Safe because the emulator core's frame loop is also paused when the pause menu opens,
+        // so neither the producer (core) nor consumer (render callback) should be active.
         for context in _contexts {
             context.buffer?.reset()
         }

--- a/PVCoreAudio/Sources/PVCoreAudio/Engines/AudioUnitGameAudioEngine.swift
+++ b/PVCoreAudio/Sources/PVCoreAudio/Engines/AudioUnitGameAudioEngine.swift
@@ -297,12 +297,12 @@ public final class AudioUnitGameAudioEngine: NSObject, AudioEngineProtocol {
 
     /// Audio control methods
     @objc public func pauseAudio() {
-        // Flush ring buffers before stopping to prevent stale audio from looping (#3183)
+        stopAudio()
+        running = false
+        // Flush ring buffers after stopping to prevent race with render callback (#3183)
         for context in _contexts {
             context.buffer?.reset()
         }
-        stopAudio()
-        running = false
     }
 
     @objc public func startAudio() throws {

--- a/PVCoreAudio/Sources/PVCoreAudio/Engines/AudioUnitGameAudioEngine.swift
+++ b/PVCoreAudio/Sources/PVCoreAudio/Engines/AudioUnitGameAudioEngine.swift
@@ -299,9 +299,17 @@ public final class AudioUnitGameAudioEngine: NSObject, AudioEngineProtocol {
     @objc public func pauseAudio() {
         stopAudio()
         running = false
-        // Flush stale audio data after stopping the consumer (#3183).
+        // Drain stale audio data after stopping the consumer (#3183).
+        // Use clear() instead of reset() to avoid deallocating/reinitialising
+        // the backing buffer while the emulator core may still be writing.
+        // Deduplicate by buffer identity so each ring buffer is cleared once,
+        // even if _contexts has grown across multiple setupAudioGraph calls.
+        var seen = Set<ObjectIdentifier>()
         for context in _contexts {
-            context.buffer?.reset()
+            guard let buf = context.buffer else { continue }
+            let id = ObjectIdentifier(buf as AnyObject)
+            guard seen.insert(id).inserted else { continue }
+            buf.clear()
         }
     }
 

--- a/PVCoreAudio/Sources/PVCoreAudio/Engines/AudioUnitGameAudioEngine.swift
+++ b/PVCoreAudio/Sources/PVCoreAudio/Engines/AudioUnitGameAudioEngine.swift
@@ -299,11 +299,12 @@ public final class AudioUnitGameAudioEngine: NSObject, AudioEngineProtocol {
     @objc public func pauseAudio() {
         stopAudio()
         running = false
-        // Flush ring buffers after stopping engine and before emulator resumes (#3183).
-        // Safe because the emulator core's frame loop is also paused when the pause menu opens,
-        // so neither the producer (core) nor consumer (render callback) should be active.
-        for context in _contexts {
-            context.buffer?.reset()
+        // Flush ring buffers after stopping engine (#3183).
+        // Only reset when core is paused to avoid racing the producer thread.
+        if let core = gameCore, core.isEmulationPaused {
+            for context in _contexts {
+                context.buffer?.reset()
+            }
         }
     }
 

--- a/PVCoreAudio/Sources/PVCoreAudio/Engines/AudioUnitGameAudioEngine.swift
+++ b/PVCoreAudio/Sources/PVCoreAudio/Engines/AudioUnitGameAudioEngine.swift
@@ -299,12 +299,9 @@ public final class AudioUnitGameAudioEngine: NSObject, AudioEngineProtocol {
     @objc public func pauseAudio() {
         stopAudio()
         running = false
-        // Flush ring buffers after stopping engine (#3183).
-        // Only reset when core is paused to avoid racing the producer thread.
-        if let core = gameCore, core.isEmulationPaused {
-            for context in _contexts {
-                context.buffer?.reset()
-            }
+        // Flush stale audio data after stopping the consumer (#3183).
+        for context in _contexts {
+            context.buffer?.reset()
         }
     }
 

--- a/PVCoreAudio/Sources/PVCoreAudio/Engines/DSPGameAudioEngine.swift
+++ b/PVCoreAudio/Sources/PVCoreAudio/Engines/DSPGameAudioEngine.swift
@@ -233,7 +233,9 @@ final public class DSPGameAudioEngine: AudioEngineProtocol {
         guard isRunning else { return }
         engine.pause()
         isRunning = false
-        // Flush ring buffer after pausing to prevent race with render callback (#3183)
+        // Flush ring buffer after pausing engine and before emulator resumes (#3183).
+        // Safe because the emulator core's frame loop is also paused when the pause menu opens,
+        // so neither the producer (core) nor consumer (render callback) should be active.
         gameCore?.ringBuffer(atIndex: 0)?.reset()
     }
 

--- a/PVCoreAudio/Sources/PVCoreAudio/Engines/DSPGameAudioEngine.swift
+++ b/PVCoreAudio/Sources/PVCoreAudio/Engines/DSPGameAudioEngine.swift
@@ -233,11 +233,8 @@ final public class DSPGameAudioEngine: AudioEngineProtocol {
         guard isRunning else { return }
         engine.pause()
         isRunning = false
-        // Flush ring buffer after pausing engine (#3183).
-        // Only reset when core is paused to avoid racing the producer thread.
-        if let core = gameCore, core.isEmulationPaused {
-            core.ringBuffer(atIndex: 0)?.reset()
-        }
+        // Flush stale audio data after stopping the consumer (#3183).
+        gameCore?.ringBuffer(atIndex: 0)?.reset()
     }
 
     private func configureAudioSession() {

--- a/PVCoreAudio/Sources/PVCoreAudio/Engines/DSPGameAudioEngine.swift
+++ b/PVCoreAudio/Sources/PVCoreAudio/Engines/DSPGameAudioEngine.swift
@@ -233,10 +233,11 @@ final public class DSPGameAudioEngine: AudioEngineProtocol {
         guard isRunning else { return }
         engine.pause()
         isRunning = false
-        // Flush ring buffer after pausing engine and before emulator resumes (#3183).
-        // Safe because the emulator core's frame loop is also paused when the pause menu opens,
-        // so neither the producer (core) nor consumer (render callback) should be active.
-        gameCore?.ringBuffer(atIndex: 0)?.reset()
+        // Flush ring buffer after pausing engine (#3183).
+        // Only reset when core is paused to avoid racing the producer thread.
+        if let core = gameCore, core.isEmulationPaused {
+            core.ringBuffer(atIndex: 0)?.reset()
+        }
     }
 
     private func configureAudioSession() {

--- a/PVCoreAudio/Sources/PVCoreAudio/Engines/DSPGameAudioEngine.swift
+++ b/PVCoreAudio/Sources/PVCoreAudio/Engines/DSPGameAudioEngine.swift
@@ -231,10 +231,10 @@ final public class DSPGameAudioEngine: AudioEngineProtocol {
 
     public func pauseAudio() {
         guard isRunning else { return }
-        // Flush ring buffer before pausing to prevent stale audio from looping (#3183)
-        gameCore?.ringBuffer(atIndex: 0)?.reset()
         engine.pause()
         isRunning = false
+        // Flush ring buffer after pausing to prevent race with render callback (#3183)
+        gameCore?.ringBuffer(atIndex: 0)?.reset()
     }
 
     private func configureAudioSession() {

--- a/PVCoreAudio/Sources/PVCoreAudio/Engines/DSPGameAudioEngine.swift
+++ b/PVCoreAudio/Sources/PVCoreAudio/Engines/DSPGameAudioEngine.swift
@@ -233,8 +233,10 @@ final public class DSPGameAudioEngine: AudioEngineProtocol {
         guard isRunning else { return }
         engine.pause()
         isRunning = false
-        // Flush stale audio data after stopping the consumer (#3183).
-        gameCore?.ringBuffer(atIndex: 0)?.reset()
+        // Drain stale audio data after stopping the consumer (#3183).
+        // Use clear() instead of reset() to avoid deallocating/reinitialising
+        // the backing buffer while the emulator core may still be writing.
+        gameCore?.ringBuffer(atIndex: 0)?.clear()
     }
 
     private func configureAudioSession() {

--- a/PVCoreAudio/Sources/PVCoreAudio/Engines/DSPGameAudioEngine.swift
+++ b/PVCoreAudio/Sources/PVCoreAudio/Engines/DSPGameAudioEngine.swift
@@ -231,6 +231,8 @@ final public class DSPGameAudioEngine: AudioEngineProtocol {
 
     public func pauseAudio() {
         guard isRunning else { return }
+        // Flush ring buffer before pausing to prevent stale audio from looping (#3183)
+        gameCore?.ringBuffer(atIndex: 0)?.reset()
         engine.pause()
         isRunning = false
     }


### PR DESCRIPTION
## Summary
- Added `ringBuffer.clear()` calls AFTER pausing/stopping in all 3 audio engines
- AudioUnitGameAudioEngine: stops AUGraph first, then clears each ring buffer
- AVAudioEngineGameAudioEngine: pauses engine first, then clears ring buffer
- DSPGameAudioEngine: pauses engine first, then clears ring buffer
- Uses `clear()` (non-reallocating drain via `TPCircularBufferClear`) instead of
  `reset()` (which calls `TPCircularBufferCleanup/Init`), preventing unsafe
  deallocation while the emulator core may still be writing audio samples
- Deduplicates buffer clears in AudioUnitGameAudioEngine so repeated
  `setupAudioGraph` calls do not clear the same buffer multiple times
- Prevents stale audio data from looping when pause menu opens

Closes #3183

## Test plan
- [ ] Start a game and let audio play
- [ ] Open pause menu — should be silent, no looping audio artifact
- [ ] Resume game — audio should continue normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
