### PR TITLE
[Agent] feat(ui): add shader parameters to RetroMenuView filter picker (#3185)

### DIFF
--- a/PVUI/Sources/PVUIBase/PVEmulatorVC/RetroMenuView+ShaderParameters.swift
+++ b/PVUI/Sources/PVUIBase/PVEmulatorVC/RetroMenuView+ShaderParameters.swift
@@ -43,11 +43,19 @@ struct ShaderParameterSlider: View {
                     .font(.system(size: 13, weight: .regular).monospacedDigit())
                     .foregroundColor((palette.settingsCellTextDetail?.swiftUIColor ?? palette.gameLibraryText.swiftUIColor).opacity(0.7))
             }
+            #if os(tvOS)
+            if let step = step {
+                Slider(value: $value, in: range, step: Float.Stride(step))
+            } else {
+                Slider(value: $value, in: range)
+            }
+            #else
             if let step = step {
                 RetroWaveSlider(value: $value, in: range, step: Float.Stride(step))
             } else {
                 RetroWaveSlider(value: $value, in: range)
             }
+            #endif
         }
         .padding(.vertical, 2)
     }

--- a/PVUI/Sources/PVUIBase/PVEmulatorVC/RetroMenuView+ShaderParameters.swift
+++ b/PVUI/Sources/PVUIBase/PVEmulatorVC/RetroMenuView+ShaderParameters.swift
@@ -50,11 +50,7 @@ struct ShaderParameterSlider: View {
                 Slider(value: $value, in: range)
             }
             #else
-            if let step = step {
-                RetroWaveSlider(value: $value, in: range, step: Float.Stride(step))
-            } else {
-                RetroWaveSlider(value: $value, in: range)
-            }
+            RetroWaveSlider(value: $value, in: range, step: Float.Stride(step ?? 0))
             #endif
         }
         .padding(.vertical, 2)

--- a/PVUI/Sources/PVUIBase/PVEmulatorVC/RetroMenuView+ShaderParameters.swift
+++ b/PVUI/Sources/PVUIBase/PVEmulatorVC/RetroMenuView+ShaderParameters.swift
@@ -1,0 +1,186 @@
+//
+//  RetroMenuView+ShaderParameters.swift
+//  PVUI
+//
+//  Created for issue #3185 - Metal filter shader parameters in pause menu
+//
+
+import SwiftUI
+import PVSettings
+import PVThemes
+import Defaults
+
+// MARK: - Shader Parameter Slider
+
+/// A slider row styled for the RetroMenuView filter picker, showing a label, value, and slider.
+struct ShaderParameterSlider: View {
+    let label: String
+    @Binding var value: Float
+    let range: ClosedRange<Float>
+    var step: Float?
+    let palette: UXThemePalette
+
+    private var formattedValue: String {
+        if let step = step, step >= 1.0 {
+            return String(format: "%.0f", value)
+        } else if range.upperBound - range.lowerBound >= 10 {
+            return String(format: "%.0f", value)
+        } else if range.upperBound - range.lowerBound >= 1 {
+            return String(format: "%.2f", value)
+        } else {
+            return String(format: "%.3f", value)
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(label)
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundColor(palette.settingsCellText?.swiftUIColor ?? palette.gameLibraryText.swiftUIColor)
+                Spacer()
+                Text(formattedValue)
+                    .font(.system(size: 13, weight: .regular).monospacedDigit())
+                    .foregroundColor((palette.settingsCellTextDetail?.swiftUIColor ?? palette.gameLibraryText.swiftUIColor).opacity(0.7))
+            }
+            if let step = step {
+                RetroWaveSlider(value: $value, in: range, step: Float.Stride(step))
+            } else {
+                RetroWaveSlider(value: $value, in: range)
+            }
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+// MARK: - Simple CRT Parameters View
+
+/// Displays adjustable parameters for the Simple CRT shader.
+struct SimpleCRTParametersView: View {
+    let palette: UXThemePalette
+
+    @Default(.simpleCRTCurvVert) private var curvVert
+    @Default(.simpleCRTCurvHoriz) private var curvHoriz
+    @Default(.simpleCRTCurvStrength) private var curvStrength
+    @Default(.simpleCRTLightBoost) private var lightBoost
+    @Default(.simpleCRTVignStrength) private var vignStrength
+    @Default(.simpleCRTZoomOut) private var zoomOut
+    @Default(.simpleCRTBrightness) private var brightness
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("SIMPLE CRT PARAMETERS")
+                .font(.system(size: 14, weight: .bold))
+                .foregroundColor(palette.defaultTintColor.swiftUIColor)
+                .padding(.bottom, 4)
+
+            ShaderParameterSlider(label: "Curvature (Vertical)", value: $curvVert, range: 1.0...10.0, palette: palette)
+            ShaderParameterSlider(label: "Curvature (Horizontal)", value: $curvHoriz, range: 1.0...10.0, palette: palette)
+            ShaderParameterSlider(label: "Curvature Strength", value: $curvStrength, range: 0.0...1.0, palette: palette)
+            ShaderParameterSlider(label: "Light Boost", value: $lightBoost, range: 0.1...3.0, palette: palette)
+            ShaderParameterSlider(label: "Vignette", value: $vignStrength, range: 0.0...1.0, palette: palette)
+            ShaderParameterSlider(label: "Zoom Out", value: $zoomOut, range: 0.5...2.0, palette: palette)
+            ShaderParameterSlider(label: "Brightness", value: $brightness, range: 0.5...1.5, palette: palette)
+
+            Button(action: {
+                Defaults.reset(
+                    .simpleCRTCurvVert, .simpleCRTCurvHoriz, .simpleCRTCurvStrength,
+                    .simpleCRTLightBoost, .simpleCRTVignStrength, .simpleCRTZoomOut,
+                    .simpleCRTBrightness
+                )
+            }) {
+                HStack {
+                    Image(systemName: "arrow.counterclockwise")
+                    Text("Reset to Defaults")
+                }
+                .font(.system(size: 14, weight: .medium))
+                .foregroundColor(.red)
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.vertical, 8)
+            }
+        }
+        .padding(.horizontal, 4)
+    }
+}
+
+// MARK: - Complex CRT Parameters View
+
+/// Displays adjustable parameters for the Complex CRT shader.
+struct ComplexCRTParametersView: View {
+    let palette: UXThemePalette
+
+    @Default(.complexCRTUseScanlines) private var useScanlines
+    @Default(.complexCRTUseShadowMask) private var useShadowMask
+    @Default(.complexCRTUseWarp) private var useWarp
+    @Default(.complexCRTBloomAmount) private var bloomAmount
+    @Default(.complexCRTScanlineHardness) private var scanlineHardness
+    @Default(.complexCRTShadowMaskHardness) private var shadowMaskHardness
+    @Default(.complexCRTRowsOfResolution) private var rowsOfResolution
+    @Default(.complexCRTTVL) private var tvl
+    @Default(.complexCRTWarpX) private var warpX
+    @Default(.complexCRTWarpY) private var warpY
+    @Default(.complexCRTDisplayGamma) private var displayGamma
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("COMPLEX CRT PARAMETERS")
+                .font(.system(size: 14, weight: .bold))
+                .foregroundColor(palette.defaultTintColor.swiftUIColor)
+                .padding(.bottom, 4)
+
+            // Feature toggles
+            Toggle("Scanlines", isOn: $useScanlines)
+                .font(.system(size: 14, weight: .medium))
+                .foregroundColor(palette.settingsCellText?.swiftUIColor ?? palette.gameLibraryText.swiftUIColor)
+                .tint(palette.defaultTintColor.swiftUIColor)
+
+            Toggle("Shadow Mask", isOn: $useShadowMask)
+                .font(.system(size: 14, weight: .medium))
+                .foregroundColor(palette.settingsCellText?.swiftUIColor ?? palette.gameLibraryText.swiftUIColor)
+                .tint(palette.defaultTintColor.swiftUIColor)
+
+            Toggle("Screen Warp", isOn: $useWarp)
+                .font(.system(size: 14, weight: .medium))
+                .foregroundColor(palette.settingsCellText?.swiftUIColor ?? palette.gameLibraryText.swiftUIColor)
+                .tint(palette.defaultTintColor.swiftUIColor)
+
+            ShaderParameterSlider(label: "Bloom Amount", value: $bloomAmount, range: 0.0...6.0, palette: palette)
+
+            if useScanlines {
+                ShaderParameterSlider(label: "Scanline Hardness", value: $scanlineHardness, range: 1.0...12.0, palette: palette)
+                ShaderParameterSlider(label: "CRT Resolution (lines)", value: $rowsOfResolution, range: 240.0...1080.0, step: 1.0, palette: palette)
+            }
+
+            if useShadowMask {
+                ShaderParameterSlider(label: "Shadow Mask Hardness", value: $shadowMaskHardness, range: 4.0...32.0, palette: palette)
+                ShaderParameterSlider(label: "TV Lines (mask density)", value: $tvl, range: 400.0...1200.0, step: 1.0, palette: palette)
+            }
+
+            if useWarp {
+                ShaderParameterSlider(label: "Warp Horizontal", value: $warpX, range: 0.0...0.05, palette: palette)
+                ShaderParameterSlider(label: "Warp Vertical", value: $warpY, range: 0.0...0.1, palette: palette)
+            }
+
+            ShaderParameterSlider(label: "Display Gamma", value: $displayGamma, range: 1.8...2.6, palette: palette)
+
+            Button(action: {
+                Defaults.reset(
+                    .complexCRTUseScanlines, .complexCRTUseShadowMask, .complexCRTUseWarp,
+                    .complexCRTBloomAmount, .complexCRTScanlineHardness, .complexCRTShadowMaskHardness,
+                    .complexCRTRowsOfResolution, .complexCRTTVL,
+                    .complexCRTWarpX, .complexCRTWarpY, .complexCRTDisplayGamma
+                )
+            }) {
+                HStack {
+                    Image(systemName: "arrow.counterclockwise")
+                    Text("Reset to Defaults")
+                }
+                .font(.system(size: 14, weight: .medium))
+                .foregroundColor(.red)
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.vertical, 8)
+            }
+        }
+        .padding(.horizontal, 4)
+    }
+}

--- a/PVUI/Sources/PVUIBase/PVEmulatorVC/RetroMenuView+ShaderParameters.swift
+++ b/PVUI/Sources/PVUIBase/PVEmulatorVC/RetroMenuView+ShaderParameters.swift
@@ -17,7 +17,7 @@ struct ShaderParameterSlider: View {
     let label: String
     @Binding var value: Float
     let range: ClosedRange<Float>
-    var step: Float?
+    var step: Float? = nil
     let palette: UXThemePalette
 
     private var formattedValue: String {

--- a/PVUI/Sources/PVUIBase/PVEmulatorVC/RetroMenuView.swift
+++ b/PVUI/Sources/PVUIBase/PVEmulatorVC/RetroMenuView.swift
@@ -1835,8 +1835,9 @@ struct RetroMenuView: View {
 
                         // Show CRT shader parameters when a CRT filter is selected
                         if selectedMetalFilter.hasCRTParameters {
-                            Divider()
-                                .background(palette.defaultTintColor.swiftUIColor.opacity(0.5))
+                            Rectangle()
+                                .fill(palette.defaultTintColor.swiftUIColor.opacity(0.5))
+                                .frame(height: 1)
                                 .padding(.vertical, 8)
 
                             if selectedMetalFilter == .simpleCRT {
@@ -1882,8 +1883,9 @@ struct RetroMenuView: View {
 
                     // Show CRT shader parameters when a CRT filter is selected
                     if selectedMetalFilter.hasCRTParameters {
-                        Divider()
-                            .background(palette.defaultTintColor.swiftUIColor.opacity(0.5))
+                        Rectangle()
+                            .fill(palette.defaultTintColor.swiftUIColor.opacity(0.5))
+                            .frame(height: 1)
                             .padding(.vertical, 8)
 
                         if selectedMetalFilter == .simpleCRT {

--- a/PVUI/Sources/PVUIBase/PVEmulatorVC/RetroMenuView.swift
+++ b/PVUI/Sources/PVUIBase/PVEmulatorVC/RetroMenuView.swift
@@ -1638,7 +1638,10 @@ struct RetroMenuView: View {
         Button(action: {
             selectedMetalFilter = option
             applyFilterImmediately(option)
-            showingFilterPicker = false
+            // Keep the picker open when selecting a CRT filter so users can adjust parameters
+            if !option.hasCRTParameters {
+                showingFilterPicker = false
+            }
         }) {
             filterOptionContent(label: label, isSelected: isSelected, textColor: textColor, isCompact: isCompact)
                 .background(filterOptionBackground(bgOpacity: bgOpacity, borderColor: borderColor, borderWidth: borderWidth))
@@ -1759,6 +1762,13 @@ struct RetroMenuView: View {
                     }
                 }
                 .pickerStyle(.navigationLink)
+
+                // Show CRT shader parameters when a CRT filter is selected
+                if selectedMetalFilter == .simpleCRT {
+                    SimpleCRTParametersView(palette: palette)
+                } else if selectedMetalFilter == .complexCRT {
+                    ComplexCRTParametersView(palette: palette)
+                }
             }
             .navigationTitle("Screen Filters")
             .toolbar {
@@ -1822,6 +1832,19 @@ struct RetroMenuView: View {
                         ForEach(MetalFilterSelectionOption.allCases, id: \.self) { option in
                             filterOptionRow(for: option, isCompact: false)
                         }
+
+                        // Show CRT shader parameters when a CRT filter is selected
+                        if selectedMetalFilter.hasCRTParameters {
+                            Divider()
+                                .background(palette.defaultTintColor.swiftUIColor.opacity(0.5))
+                                .padding(.vertical, 8)
+
+                            if selectedMetalFilter == .simpleCRT {
+                                SimpleCRTParametersView(palette: palette)
+                            } else if selectedMetalFilter == .complexCRT {
+                                ComplexCRTParametersView(palette: palette)
+                            }
+                        }
                     }
                     .padding(.horizontal, 60)
                 }
@@ -1850,11 +1873,24 @@ struct RetroMenuView: View {
                 .foregroundColor(palette.gameLibraryHeaderText.swiftUIColor)
                 .shadow(color: headerShadow, radius: 10, x: 0, y: 0)
 
-            // Filter options
+            // Filter options and shader parameters
             ScrollView {
                 VStack(spacing: 16) {
                     ForEach(MetalFilterSelectionOption.allCases, id: \.self) { option in
                         filterOptionRow(for: option, isCompact: isCompact)
+                    }
+
+                    // Show CRT shader parameters when a CRT filter is selected
+                    if selectedMetalFilter.hasCRTParameters {
+                        Divider()
+                            .background(palette.defaultTintColor.swiftUIColor.opacity(0.5))
+                            .padding(.vertical, 8)
+
+                        if selectedMetalFilter == .simpleCRT {
+                            SimpleCRTParametersView(palette: palette)
+                        } else if selectedMetalFilter == .complexCRT {
+                            ComplexCRTParametersView(palette: palette)
+                        }
                     }
                 }
             }
@@ -1867,7 +1903,7 @@ struct RetroMenuView: View {
         }
         .frame(
             width: isLandscape ? min(400, geometry.size.width * 0.8) : min(500, geometry.size.width * 0.9),
-            height: isLandscape ? geometry.size.height * 0.9 : min(600, geometry.size.height * 0.8)
+            height: isLandscape ? geometry.size.height * 0.9 : min(700, geometry.size.height * 0.85)
         )
         .background(containerBg)
         .cornerRadius(20)


### PR DESCRIPTION
## Summary
- Created `RetroMenuView+ShaderParameters.swift` with `SimpleCRTParametersView` and `ComplexCRTParametersView`
- Added slider controls for all CRT parameters (curvature, bloom, scanlines, etc.)
- Integrated into filter picker for iOS/macOS and tvOS layouts
- Uses same `@Default` keys as Settings for immediate persistence

Closes #3185

## Test plan
- [ ] Open pause menu → select filter → choose Simple CRT or Complex CRT
- [ ] Verify parameter sliders appear below filter selection
- [ ] Adjust parameters and verify they take effect on the game view
- [ ] Verify reset button restores defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>