### PR TITLE
[Agent] fix(ui): stop HomeView flickering with ViewModel pattern (#3184)

### DIFF
--- a/.changelog/3196.md
+++ b/.changelog/3196.md
@@ -1,0 +1,3 @@
+### Fixed
+- **HomeView sort sync** — `homeViewModel.sortAscending` now stays in sync with `viewModel.sortGamesAscending` via `onChange` while the view is visible, not only on appear.
+- **HomeView game resolution** — Factored duplicate MD5-resolution logic into a single `resolveGame(md5:)` helper shared by `liveGame(for:)` and `launchGame(md5:)`; added warning log when a game cannot be resolved.

--- a/PVUI/Sources/PVSwiftUI/Home/HomeView.swift
+++ b/PVUI/Sources/PVSwiftUI/Home/HomeView.swift
@@ -682,7 +682,7 @@ struct HomeView: SwiftUI.View {
         } else {
             count = min(max(0, roundedScale), allGames.count)
         }
-        return count
+        return max(1, count)
     }
 
 

--- a/PVUI/Sources/PVSwiftUI/Home/HomeView.swift
+++ b/PVUI/Sources/PVSwiftUI/Home/HomeView.swift
@@ -270,6 +270,9 @@ struct HomeView: SwiftUI.View {
             // Consume any pending search action from LibraryNavigator (covers cold-launch).
             consumePendingSearch()
         }
+        .onChange(of: viewModel.sortGamesAscending) { newValue in
+            homeViewModel.sortAscending = newValue
+        }
         .onChange(of: GamepadManager.shared.isControllerConnected) { isConnected in
             isControllerConnected = isConnected
             if isConnected {
@@ -814,12 +817,13 @@ struct HomeView: SwiftUI.View {
 
     // MARK: - Realm resolution helpers
 
-    /// Resolve a live `PVGame` from the main-thread Realm for a snapshot model.
-    private func liveGame(for model: GameCellModel) -> PVGame? {
+    /// Resolve a live `PVGame` from the main-thread Realm by MD5.
+    /// Tries the raw casing first, then uppercase and lowercase variants.
+    @MainActor
+    private func resolveGame(md5: String) -> PVGame? {
         let realm = RomDatabase.sharedInstance.realm
-        let candidates = [model.md5, model.md5.uppercased(), model.md5.lowercased()]
         var seen = Set<String>()
-        for key in candidates where seen.insert(key).inserted {
+        for key in [md5, md5.uppercased(), md5.lowercased()] where seen.insert(key).inserted {
             if let game = realm.object(ofType: PVGame.self, forPrimaryKey: key) {
                 return game
             }
@@ -827,16 +831,18 @@ struct HomeView: SwiftUI.View {
         return nil
     }
 
+    /// Resolve a live `PVGame` from the main-thread Realm for a snapshot model.
+    private func liveGame(for model: GameCellModel) -> PVGame? {
+        resolveGame(md5: model.md5)
+    }
+
     /// Launch a game by MD5, resolving the Realm object on the main thread.
     func launchGame(md5: String) {
         Task { @MainActor in
-            let realm = RomDatabase.sharedInstance.realm
-            let candidates = [md5, md5.uppercased(), md5.lowercased()]
-            var seen = Set<String>()
-            guard let game = candidates.lazy.compactMap({ key -> PVGame? in
-                guard seen.insert(key).inserted else { return nil }
-                return realm.object(ofType: PVGame.self, forPrimaryKey: key)
-            }).first else { return }
+            guard let game = resolveGame(md5: md5) else {
+                WLOG("HomeView: could not resolve PVGame for md5 '\(md5)' — object may have been deleted")
+                return
+            }
             SceneCoordinator.shared.launchGame(game.freeze())
         }
     }

--- a/PVUI/Sources/PVSwiftUI/Home/HomeView.swift
+++ b/PVUI/Sources/PVSwiftUI/Home/HomeView.swift
@@ -765,7 +765,7 @@ struct HomeView: SwiftUI.View {
                 ) {
                     launchGame(md5: model.md5)
                 }
-                .id(model.hashValue)
+                .id(model.id)
                 .contextMenu {
                     if let live = liveGame(for: model) {
                         GameContextMenu(game: live, rootDelegate: rootDelegate, contextMenuDelegate: self)
@@ -801,7 +801,7 @@ struct HomeView: SwiftUI.View {
                 ) {
                     launchGame(md5: model.md5)
                 }
-                .id(model.hashValue)
+                .id(model.id)
                 .focusableIfAvailable()
                 .contextMenu {
                     if let live = liveGame(for: model) {
@@ -1154,7 +1154,7 @@ struct HomeView: SwiftUI.View {
         ) {
             launchGame(md5: model.md5)
         }
-        .id(model.hashValue)
+        .id(model.id)
         .focusableIfAvailable()
         .contextMenu {
             if let live = liveGame(for: model) {
@@ -1307,7 +1307,7 @@ struct HomeView: SwiftUI.View {
                         ) {
                             launchGame(md5: model.md5)
                         }
-                        .id(model.hashValue)
+                        .id(model.id)
                         .focusableIfAvailable()
                         .contextMenu {
                             if let live = liveGame(for: model) {

--- a/PVUI/Sources/PVSwiftUI/Home/HomeView.swift
+++ b/PVUI/Sources/PVSwiftUI/Home/HomeView.swift
@@ -54,7 +54,7 @@ struct HomeView: SwiftUI.View {
     /// Manages game-related Realm observations on a background queue,
     /// publishing immutable snapshots to avoid excessive SwiftUI invalidation.
     /// Fixes #3184: HomeView flickering/reloading caused by multiple @ObservedResults.
-    @StateObject private var homeViewModel = HomeViewModel()
+    @StateObject private var homeViewModel: HomeViewModel
 
     // Convenience accessors matching old @ObservedResults names for minimal diff.
     private var recentlyPlayedGames: [GameCellModel] { homeViewModel.recentlyPlayedModels }
@@ -105,6 +105,7 @@ struct HomeView: SwiftUI.View {
         self.rootDelegate = delegate
         self.viewModel = viewModel
         self.showGameInfo = showGameInfo
+        self._homeViewModel = StateObject(wrappedValue: HomeViewModel(sortAscending: viewModel.sortGamesAscending))
 
     }
 
@@ -765,7 +766,6 @@ struct HomeView: SwiftUI.View {
                 ) {
                     launchGame(md5: model.md5)
                 }
-                .id(model.id)
                 .contextMenu {
                     if let live = liveGame(for: model) {
                         GameContextMenu(game: live, rootDelegate: rootDelegate, contextMenuDelegate: self)
@@ -801,7 +801,6 @@ struct HomeView: SwiftUI.View {
                 ) {
                     launchGame(md5: model.md5)
                 }
-                .id(model.id)
                 .focusableIfAvailable()
                 .contextMenu {
                     if let live = liveGame(for: model) {
@@ -1154,7 +1153,6 @@ struct HomeView: SwiftUI.View {
         ) {
             launchGame(md5: model.md5)
         }
-        .id(model.id)
         .focusableIfAvailable()
         .contextMenu {
             if let live = liveGame(for: model) {
@@ -1307,7 +1305,6 @@ struct HomeView: SwiftUI.View {
                         ) {
                             launchGame(md5: model.md5)
                         }
-                        .id(model.id)
                         .focusableIfAvailable()
                         .contextMenu {
                             if let live = liveGame(for: model) {

--- a/PVUI/Sources/PVSwiftUI/Home/HomeView.swift
+++ b/PVUI/Sources/PVSwiftUI/Home/HomeView.swift
@@ -51,29 +51,16 @@ struct HomeView: SwiftUI.View {
         sortDescriptor: SortDescriptor(keyPath: #keyPath(PVSaveState.date), ascending: false)
     ) var recentSaveStates
 
-    @ObservedResults(
-        PVRecentGame.self,
-        sortDescriptor: SortDescriptor(keyPath: #keyPath(PVRecentGame.lastPlayedDate), ascending: false)
-    ) var recentlyPlayedGames
+    /// Manages game-related Realm observations on a background queue,
+    /// publishing immutable snapshots to avoid excessive SwiftUI invalidation.
+    /// Fixes #3184: HomeView flickering/reloading caused by multiple @ObservedResults.
+    @StateObject private var homeViewModel = HomeViewModel()
 
-    @ObservedResults(
-        PVGame.self,
-        filter: NSPredicate(format: "\(#keyPath(PVGame.isFavorite)) == %@", NSNumber(value: true)),
-        sortDescriptor: SortDescriptor(keyPath: #keyPath(PVGame.title), ascending: false)
-    ) var favorites
-
-    @ObservedResults(
-        PVGame.self,
-        filter: NSPredicate(format: "playCount > 0"),
-        sortDescriptor: SortDescriptor(keyPath: #keyPath(PVGame.playCount), ascending: false)
-    ) var mostPlayed
-
-    /// Sorted by systemIdentifier, then title
-    @ObservedResults(
-        PVGame.self,
-        sortDescriptor: .init(keyPath: \PVGame.title, ascending: false)
-    ) var allGames
-    // RomDatabase.sharedInstance.allGamesSortedBySystemThenTitle
+    // Convenience accessors matching old @ObservedResults names for minimal diff.
+    private var recentlyPlayedGames: [GameCellModel] { homeViewModel.recentlyPlayedModels }
+    private var favorites: [GameCellModel] { homeViewModel.favoritesModels }
+    private var mostPlayed: [GameCellModel] { homeViewModel.mostPlayedModels }
+    private var allGames: [GameCellModel] { homeViewModel.allGamesModels }
 
     @State private var gamepadCancellable: AnyCancellable?
 
@@ -119,10 +106,6 @@ struct HomeView: SwiftUI.View {
         self.viewModel = viewModel
         self.showGameInfo = showGameInfo
 
-        _allGames = ObservedResults(
-            PVGame.self,
-            sortDescriptor: SortDescriptor(keyPath: #keyPath(PVGame.title), ascending: viewModel.sortGamesAscending)
-        )
     }
 
     @ObservedObject private var themeManager = ThemeManager.shared
@@ -274,6 +257,7 @@ struct HomeView: SwiftUI.View {
         .onAppear {
             adjustZoomLevel(for: gameLibraryScale)
             setupGamepadHandling()
+            homeViewModel.sortAscending = viewModel.sortGamesAscending
 
             // Check initial controller connection state
             isControllerConnected = GamepadManager.shared.isControllerConnected
@@ -729,7 +713,10 @@ struct HomeView: SwiftUI.View {
             },
             settingsContext: .home,
             toggleFilterAction: { self.rootDelegate?.showUnderConstructionAlert() },
-            toggleSortAction: { viewModel.sortGamesAscending.toggle() },
+            toggleSortAction: {
+                viewModel.sortGamesAscending.toggle()
+                homeViewModel.sortAscending = viewModel.sortGamesAscending
+            },
             toggleViewTypeAction: { viewModel.viewGamesAsGrid.toggle() }
         )
         .padding(.vertical, 12)
@@ -755,84 +742,104 @@ struct HomeView: SwiftUI.View {
     }
 
     @ViewBuilder
-    private func showGamesList(_ games: Results<PVGame>) -> some View {
+    private func showGamesList(_ games: [GameCellModel]) -> some View {
         LazyVStack(spacing: 8) {
-            ForEach(games, id: \.self) { game in
-                if !game.isInvalidated {
-                    GameItemView(
-                        game: game,
-                        constrainHeight: true,
-                        viewType: .row,
-                        sectionContext: .allGames,
-                        isFocused: Binding(
-                            get: {
-                                !game.isInvalidated &&
-                                focusedSection == .allGames &&
-                                focusedItemInSection == game.id
-                            },
-                            set: {
-                                if $0 {
-                                    focusedSection = .allGames
-                                    focusedItemInSection = game.id
-                                }
+            ForEach(games, id: \.id) { model in
+                GameItemPresentableView(
+                    game: model,
+                    constrainHeight: true,
+                    viewType: .row,
+                    sectionContext: .allGames,
+                    isFocused: Binding(
+                        get: {
+                            focusedSection == .allGames &&
+                            focusedItemInSection == model.id
+                        },
+                        set: {
+                            if $0 {
+                                focusedSection = .allGames
+                                focusedItemInSection = model.id
                             }
-                        )
-                    ) {
-                        Task.detached { @MainActor in
-                            SceneCoordinator.shared.launchGame(game.freeze())
                         }
+                    )
+                ) {
+                    launchGame(md5: model.md5)
+                }
+                .id(model.hashValue)
+                .contextMenu {
+                    if let live = liveGame(for: model) {
+                        GameContextMenu(game: live, rootDelegate: rootDelegate, contextMenuDelegate: self)
                     }
-                    .contextMenu { GameContextMenu(game: game, rootDelegate: rootDelegate, contextMenuDelegate: self) }
                 }
             }
         }
     }
 
     @ViewBuilder
-    private func showGamesGrid(_ games: Results<PVGame>) -> some View {
-        var gameLibraryItemsPerRow: Int {
-            let gamesPerRow = min(8, games.count)
-            return gamesPerRow.isMultiple(of: 2) ? gamesPerRow : gamesPerRow + 1
-        }
-
+    private func showGamesGrid(_ games: [GameCellModel]) -> some View {
         let columns = Array(repeating: GridItem(.flexible(), spacing: 10), count: itemsPerRow)
 
-        return LazyVGrid(columns: columns, spacing: 10) {
-            ForEach(games, id: \.self) { game in
-                gameGridItem(game)
+        LazyVGrid(columns: columns, spacing: 10) {
+            ForEach(games, id: \.id) { model in
+                GameItemPresentableView(
+                    game: model,
+                    constrainHeight: true,
+                    viewType: .cell,
+                    sectionContext: .allGames,
+                    isFocused: Binding(
+                        get: {
+                            focusedSection == .allGames &&
+                            focusedItemInSection == model.id
+                        },
+                        set: {
+                            if $0 {
+                                focusedSection = .allGames
+                                focusedItemInSection = model.id
+                            }
+                        }
+                    )
+                ) {
+                    launchGame(md5: model.md5)
+                }
+                .id(model.hashValue)
+                .focusableIfAvailable()
+                .contextMenu {
+                    if let live = liveGame(for: model) {
+                        GameContextMenu(game: live, rootDelegate: rootDelegate, contextMenuDelegate: self)
+                    }
+                }
             }
         }
         .padding(.horizontal, 10)
     }
 
-    /// Creates a grid item view for a game with focus and context menu
-    @ViewBuilder
-    private func gameGridItem(_ game: PVGame) -> some View {
-        GameItemView(
-            game: game,
-            constrainHeight: true,
-            viewType: .cell,
-            sectionContext: .allGames,
-            isFocused: Binding(
-                get: {
-                    !game.isInvalidated &&
-                    focusedSection == .allGames &&
-                    focusedItemInSection == game.id
-                },
-                set: {
-                    if $0 {
-                        focusedSection = .allGames
-                        focusedItemInSection = game.id
-                    }
-                }
-            )
-        ) {
-            Task.detached { @MainActor in
-                SceneCoordinator.shared.launchGame(game.freeze())
+    // MARK: - Realm resolution helpers
+
+    /// Resolve a live `PVGame` from the main-thread Realm for a snapshot model.
+    private func liveGame(for model: GameCellModel) -> PVGame? {
+        let realm = RomDatabase.sharedInstance.realm
+        let candidates = [model.md5, model.md5.uppercased(), model.md5.lowercased()]
+        var seen = Set<String>()
+        for key in candidates where seen.insert(key).inserted {
+            if let game = realm.object(ofType: PVGame.self, forPrimaryKey: key) {
+                return game
             }
         }
-        .focusableIfAvailable()
-        .contextMenu { GameContextMenu(game: game, rootDelegate: rootDelegate, contextMenuDelegate: self) }
+        return nil
+    }
+
+    /// Launch a game by MD5, resolving the Realm object on the main thread.
+    func launchGame(md5: String) {
+        Task.detached { @MainActor in
+            let realm = RomDatabase.sharedInstance.realm
+            let candidates = [md5, md5.uppercased(), md5.lowercased()]
+            var seen = Set<String>()
+            guard let game = candidates.lazy.compactMap({ key -> PVGame? in
+                guard seen.insert(key).inserted else { return nil }
+                return realm.object(ofType: PVGame.self, forPrimaryKey: key)
+            }).first else { return }
+            SceneCoordinator.shared.launchGame(game.freeze())
+        }
     }
 
     // MARK: - GamepadNavigationDelegate
@@ -849,16 +856,12 @@ struct HomeView: SwiftUI.View {
                 }
             }
         case .recentlyPlayedGames:
-            if let game = recentlyPlayedGames.first(where: { $0.game?.id == itemId })?.game {
-                Task.detached { @MainActor in
-                    SceneCoordinator.shared.launchGame(game.freeze())
-                }
+            if let model = recentlyPlayedGames.first(where: { $0.id == itemId }) {
+                launchGame(md5: model.md5)
             }
         case .favorites, .mostPlayed, .allGames:
-            if let game = allGames.first(where: { $0.id == itemId }) {
-                Task.detached { @MainActor in
-                    SceneCoordinator.shared.launchGame(game.freeze())
-                }
+            if let model = allGames.first(where: { $0.id == itemId }) {
+                launchGame(md5: model.md5)
             }
         }
     }
@@ -1008,7 +1011,7 @@ struct HomeView: SwiftUI.View {
         case .recentSaveStates:
             return recentSaveStateIDs.last
         case .recentlyPlayedGames:
-            return recentlyPlayedGames.last?.game?.id
+            return recentlyPlayedGames.last?.id
         case .favorites:
             return favorites.last?.id
         case .mostPlayed:
@@ -1023,7 +1026,7 @@ struct HomeView: SwiftUI.View {
         case .recentSaveStates:
             return recentSaveStateIDs
         case .recentlyPlayedGames:
-            return recentlyPlayedGames.compactMap { $0.game?.id }
+            return recentlyPlayedGames.map { $0.id }
         case .favorites:
             return favorites.map { $0.id }
         case .mostPlayed:
@@ -1038,7 +1041,7 @@ struct HomeView: SwiftUI.View {
         case .recentSaveStates:
             return recentSaveStateIDs.first
         case .recentlyPlayedGames:
-            return recentlyPlayedGames.first?.game?.id
+            return recentlyPlayedGames.first?.id
         case .favorites:
             return favorites.first?.id
         case .mostPlayed:
@@ -1098,32 +1101,8 @@ struct HomeView: SwiftUI.View {
     private func recentlyPlayedSection() -> some View {
         if showRecentGames {
             HomeSection(title: String(localized: "Recently Played")) {
-                ForEach(recentlyPlayedGames.compactMap{$0.game}, id: \.self) { game in
-                    GameItemView(
-                        game: game,
-                        constrainHeight: true,
-                        viewType: .cell,
-                        sectionContext: .recentlyPlayedGames,
-                        isFocused: Binding(
-                            get: {
-                                !game.isInvalidated &&
-                                focusedSection == .recentlyPlayedGames &&
-                                focusedItemInSection == game.id
-                            },
-                            set: {
-                                if $0 {
-                                    focusedSection = .recentlyPlayedGames
-                                    focusedItemInSection = game.id
-                                }
-                            }
-                        )
-                    ) {
-                        Task.detached { @MainActor in
-                            SceneCoordinator.shared.launchGame(game.freeze())
-                        }
-                    }
-                    .focusableIfAvailable()
-                    .contextMenu { GameContextMenu(game: game, rootDelegate: rootDelegate, contextMenuDelegate: self) }
+                ForEach(recentlyPlayedGames, id: \.id) { model in
+                    gameItem(model, section: .recentlyPlayedGames)
                 }
             }
             HomeDividerView()
@@ -1134,32 +1113,8 @@ struct HomeView: SwiftUI.View {
     private func favoritesSection() -> some View {
         if showFavorites {
             HomeSection(title: String(localized: "Favorites")) {
-                ForEach(favorites, id: \.self) { favorite in
-                    GameItemView(
-                        game: favorite,
-                        constrainHeight: true,
-                        viewType: .cell,
-                        sectionContext: .favorites,
-                        isFocused: Binding(
-                            get: {
-                                !favorite.isInvalidated &&
-                                focusedSection == .favorites &&
-                                focusedItemInSection == favorite.id
-                            },
-                            set: {
-                                if $0 {
-                                    focusedSection = .favorites
-                                    focusedItemInSection = favorite.id
-                                }
-                            }
-                        )
-                    ) {
-                        Task.detached { @MainActor in
-                            SceneCoordinator.shared.launchGame(favorite.freeze())
-                        }
-                    }
-                    .focusableIfAvailable()
-                    .contextMenu { GameContextMenu(game: favorite, rootDelegate: rootDelegate, contextMenuDelegate: self) }
+                ForEach(favorites, id: \.id) { model in
+                    gameItem(model, section: .favorites)
                 }
             }
             HomeDividerView()
@@ -1169,35 +1124,43 @@ struct HomeView: SwiftUI.View {
     @ViewBuilder
     private func mostPlayedSection() -> some View {
         HomeSection(title: "Most Played") {
-            ForEach(mostPlayed, id: \.self) { playedGame in
-                GameItemView(
-                    game: playedGame,
-                    constrainHeight: true,
-                    viewType: .cell,
-                    sectionContext: .mostPlayed,
-                    isFocused: Binding(
-                        get: {
-                            !playedGame.isInvalidated &&
-                            focusedSection == .mostPlayed &&
-                            focusedItemInSection == playedGame.id
-                        },
-                        set: {
-                            if $0 {
-                                focusedSection = .mostPlayed
-                                focusedItemInSection = playedGame.id
-                            }
-                        }
-                    )
-                ) {
-                    Task.detached { @MainActor in
-                        SceneCoordinator.shared.launchGame(playedGame.freeze())
-                    }
-                }
-                .focusableIfAvailable()
-                .contextMenu { GameContextMenu(game: playedGame, rootDelegate: rootDelegate, contextMenuDelegate: self) }
+            ForEach(mostPlayed, id: \.id) { model in
+                gameItem(model, section: .mostPlayed)
             }
         }
         HomeDividerView()
+    }
+
+    /// Shared game item builder used by all horizontal carousel sections.
+    @ViewBuilder
+    private func gameItem(_ model: GameCellModel, section: HomeSectionType) -> some View {
+        GameItemPresentableView(
+            game: model,
+            constrainHeight: true,
+            viewType: .cell,
+            sectionContext: section,
+            isFocused: Binding(
+                get: {
+                    focusedSection == section &&
+                    focusedItemInSection == model.id
+                },
+                set: {
+                    if $0 {
+                        focusedSection = section
+                        focusedItemInSection = model.id
+                    }
+                }
+            )
+        ) {
+            launchGame(md5: model.md5)
+        }
+        .id(model.hashValue)
+        .focusableIfAvailable()
+        .contextMenu {
+            if let live = liveGame(for: model) {
+                GameContextMenu(game: live, rootDelegate: rootDelegate, contextMenuDelegate: self)
+            }
+        }
     }
 
     private func setInitialFocus() {
@@ -1297,13 +1260,13 @@ struct HomeView: SwiftUI.View {
     }
 
     /// Function to filter games based on search text
-    private func filteredSearchResults() -> [PVGame] {
+    private func filteredSearchResults() -> [GameCellModel] {
         guard !searchText.isEmpty else { return [] }
 
         let searchTextLowercased = searchText.lowercased()
-        return Array(allGames.filter { game in
-            game.title.lowercased().contains(searchTextLowercased)
-        })
+        return allGames.filter { model in
+            model.title.lowercased().contains(searchTextLowercased)
+        }
     }
 
     @ViewBuilder
@@ -1323,32 +1286,34 @@ struct HomeView: SwiftUI.View {
                         .shadow(color: RetroTheme.retroBlue.opacity(0.7), radius: 3, x: 0, y: 0)
                         .padding()
                 } else {
-                    ForEach(results, id: \.self) { game in
-                        GameItemView(
-                            game: game,
+                    ForEach(results, id: \.id) { model in
+                        GameItemPresentableView(
+                            game: model,
                             constrainHeight: true,
                             viewType: .row,
                             sectionContext: .allGames,
                             isFocused: Binding(
                                 get: {
-                                    !game.isInvalidated &&
                                     focusedSection == .allGames &&
-                                    focusedItemInSection == game.id
+                                    focusedItemInSection == model.id
                                 },
                                 set: {
                                     if $0 {
                                         focusedSection = .allGames
-                                        focusedItemInSection = game.id
+                                        focusedItemInSection = model.id
                                     }
                                 }
                             )
                         ) {
-                            Task.detached { @MainActor in
-                                SceneCoordinator.shared.launchGame(game.freeze())
+                            launchGame(md5: model.md5)
+                        }
+                        .id(model.hashValue)
+                        .focusableIfAvailable()
+                        .contextMenu {
+                            if let live = liveGame(for: model) {
+                                GameContextMenu(game: live, rootDelegate: rootDelegate, contextMenuDelegate: self)
                             }
                         }
-                        .focusableIfAvailable()
-                        .contextMenu { GameContextMenu(game: game, rootDelegate: rootDelegate, contextMenuDelegate: self) }
                         GamesDividerView()
                     }
                 }

--- a/PVUI/Sources/PVSwiftUI/Home/HomeView.swift
+++ b/PVUI/Sources/PVSwiftUI/Home/HomeView.swift
@@ -829,7 +829,7 @@ struct HomeView: SwiftUI.View {
 
     /// Launch a game by MD5, resolving the Realm object on the main thread.
     func launchGame(md5: String) {
-        Task.detached { @MainActor in
+        Task { @MainActor in
             let realm = RomDatabase.sharedInstance.realm
             let candidates = [md5, md5.uppercased(), md5.lowercased()]
             var seen = Set<String>()
@@ -850,7 +850,7 @@ struct HomeView: SwiftUI.View {
         switch section {
         case .recentSaveStates:
             if let saveState = recentSaveStates.first(where: { $0.id == itemId }) {
-                Task.detached { @MainActor in
+                Task { @MainActor in
                     SceneCoordinator.shared.launchSaveState(saveState.freeze(), core: saveState.core?.freeze())
                 }
             }

--- a/PVUI/Sources/PVSwiftUI/Home/HomeViewModel.swift
+++ b/PVUI/Sources/PVSwiftUI/Home/HomeViewModel.swift
@@ -121,7 +121,7 @@ final class HomeViewModel: ObservableObject {
                 let mostPlayed = realm.objects(PVGame.self)
                     .filter("playCount > 0")
                 self.mostPlayedToken = mostPlayed.observe(
-                    keyPaths: ["playCount", "title", "isFavorite", "customArtworkURL", "originalArtworkURL"],
+                    keyPaths: GameCellModel.observedKeyPaths,
                     on: self.modelsQueue
                 ) { [weak self] change in
                     autoreleasepool {

--- a/PVUI/Sources/PVSwiftUI/Home/HomeViewModel.swift
+++ b/PVUI/Sources/PVSwiftUI/Home/HomeViewModel.swift
@@ -32,6 +32,7 @@ final class HomeViewModel: ObservableObject {
     /// Sort direction - toggling re-sorts the cached models without a Realm re-query.
     @Published var sortAscending: Bool = true {
         didSet {
+            guard oldValue != sortAscending else { return }
             Task { @MainActor in
                 resortModelsOnMain()
             }

--- a/PVUI/Sources/PVSwiftUI/Home/HomeViewModel.swift
+++ b/PVUI/Sources/PVSwiftUI/Home/HomeViewModel.swift
@@ -121,7 +121,7 @@ final class HomeViewModel: ObservableObject {
                 let mostPlayed = realm.objects(PVGame.self)
                     .filter("playCount > 0")
                 self.mostPlayedToken = mostPlayed.observe(
-                    keyPaths: ["playCount", "title"],
+                    keyPaths: ["playCount", "title", "isFavorite", "customArtworkURL", "originalArtworkURL"],
                     on: self.modelsQueue
                 ) { [weak self] change in
                     autoreleasepool {
@@ -226,7 +226,7 @@ final class HomeViewModel: ObservableObject {
                 guard !recent.isInvalidated,
                       let game = recent.game,
                       !game.isInvalidated else { return nil }
-                return game.md5Hash.uppercased()
+                return game.md5Hash
             }
 
             let models = recentMD5Order.compactMap { modelsByMD5[$0] }
@@ -248,8 +248,9 @@ final class HomeViewModel: ObservableObject {
     }
 
     private func sorted(_ models: [GameCellModel]) -> [GameCellModel] {
-        models.sorted { lhs, rhs in
-            if sortAscending {
+        let ascending = sortAscending
+        return models.sorted { lhs, rhs in
+            if ascending {
                 return lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedAscending
             } else {
                 return lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedDescending

--- a/PVUI/Sources/PVSwiftUI/Home/HomeViewModel.swift
+++ b/PVUI/Sources/PVSwiftUI/Home/HomeViewModel.swift
@@ -1,1 +1,267 @@
- 
+//
+//  HomeViewModel.swift
+//  PVUI
+//
+//  Created by Joseph Mattiello on 3/15/26.
+//
+
+#if canImport(SwiftUI)
+import SwiftUI
+import RealmSwift
+import PVLibrary
+import PVRealm
+import PVUIBase
+import Combine
+
+/// View model for HomeView that observes Realm collections on a background queue
+/// and publishes immutable snapshot models. This prevents the excessive SwiftUI
+/// view invalidation caused by multiple `@ObservedResults` property wrappers
+/// each independently triggering re-renders on any Realm write.
+///
+/// Modelled after `ConsoleGamesViewModel` which does not have the flickering issue.
+@available(iOS 14, tvOS 14, *)
+final class HomeViewModel: ObservableObject {
+
+    // MARK: - Published snapshot models
+
+    @Published var allGamesModels: [GameCellModel] = []
+    @Published var favoritesModels: [GameCellModel] = []
+    @Published var recentlyPlayedModels: [GameCellModel] = []
+    @Published var mostPlayedModels: [GameCellModel] = []
+
+    /// Sort direction - toggling re-sorts the cached models without a Realm re-query.
+    @Published var sortAscending: Bool = true {
+        didSet {
+            Task { @MainActor in
+                resortModelsOnMain()
+            }
+        }
+    }
+
+    // MARK: - Private Realm observation
+
+    private let modelsQueue = DispatchQueue(
+        label: "org.provenance.ui.home.models",
+        qos: .userInitiated
+    )
+    private var modelsRealm: Realm?
+    private var allGamesToken: NotificationToken?
+    private var favoritesToken: NotificationToken?
+    private var recentToken: NotificationToken?
+    private var mostPlayedToken: NotificationToken?
+
+    /// MD5 -> model lookup for deriving recently-played from the order list.
+    private var modelsByMD5: [String: GameCellModel] = [:]
+    /// Ordered list of MD5 hashes from PVRecentGame, newest first.
+    private var recentMD5Order: [String] = []
+
+    // MARK: - Init / Deinit
+
+    init(sortAscending: Bool = true) {
+        self.sortAscending = sortAscending
+        startModelObservations()
+    }
+
+    deinit {
+        allGamesToken?.invalidate()
+        favoritesToken?.invalidate()
+        recentToken?.invalidate()
+        mostPlayedToken?.invalidate()
+    }
+
+    // MARK: - Observation setup
+
+    private func startModelObservations() {
+        modelsQueue.async { [weak self] in
+            guard let self else { return }
+            do {
+                let realm = try Realm()
+                self.modelsRealm = realm
+
+                // All games
+                let allGames = realm.objects(PVGame.self)
+                self.allGamesToken = allGames.observe(
+                    keyPaths: GameCellModel.observedKeyPaths,
+                    on: self.modelsQueue
+                ) { [weak self] change in
+                    autoreleasepool {
+                        guard let self else { return }
+                        switch change {
+                        case .initial(let collection),
+                             .update(let collection, _, _, _):
+                            let snapshot = collection.freeze()
+                            self.rebuildAllGamesModels(from: snapshot)
+                        case .error(let error):
+                            ELOG("HomeViewModel: error observing all games: \(error.localizedDescription)")
+                        }
+                    }
+                }
+
+                // Favorites
+                let favorites = realm.objects(PVGame.self)
+                    .filter("isFavorite == true")
+                self.favoritesToken = favorites.observe(
+                    keyPaths: GameCellModel.observedKeyPaths,
+                    on: self.modelsQueue
+                ) { [weak self] change in
+                    autoreleasepool {
+                        guard let self else { return }
+                        switch change {
+                        case .initial(let collection),
+                             .update(let collection, _, _, _):
+                            let snapshot = collection.freeze()
+                            self.rebuildFavoritesModels(from: snapshot)
+                        case .error(let error):
+                            ELOG("HomeViewModel: error observing favorites: \(error.localizedDescription)")
+                        }
+                    }
+                }
+
+                // Most played
+                let mostPlayed = realm.objects(PVGame.self)
+                    .filter("playCount > 0")
+                self.mostPlayedToken = mostPlayed.observe(
+                    keyPaths: ["playCount", "title"],
+                    on: self.modelsQueue
+                ) { [weak self] change in
+                    autoreleasepool {
+                        guard let self else { return }
+                        switch change {
+                        case .initial(let collection),
+                             .update(let collection, _, _, _):
+                            let snapshot = collection.freeze()
+                            self.rebuildMostPlayedModels(from: snapshot)
+                        case .error(let error):
+                            ELOG("HomeViewModel: error observing most played: \(error.localizedDescription)")
+                        }
+                    }
+                }
+
+                // Recently played
+                let recent = realm.objects(PVRecentGame.self)
+                    .sorted(byKeyPath: "lastPlayedDate", ascending: false)
+                self.recentToken = recent.observe(
+                    on: self.modelsQueue
+                ) { [weak self] change in
+                    autoreleasepool {
+                        guard let self else { return }
+                        switch change {
+                        case .initial(let collection),
+                             .update(let collection, _, _, _):
+                            let snapshot = collection.freeze()
+                            self.rebuildRecentOrder(from: snapshot)
+                        case .error(let error):
+                            ELOG("HomeViewModel: error observing recent games: \(error.localizedDescription)")
+                        }
+                    }
+                }
+
+            } catch {
+                ELOG("HomeViewModel: failed to open Realm: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    // MARK: - Model rebuilding
+
+    private func rebuildAllGamesModels(from games: Results<PVGame>) {
+        autoreleasepool {
+            var byMD5: [String: GameCellModel] = [:]
+            byMD5.reserveCapacity(games.count)
+
+            var all: [GameCellModel] = []
+            all.reserveCapacity(games.count)
+
+            for game in games where !game.isInvalidated {
+                let model = GameCellModel(game: game)
+                byMD5[model.md5] = model
+                all.append(model)
+            }
+
+            self.modelsByMD5 = byMD5
+
+            // Re-derive recently played from existing order with updated models.
+            let recents = self.recentMD5Order.compactMap { byMD5[$0] }
+
+            let sorted = self.sorted(all)
+            Task { @MainActor [weak self] in
+                self?.allGamesModels = sorted
+                self?.recentlyPlayedModels = recents
+            }
+        }
+    }
+
+    private func rebuildFavoritesModels(from games: Results<PVGame>) {
+        autoreleasepool {
+            var favs: [GameCellModel] = []
+            favs.reserveCapacity(games.count)
+            for game in games where !game.isInvalidated {
+                favs.append(GameCellModel(game: game))
+            }
+            let sorted = self.sorted(favs)
+            Task { @MainActor [weak self] in
+                self?.favoritesModels = sorted
+            }
+        }
+    }
+
+    private func rebuildMostPlayedModels(from games: Results<PVGame>) {
+        autoreleasepool {
+            var models: [GameCellModel] = []
+            models.reserveCapacity(games.count)
+            for game in games where !game.isInvalidated {
+                models.append(GameCellModel(game: game))
+            }
+            // Sort by play count descending.
+            models.sort { $0.playCount > $1.playCount }
+            Task { @MainActor [weak self] in
+                self?.mostPlayedModels = models
+            }
+        }
+    }
+
+    private func rebuildRecentOrder(from recents: Results<PVRecentGame>) {
+        autoreleasepool {
+            recentMD5Order = recents.compactMap { recent in
+                guard !recent.isInvalidated,
+                      let game = recent.game,
+                      !game.isInvalidated else { return nil }
+                return game.md5Hash.uppercased()
+            }
+
+            let models = recentMD5Order.compactMap { modelsByMD5[$0] }
+
+            Task { @MainActor [weak self] in
+                self?.recentlyPlayedModels = models
+            }
+        }
+    }
+
+    // MARK: - Sorting
+
+    @MainActor
+    private func resortModelsOnMain() {
+        allGamesModels = sorted(allGamesModels)
+        favoritesModels = sorted(favoritesModels)
+        // recentlyPlayedModels keeps play-order, do not resort.
+        // mostPlayedModels keeps play-count order, do not resort.
+    }
+
+    private func sorted(_ models: [GameCellModel]) -> [GameCellModel] {
+        models.sorted { lhs, rhs in
+            if sortAscending {
+                return lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedAscending
+            } else {
+                return lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedDescending
+            }
+        }
+    }
+
+    // MARK: - Convenience accessors for navigation
+
+    /// Look up a game model by its ID across the all-games model cache.
+    func gameModel(byID id: String) -> GameCellModel? {
+        allGamesModels.first { $0.id == id }
+    }
+}
+#endif

--- a/PVUI/Sources/PVSwiftUI/Home/HomeViewModel.swift
+++ b/PVUI/Sources/PVSwiftUI/Home/HomeViewModel.swift
@@ -183,11 +183,10 @@ final class HomeViewModel: ObservableObject {
             // Re-derive recently played from existing order with updated models.
             let recents = self.recentMD5Order.compactMap { byMD5[$0] }
 
-            let asc = self.sortAscending
-            let sorted = self.sorted(all, ascending: asc)
             Task { @MainActor [weak self] in
-                self?.allGamesModels = sorted
-                self?.recentlyPlayedModels = recents
+                guard let self else { return }
+                self.allGamesModels = self.sorted(all, ascending: self.sortAscending)
+                self.recentlyPlayedModels = recents
             }
         }
     }
@@ -199,10 +198,9 @@ final class HomeViewModel: ObservableObject {
             for game in games where !game.isInvalidated {
                 favs.append(GameCellModel(game: game))
             }
-            let asc = self.sortAscending
-            let sorted = self.sorted(favs, ascending: asc)
             Task { @MainActor [weak self] in
-                self?.favoritesModels = sorted
+                guard let self else { return }
+                self.favoritesModels = self.sorted(favs, ascending: self.sortAscending)
             }
         }
     }

--- a/PVUI/Sources/PVSwiftUI/Home/HomeViewModel.swift
+++ b/PVUI/Sources/PVSwiftUI/Home/HomeViewModel.swift
@@ -11,7 +11,6 @@ import RealmSwift
 import PVLibrary
 import PVRealm
 import PVUIBase
-import Combine
 
 /// View model for HomeView that observes Realm collections on a background queue
 /// and publishes immutable snapshot models. This prevents the excessive SwiftUI

--- a/PVUI/Sources/PVSwiftUI/Home/HomeViewModel.swift
+++ b/PVUI/Sources/PVSwiftUI/Home/HomeViewModel.swift
@@ -184,7 +184,8 @@ final class HomeViewModel: ObservableObject {
             // Re-derive recently played from existing order with updated models.
             let recents = self.recentMD5Order.compactMap { byMD5[$0] }
 
-            let sorted = self.sorted(all)
+            let asc = self.sortAscending
+            let sorted = self.sorted(all, ascending: asc)
             Task { @MainActor [weak self] in
                 self?.allGamesModels = sorted
                 self?.recentlyPlayedModels = recents
@@ -199,7 +200,8 @@ final class HomeViewModel: ObservableObject {
             for game in games where !game.isInvalidated {
                 favs.append(GameCellModel(game: game))
             }
-            let sorted = self.sorted(favs)
+            let asc = self.sortAscending
+            let sorted = self.sorted(favs, ascending: asc)
             Task { @MainActor [weak self] in
                 self?.favoritesModels = sorted
             }
@@ -242,16 +244,19 @@ final class HomeViewModel: ObservableObject {
 
     @MainActor
     private func resortModelsOnMain() {
-        allGamesModels = sorted(allGamesModels)
-        favoritesModels = sorted(favoritesModels)
+        let asc = sortAscending
+        allGamesModels = sorted(allGamesModels, ascending: asc)
+        favoritesModels = sorted(favoritesModels, ascending: asc)
         // recentlyPlayedModels keeps play-order, do not resort.
         // mostPlayedModels keeps play-count order, do not resort.
     }
 
-    private func sorted(_ models: [GameCellModel]) -> [GameCellModel] {
-        let ascending = sortAscending
+    /// Sort models by title. Pass `ascending` explicitly from background queues
+    /// to avoid cross-thread reads of `sortAscending`.
+    private func sorted(_ models: [GameCellModel], ascending: Bool) -> [GameCellModel] {
+        let asc = ascending
         return models.sorted { lhs, rhs in
-            if ascending {
+            if asc {
                 return lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedAscending
             } else {
                 return lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedDescending


### PR DESCRIPTION
## Summary
- Root cause: 5 independent `@ObservedResults` each firing Realm notifications causing cascading re-renders
- Created `HomeViewModel` with background Realm notification tokens and `keyPaths` filtering
- Mirrors the `ConsoleGamesViewModel` pattern (which doesn't flicker)
- Switched from `GameItemView` (PVGame) to `GameItemPresentableView` (GameCellModel) to avoid per-cell subscriptions

Closes #3184

## Test plan
- [ ] Open HomeView and let it sit idle — no flickering/reloading
- [ ] Verify recently played, favorites, most played sections all populate correctly
- [ ] Launch a game from HomeView and return — data should be up to date

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>