### PR TITLE
[Agent] fix(ui): move JIT indicator to bottom edge with auto-hide (#3186)

### DIFF
--- a/PVUI/Sources/PVUIBase/SwiftUI/Components/IndicatorLights/PVIndicatorLightView.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/Components/IndicatorLights/PVIndicatorLightView.swift
@@ -196,11 +196,11 @@ public struct PVIndicatorLightRowView: View {
                 PVIndicatorLightView(state: indicator)
             }
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 6)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 3)
         .background(
             Capsule()
-                .fill(Color.black.opacity(0.4))
+                .fill(Color.black.opacity(0.25))
         )
     }
 }
@@ -215,8 +215,16 @@ public struct PVIndicatorOverlayView: View {
         self.registry = registry
     }
 
+    /// Controls auto-hide fade for the indicator overlay.
+    @State private var isVisible: Bool = true
+
+    /// Seconds before the overlay auto-hides.
+    private let autoHideDelay: TimeInterval = 5.0
+
     public var body: some View {
         VStack {
+            Spacer()
+
             HStack {
                 Spacer()
 
@@ -225,10 +233,26 @@ public struct PVIndicatorOverlayView: View {
                         .transition(.opacity.combined(with: .scale))
                 }
             }
-            .padding(.top, 8)
+            .padding(.bottom, 4)
             .padding(.trailing, 16)
+        }
+        .opacity(isVisible ? 0.85 : 0.0)
+        .animation(.easeInOut(duration: 0.6), value: isVisible)
+        .onAppear {
+            scheduleAutoHide()
+        }
+        .onChange(of: registry.visibleIndicators) { _ in
+            // Re-show when indicators change state
+            withAnimation { isVisible = true }
+            scheduleAutoHide()
+        }
+    }
 
-            Spacer()
+    private func scheduleAutoHide() {
+        guard autoHideDelay > 0 else { return }
+        isVisible = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + autoHideDelay) {
+            withAnimation { isVisible = false }
         }
     }
 }

--- a/PVUI/Sources/PVUIBase/SwiftUI/Components/IndicatorLights/PVIndicatorLightView.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/Components/IndicatorLights/PVIndicatorLightView.swift
@@ -237,6 +237,7 @@ public struct PVIndicatorOverlayView: View {
             .padding(.trailing, 16)
         }
         .opacity(isVisible ? 0.85 : 0.0)
+        .allowsHitTesting(isVisible)
         .animation(.easeInOut(duration: 0.6), value: isVisible)
         .onAppear {
             scheduleAutoHide()

--- a/PVUI/Sources/PVUIBase/SwiftUI/Components/IndicatorLights/PVIndicatorLightView.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/Components/IndicatorLights/PVIndicatorLightView.swift
@@ -244,6 +244,7 @@ public struct PVIndicatorOverlayView: View {
         }
         .onDisappear {
             pendingHideWorkItem?.cancel()
+            pendingHideWorkItem = nil
         }
         .onChange(of: registry.visibleIndicators) { _ in
             // Re-show when indicators change state

--- a/PVUI/Sources/PVUIBase/SwiftUI/Components/IndicatorLights/PVIndicatorLightView.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/Components/IndicatorLights/PVIndicatorLightView.swift
@@ -242,6 +242,9 @@ public struct PVIndicatorOverlayView: View {
         .onAppear {
             scheduleAutoHide()
         }
+        .onDisappear {
+            pendingHideWorkItem?.cancel()
+        }
         .onChange(of: registry.visibleIndicators) { _ in
             // Re-show when indicators change state
             withAnimation { isVisible = true }

--- a/PVUI/Sources/PVUIBase/SwiftUI/Components/IndicatorLights/PVIndicatorLightView.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/Components/IndicatorLights/PVIndicatorLightView.swift
@@ -248,12 +248,17 @@ public struct PVIndicatorOverlayView: View {
         }
     }
 
+    @State private var pendingHideWorkItem: DispatchWorkItem?
+
     private func scheduleAutoHide() {
         guard autoHideDelay > 0 else { return }
+        pendingHideWorkItem?.cancel()
         isVisible = true
-        DispatchQueue.main.asyncAfter(deadline: .now() + autoHideDelay) {
+        let workItem = DispatchWorkItem {
             withAnimation { isVisible = false }
         }
+        pendingHideWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + autoHideDelay, execute: workItem)
     }
 }
 

--- a/PVUI/Sources/PVUIBase/SwiftUI/Components/JIT/JITStatusIndicatorView.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/Components/JIT/JITStatusIndicatorView.swift
@@ -255,7 +255,8 @@ public final class JITStatusViewModel: ObservableObject {
 
 // MARK: - JIT Status Indicator View
 
-/// A small, unobtrusive JIT status indicator for the emulator HUD.
+/// A subtle, bottom-edge LED-style JIT status indicator for the emulator HUD.
+/// Auto-hides after 5 seconds to avoid covering game content.
 /// Tap the indicator to trigger `onTap`, which the hosting UIViewController
 /// uses to present a compact `UIAlertController` — no full-screen sheet.
 public struct JITStatusIndicatorView: View {
@@ -269,45 +270,82 @@ public struct JITStatusIndicatorView: View {
         self.onTap = onTap
     }
 
+    /// Controls the fade-out after auto-hide delay.
+    @State private var isVisible: Bool = true
+    /// Tracks whether the user has tapped to temporarily reveal the indicator.
+    @State private var userRevealed: Bool = false
+
+    /// Seconds before the indicator auto-hides (0 = never hide).
+    private let autoHideDelay: TimeInterval = 5.0
+
     public var body: some View {
         ZStack {
             if viewModel.status.isVisible {
                 Button(action: {
-                    onTap?()
+                    if !isVisible {
+                        // Tap to reveal again temporarily
+                        revealTemporarily()
+                    } else {
+                        onTap?()
+                    }
                 }) {
-                    HStack(spacing: 8) {
-                        // Status dot
+                    HStack(spacing: 4) {
+                        // LED dot — small, subtle
                         Circle()
                             .fill(viewModel.status.iconColor)
-                            .frame(width: 10, height: 10)
-                            .shadow(color: viewModel.status.iconColor.opacity(0.6), radius: 4, x: 0, y: 0)
+                            .frame(width: 6, height: 6)
+                            .shadow(color: viewModel.status.iconColor.opacity(0.7), radius: 3, x: 0, y: 0)
 
-                        // Label — shows source name (e.g. "JIT · AltStore") when active and source is known
+                        // Short label
                         Text(viewModel.indicatorLabel)
-                            .font(.system(size: 12, weight: .semibold, design: .rounded))
-                            .foregroundColor(.white)
+                            .font(.system(size: 9, weight: .medium, design: .rounded))
+                            .foregroundColor(.white.opacity(0.8))
                     }
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 8)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 3)
                     .background(
-                        RoundedRectangle(cornerRadius: 16)
-                            .fill(Color.black.opacity(0.75))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 16)
-                                    .strokeBorder(viewModel.status.iconColor.opacity(0.5), lineWidth: 1)
-                            )
+                        Capsule()
+                            .fill(Color.black.opacity(0.35))
                     )
                 }
                 .buttonStyle(PlainButtonStyle())
+                .opacity(isVisible ? 0.85 : 0.0)
+                .animation(.easeInOut(duration: 0.6), value: isVisible)
                 .accessibilityLabel(viewModel.indicatorAccessibilityLabel)
                 .accessibilityHint("Tap to see details about the current emulation mode")
+                .onAppear {
+                    scheduleAutoHide()
+                }
             }
         }
         #if canImport(JITManager)
         .onReceive(NotificationCenter.default.publisher(for: .DOLJitAcquired)) { _ in
             viewModel.updateStatus()
+            revealTemporarily()
         }
         #endif
+    }
+
+    /// Schedules the indicator to fade out after `autoHideDelay` seconds.
+    private func scheduleAutoHide() {
+        guard autoHideDelay > 0 else { return }
+        isVisible = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + autoHideDelay) {
+            // Only auto-hide if the user hasn't tapped to reveal
+            if !userRevealed {
+                withAnimation { isVisible = false }
+            }
+        }
+    }
+
+    /// Temporarily reveals the indicator for another cycle, then fades it out again.
+    private func revealTemporarily() {
+        userRevealed = true
+        withAnimation { isVisible = true }
+        DispatchQueue.main.asyncAfter(deadline: .now() + autoHideDelay) {
+            userRevealed = false
+            withAnimation { isVisible = false }
+        }
     }
 }
 
@@ -336,24 +374,21 @@ struct JITStatusIndicatorPreview: View {
     let status: JITStatus
 
     var body: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: 4) {
             Circle()
                 .fill(status.iconColor)
-                .frame(width: 10, height: 10)
+                .frame(width: 6, height: 6)
+                .shadow(color: status.iconColor.opacity(0.7), radius: 3, x: 0, y: 0)
 
             Text(status.label)
-                .font(.system(size: 12, weight: .semibold, design: .rounded))
-                .foregroundColor(.white)
+                .font(.system(size: 9, weight: .medium, design: .rounded))
+                .foregroundColor(.white.opacity(0.8))
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 3)
         .background(
-            RoundedRectangle(cornerRadius: 16)
-                .fill(Color.black.opacity(0.75))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 16)
-                        .strokeBorder(status.iconColor.opacity(0.5), lineWidth: 1)
-                )
+            Capsule()
+                .fill(Color.black.opacity(0.35))
         )
     }
 }

--- a/PVUI/Sources/PVUIBase/SwiftUI/Components/JIT/JITStatusIndicatorView.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/Components/JIT/JITStatusIndicatorView.swift
@@ -302,6 +302,7 @@ public struct JITStatusIndicatorView: View {
                         Text(viewModel.indicatorLabel)
                             .font(.system(size: 9, weight: .medium, design: .rounded))
                             .foregroundColor(.white.opacity(0.8))
+                            .lineLimit(1)
                     }
                     .padding(.horizontal, 8)
                     .padding(.vertical, 3)
@@ -321,6 +322,7 @@ public struct JITStatusIndicatorView: View {
                 }
                 .onDisappear {
                     pendingHideWorkItem?.cancel()
+                    pendingHideWorkItem = nil
                 }
             }
         }

--- a/PVUI/Sources/PVUIBase/SwiftUI/Components/JIT/JITStatusIndicatorView.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/Components/JIT/JITStatusIndicatorView.swift
@@ -319,6 +319,9 @@ public struct JITStatusIndicatorView: View {
                 .onAppear {
                     scheduleAutoHide()
                 }
+                .onDisappear {
+                    pendingHideWorkItem?.cancel()
+                }
             }
         }
         .onChange(of: viewModel.status) { _ in

--- a/PVUI/Sources/PVUIBase/SwiftUI/Components/JIT/JITStatusIndicatorView.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/Components/JIT/JITStatusIndicatorView.swift
@@ -321,10 +321,12 @@ public struct JITStatusIndicatorView: View {
                 }
             }
         }
+        .onChange(of: viewModel.status) { _ in
+            revealTemporarily()
+        }
         #if canImport(JITManager)
         .onReceive(NotificationCenter.default.publisher(for: .DOLJitAcquired)) { _ in
             viewModel.updateStatus()
-            revealTemporarily()
         }
         #endif
     }

--- a/PVUI/Sources/PVUIBase/SwiftUI/Components/JIT/JITStatusIndicatorView.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/Components/JIT/JITStatusIndicatorView.swift
@@ -316,7 +316,7 @@ public struct JITStatusIndicatorView: View {
                 .animation(.easeInOut(duration: 0.6), value: isVisible)
                 .accessibilityLabel(viewModel.indicatorAccessibilityLabel)
                 .accessibilityHint("Tap to see details about the current emulation mode")
-                .accessibilityHidden(!isVisible)
+                .accessibilityElement(children: .combine)
                 .onAppear {
                     scheduleAutoHide()
                 }
@@ -327,8 +327,10 @@ public struct JITStatusIndicatorView: View {
                 }
             }
         }
-        .onChange(of: viewModel.status) { _ in
-            revealTemporarily()
+        .onChange(of: viewModel.status) { newStatus in
+            if newStatus.isVisible {
+                revealTemporarily()
+            }
         }
         #if canImport(JITManager)
         .onReceive(NotificationCenter.default.publisher(for: .DOLJitAcquired)) { _ in

--- a/PVUI/Sources/PVUIBase/SwiftUI/Components/JIT/JITStatusIndicatorView.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/Components/JIT/JITStatusIndicatorView.swift
@@ -274,6 +274,8 @@ public struct JITStatusIndicatorView: View {
     @State private var isVisible: Bool = true
     /// Tracks whether the user has tapped to temporarily reveal the indicator.
     @State private var userRevealed: Bool = false
+    /// Pending auto-hide work item, cancelled when a new hide is scheduled.
+    @State private var pendingHideWorkItem: DispatchWorkItem?
 
     /// Seconds before the indicator auto-hides (0 = never hide).
     private let autoHideDelay: TimeInterval = 5.0
@@ -327,25 +329,33 @@ public struct JITStatusIndicatorView: View {
     }
 
     /// Schedules the indicator to fade out after `autoHideDelay` seconds.
+    /// Cancels any previously scheduled hide to avoid premature dismissal.
     private func scheduleAutoHide() {
         guard autoHideDelay > 0 else { return }
+        pendingHideWorkItem?.cancel()
         isVisible = true
-        DispatchQueue.main.asyncAfter(deadline: .now() + autoHideDelay) {
+        let workItem = DispatchWorkItem { [self] in
             // Only auto-hide if the user hasn't tapped to reveal
             if !userRevealed {
                 withAnimation { isVisible = false }
             }
         }
+        pendingHideWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + autoHideDelay, execute: workItem)
     }
 
     /// Temporarily reveals the indicator for another cycle, then fades it out again.
+    /// Cancels any previously scheduled hide to avoid premature dismissal.
     private func revealTemporarily() {
+        pendingHideWorkItem?.cancel()
         userRevealed = true
         withAnimation { isVisible = true }
-        DispatchQueue.main.asyncAfter(deadline: .now() + autoHideDelay) {
+        let workItem = DispatchWorkItem { [self] in
             userRevealed = false
             withAnimation { isVisible = false }
         }
+        pendingHideWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + autoHideDelay, execute: workItem)
     }
 }
 

--- a/PVUI/Sources/PVUIBase/SwiftUI/Components/JIT/JITStatusIndicatorView.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/Components/JIT/JITStatusIndicatorView.swift
@@ -315,6 +315,7 @@ public struct JITStatusIndicatorView: View {
                 .animation(.easeInOut(duration: 0.6), value: isVisible)
                 .accessibilityLabel(viewModel.indicatorAccessibilityLabel)
                 .accessibilityHint("Tap to see details about the current emulation mode")
+                .accessibilityHidden(!isVisible)
                 .onAppear {
                     scheduleAutoHide()
                 }

--- a/PVUI/Sources/PVUIBase/SwiftUI/Components/JIT/JITStatusIndicatorView.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/Components/JIT/JITStatusIndicatorView.swift
@@ -323,6 +323,7 @@ public struct JITStatusIndicatorView: View {
                 .onDisappear {
                     pendingHideWorkItem?.cancel()
                     pendingHideWorkItem = nil
+                    userRevealed = false
                 }
             }
         }
@@ -355,6 +356,7 @@ public struct JITStatusIndicatorView: View {
     /// Temporarily reveals the indicator for another cycle, then fades it out again.
     /// Cancels any previously scheduled hide to avoid premature dismissal.
     private func revealTemporarily() {
+        guard autoHideDelay > 0 else { return }
         pendingHideWorkItem?.cancel()
         userRevealed = true
         withAnimation { isVisible = true }

--- a/PVUI/Sources/PVUIBase/SwiftUI/Components/JIT/JITStatusIndicatorViewController.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/Components/JIT/JITStatusIndicatorViewController.swift
@@ -36,8 +36,8 @@ private final class PassthroughView: UIView {
 ///
 /// ## PVToast notifications
 /// Status transitions automatically post in-game toasts via `PVToastManager`:
-///  - JIT acquired → `.jit` success toast (auto-dismissed after 4 s)
-///  - JIT unavailable for a required core → persistent `.error` toast until status changes
+///  - JIT acquired -> `.jit` success toast (auto-dismissed after 4 s)
+///  - JIT unavailable for a required core -> persistent `.error` toast until status changes
 @MainActor
 public final class JITStatusIndicatorViewController: UIViewController {
 
@@ -75,12 +75,11 @@ public final class JITStatusIndicatorViewController: UIViewController {
         view.addSubview(host.view)
         host.view.translatesAutoresizingMaskIntoConstraints = false
 
-        // Top-left corner, respecting the safe area so it clears the notch/Dynamic Island
-        // and lands above the skin controller area (which is at the bottom/sides).
+        // Bottom-center, hugging the bottom edge as a subtle LED-style indicator.
+        // Stays out of the way of game content at the top of the screen.
         NSLayoutConstraint.activate([
-            host.view.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 8),
-            host.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 4),
-            host.view.trailingAnchor.constraint(lessThanOrEqualTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -8)
+            host.view.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            host.view.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -2)
         ])
 
         host.didMove(toParent: self)
@@ -126,11 +125,11 @@ public final class JITStatusIndicatorViewController: UIViewController {
             message: """
             JIT compilation can be enabled using one of the following tools:
 
-            • AltStore / AltServer — free, requires a Mac or PC to refresh periodically
-            • SideStore — wireless alternative to AltStore
-            • SideJITServer — lightweight local server for over-the-air JIT
-            • StikDebug — on-device JIT enabler (requires compatible setup)
-            • TrollStore — permanent JIT for supported iOS/iPadOS versions
+            \u{2022} AltStore / AltServer \u{2014} free, requires a Mac or PC to refresh periodically
+            \u{2022} SideStore \u{2014} wireless alternative to AltStore
+            \u{2022} SideJITServer \u{2014} lightweight local server for over-the-air JIT
+            \u{2022} StikDebug \u{2014} on-device JIT enabler (requires compatible setup)
+            \u{2022} TrollStore \u{2014} permanent JIT for supported iOS/iPadOS versions
 
             After enabling JIT, return to the game and the indicator will update automatically.
             """,
@@ -176,12 +175,12 @@ public final class JITStatusIndicatorViewController: UIViewController {
             // Dismiss any lingering "unavailable" toast
             PVToastManager.shared.dismiss(id: jitUnavailableToastID)
             let label = viewModel.indicatorLabel
-            PVToastManager.shared.show("JIT active — \(label)", type: .jit, duration: 4.0)
+            PVToastManager.shared.show("JIT active \u{2014} \(label)", type: .jit, duration: 4.0)
 
         case .unavailable:
             // Persistent toast so the user always sees the guidance
             PVToastManager.shared.showPersistent(
-                "JIT required — enable via AltStore, SideJITServer, or StikDebug",
+                "JIT required \u{2014} enable via AltStore, SideJITServer, or StikDebug",
                 id: jitUnavailableToastID,
                 type: .error,
                 icon: "bolt.slash.fill"
@@ -191,7 +190,7 @@ public final class JITStatusIndicatorViewController: UIViewController {
             PVToastManager.shared.dismiss(id: jitUnavailableToastID)
             if previousStatus == .active {
                 PVToastManager.shared.show(
-                    "JIT lost — running in compatibility mode",
+                    "JIT lost \u{2014} running in compatibility mode",
                     type: .warning,
                     duration: 5.0
                 )

--- a/PVUI/Sources/PVUIBase/SwiftUI/Components/JIT/JITStatusIndicatorViewController.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/Components/JIT/JITStatusIndicatorViewController.swift
@@ -79,7 +79,9 @@ public final class JITStatusIndicatorViewController: UIViewController {
         // Stays out of the way of game content at the top of the screen.
         NSLayoutConstraint.activate([
             host.view.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            host.view.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -2)
+            host.view.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -2),
+            host.view.leadingAnchor.constraint(greaterThanOrEqualTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 8),
+            host.view.trailingAnchor.constraint(lessThanOrEqualTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -8)
         ])
 
         host.didMove(toParent: self)

--- a/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/Catalog/SkinCatalogDetailView.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/Catalog/SkinCatalogDetailView.swift
@@ -26,10 +26,6 @@ public struct SkinCatalogDetailView: View {
     @State private var screenshotIndex = 0
     @State private var glowIntensity: CGFloat = 0.5
     @State private var downloadTask: Task<Void, Never>?
-    @State private var skinActivationState: SkinActivationState = .idle
-
-    /// Observe the skin manager so we can detect already-installed skins.
-    @StateObject private var skinManager = DeltaSkinManager.shared
 
     // MARK: - Types
 
@@ -38,13 +34,6 @@ public struct SkinCatalogDetailView: View {
         case downloading(progress: Double)
         case installing
         case installed
-        case failed(String)
-    }
-
-    private enum SkinActivationState: Equatable {
-        case idle
-        case activating
-        case activated
         case failed(String)
     }
 
@@ -80,14 +69,6 @@ public struct SkinCatalogDetailView: View {
             withAnimation(.easeInOut(duration: 1.5).repeatForever(autoreverses: true)) {
                 glowIntensity = 0.8
             }
-            // Check if this skin is already installed locally so the
-            // action section shows "INSTALLED" instead of "DOWNLOAD".
-            checkIfAlreadyInstalled()
-        }
-        .onChange(of: skinManager.skinsAreLoaded) { _, loaded in
-            // Re-check once skins finish loading (scan may complete after
-            // onAppear if it was triggered lazily).
-            if loaded { checkIfAlreadyInstalled() }
         }
         .onDisappear {
             downloadTask?.cancel()
@@ -337,7 +318,25 @@ public struct SkinCatalogDetailView: View {
                     .shadow(color: RetroTheme.retroPink.opacity(0.4), radius: 6)
 
                     if let system = primarySystemIdentifier {
-                        activateSkinButton(for: system)
+                        NavigationLink(destination: SystemSkinSelectionView(system: system)) {
+                            HStack(spacing: 8) {
+                                Image(systemName: "checkmark.seal.fill")
+                                    .font(.system(size: 16))
+                                    .foregroundStyle(RetroTheme.retroHorizontalGradient)
+                                Text("SET AS ACTIVE SKIN")
+                                    .font(.system(size: 15, weight: .bold, design: .rounded))
+                                    .foregroundStyle(RetroTheme.retroHorizontalGradient)
+                                    .tracking(1)
+                            }
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 12)
+                            .background(
+                                RoundedRectangle(cornerRadius: 10)
+                                    .fill(Color.black.opacity(0.4))
+                                    .overlay(RoundedRectangle(cornerRadius: 10).strokeBorder(RetroTheme.retroGradient, lineWidth: 1.5))
+                            )
+                        }
+                        .buttonStyle(PlainButtonStyle())
                     }
                 }
 
@@ -591,198 +590,6 @@ public struct SkinCatalogDetailView: View {
         return entry.systems.lazy.compactMap {
             DeltaSkinGameType.fromAnyString($0)?.systemIdentifier
         }.first
-    }
-
-    // MARK: - Activate Skin Button
-
-    @ViewBuilder
-    private func activateSkinButton(for system: SystemIdentifier) -> some View {
-        switch skinActivationState {
-        case .idle:
-            Button {
-                Task { await activateSkin(for: system) }
-            } label: {
-                HStack(spacing: 8) {
-                    Image(systemName: "checkmark.seal.fill")
-                        .font(.system(size: 16))
-                        .foregroundStyle(RetroTheme.retroHorizontalGradient)
-                    Text("SET AS ACTIVE SKIN")
-                        .font(.system(size: 15, weight: .bold, design: .rounded))
-                        .foregroundStyle(RetroTheme.retroHorizontalGradient)
-                        .tracking(1)
-                }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 12)
-                .background(
-                    RoundedRectangle(cornerRadius: 10)
-                        .fill(Color.black.opacity(0.4))
-                        .overlay(RoundedRectangle(cornerRadius: 10).strokeBorder(RetroTheme.retroGradient, lineWidth: 1.5))
-                )
-            }
-            .buttonStyle(PlainButtonStyle())
-
-        case .activating:
-            HStack(spacing: 10) {
-                ProgressView()
-                    .tint(RetroTheme.retroPink)
-                Text("ACTIVATING...")
-                    .font(.system(size: 14, weight: .bold, design: .rounded))
-                    .foregroundStyle(RetroTheme.retroHorizontalGradient)
-                    .tracking(1)
-            }
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 12)
-            .background(
-                RoundedRectangle(cornerRadius: 10)
-                    .fill(Color.black.opacity(0.4))
-                    .overlay(RoundedRectangle(cornerRadius: 10).strokeBorder(RetroTheme.retroGradient, lineWidth: 1.5))
-            )
-
-        case .activated:
-            HStack(spacing: 8) {
-                Image(systemName: "checkmark.seal.fill")
-                    .font(.system(size: 16))
-                    .foregroundColor(.green)
-                Text("ACTIVE SKIN SET")
-                    .font(.system(size: 15, weight: .bold, design: .rounded))
-                    .foregroundColor(.green)
-                    .tracking(1)
-            }
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 12)
-            .background(
-                RoundedRectangle(cornerRadius: 10)
-                    .fill(Color.black.opacity(0.4))
-                    .overlay(RoundedRectangle(cornerRadius: 10).strokeBorder(Color.green.opacity(0.6), lineWidth: 1.5))
-            )
-
-        case .failed(let message):
-            VStack(spacing: 6) {
-                HStack(spacing: 8) {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .font(.system(size: 14))
-                        .foregroundColor(.orange)
-                    Text("ACTIVATION FAILED")
-                        .font(.system(size: 13, weight: .bold, design: .rounded))
-                        .foregroundColor(.orange)
-                        .tracking(1)
-                }
-                Text(message)
-                    .font(.system(size: 11))
-                    .foregroundColor(.white.opacity(0.6))
-                    .multilineTextAlignment(.center)
-                Button {
-                    Task { await activateSkin(for: system) }
-                } label: {
-                    Text("RETRY")
-                        .font(.system(size: 13, weight: .bold, design: .rounded))
-                        .foregroundStyle(RetroTheme.retroHorizontalGradient)
-                        .tracking(1)
-                        .padding(.vertical, 8)
-                        .padding(.horizontal, 20)
-                        .background(
-                            RoundedRectangle(cornerRadius: 8)
-                                .fill(Color.black.opacity(0.4))
-                                .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(RetroTheme.retroGradient, lineWidth: 1))
-                        )
-                }
-                .buttonStyle(PlainButtonStyle())
-            }
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 12)
-            .background(
-                RoundedRectangle(cornerRadius: 10)
-                    .fill(Color.black.opacity(0.4))
-                    .overlay(RoundedRectangle(cornerRadius: 10).strokeBorder(Color.orange.opacity(0.4), lineWidth: 1))
-            )
-        }
-    }
-
-    // MARK: - Activate Skin Logic
-
-    /// Activates the just-installed skin by finding it in the skin manager
-    /// and setting it as the system default for all supported orientations.
-    private func activateSkin(for system: SystemIdentifier) async {
-        await MainActor.run {
-            withAnimation(.easeInOut(duration: 0.2)) {
-                skinActivationState = .activating
-            }
-        }
-
-        do {
-            // Find the installed skin by matching name
-            let skins = try await DeltaSkinManager.shared.skins(for: system)
-            guard let installedSkin = skins.first(where: { $0.name == entry.name }) else {
-                throw NSError(
-                    domain: "SkinCatalog",
-                    code: 1,
-                    userInfo: [NSLocalizedDescriptionKey: "Could not find installed skin '\(entry.name)' for this system."]
-                )
-            }
-
-            let selectionManager = DeltaSkinSelectionManager.shared
-            let identifier = installedSkin.identifier
-
-            // Set the skin as active for both orientations at system scope
-            for orientation in SkinOrientation.allCases {
-                await selectionManager.setSkin(
-                    identifier,
-                    for: system,
-                    orientation: orientation,
-                    scope: .system
-                )
-            }
-
-            ILOG("SkinCatalogDetailView: Activated skin '\(entry.name)' (\(identifier ?? "no id")) for system \(system.rawValue)")
-
-            await MainActor.run {
-                withAnimation(.spring(response: 0.4, dampingFraction: 0.7)) {
-                    skinActivationState = .activated
-                }
-            }
-        } catch {
-            ELOG("SkinCatalogDetailView: Failed to activate skin '\(entry.name)': \(error)")
-            await MainActor.run {
-                withAnimation(.easeInOut(duration: 0.2)) {
-                    skinActivationState = .failed(error.localizedDescription)
-                }
-            }
-        }
-    }
-
-    // MARK: - Installed Check
-
-    /// Sets `downloadState` to `.installed` when the catalog entry matches a
-    /// locally installed skin. Uses the same multi-strategy matching as the
-    /// browser grid (identifier, filename, name).
-    private func checkIfAlreadyInstalled() {
-        // Only override when we haven't already started a download/install.
-        guard downloadState == .idle else { return }
-
-        let skins = skinManager.loadedSkins
-        guard !skins.isEmpty else { return }
-
-        let isInstalled: Bool = {
-            // 1. Identifier match
-            if skins.contains(where: { $0.identifier == entry.id }) { return true }
-
-            // 2. Filename match
-            let catalogStem = entry.downloadURL.deletingPathExtension().lastPathComponent.lowercased()
-            if !catalogStem.isEmpty,
-               skins.contains(where: { $0.fileURL.deletingPathExtension().lastPathComponent.lowercased() == catalogStem }) {
-                return true
-            }
-
-            // 3. Name match (case-insensitive)
-            let nameLower = entry.name.lowercased()
-            if skins.contains(where: { $0.name.lowercased() == nameLower }) { return true }
-
-            return false
-        }()
-
-        if isInstalled {
-            downloadState = .installed
-        }
     }
 
     // MARK: - Download & Install Logic

--- a/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/Catalog/SkinCatalogDetailView.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/DeltaSkins/Views/Catalog/SkinCatalogDetailView.swift
@@ -26,6 +26,10 @@ public struct SkinCatalogDetailView: View {
     @State private var screenshotIndex = 0
     @State private var glowIntensity: CGFloat = 0.5
     @State private var downloadTask: Task<Void, Never>?
+    @State private var skinActivationState: SkinActivationState = .idle
+
+    /// Observe the skin manager so we can detect already-installed skins.
+    @StateObject private var skinManager = DeltaSkinManager.shared
 
     // MARK: - Types
 
@@ -34,6 +38,13 @@ public struct SkinCatalogDetailView: View {
         case downloading(progress: Double)
         case installing
         case installed
+        case failed(String)
+    }
+
+    private enum SkinActivationState: Equatable {
+        case idle
+        case activating
+        case activated
         case failed(String)
     }
 
@@ -69,6 +80,14 @@ public struct SkinCatalogDetailView: View {
             withAnimation(.easeInOut(duration: 1.5).repeatForever(autoreverses: true)) {
                 glowIntensity = 0.8
             }
+            // Check if this skin is already installed locally so the
+            // action section shows "INSTALLED" instead of "DOWNLOAD".
+            checkIfAlreadyInstalled()
+        }
+        .onChange(of: skinManager.skinsAreLoaded) { _, loaded in
+            // Re-check once skins finish loading (scan may complete after
+            // onAppear if it was triggered lazily).
+            if loaded { checkIfAlreadyInstalled() }
         }
         .onDisappear {
             downloadTask?.cancel()
@@ -318,25 +337,7 @@ public struct SkinCatalogDetailView: View {
                     .shadow(color: RetroTheme.retroPink.opacity(0.4), radius: 6)
 
                     if let system = primarySystemIdentifier {
-                        NavigationLink(destination: SystemSkinSelectionView(system: system)) {
-                            HStack(spacing: 8) {
-                                Image(systemName: "checkmark.seal.fill")
-                                    .font(.system(size: 16))
-                                    .foregroundStyle(RetroTheme.retroHorizontalGradient)
-                                Text("SET AS ACTIVE SKIN")
-                                    .font(.system(size: 15, weight: .bold, design: .rounded))
-                                    .foregroundStyle(RetroTheme.retroHorizontalGradient)
-                                    .tracking(1)
-                            }
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 12)
-                            .background(
-                                RoundedRectangle(cornerRadius: 10)
-                                    .fill(Color.black.opacity(0.4))
-                                    .overlay(RoundedRectangle(cornerRadius: 10).strokeBorder(RetroTheme.retroGradient, lineWidth: 1.5))
-                            )
-                        }
-                        .buttonStyle(PlainButtonStyle())
+                        activateSkinButton(for: system)
                     }
                 }
 
@@ -590,6 +591,198 @@ public struct SkinCatalogDetailView: View {
         return entry.systems.lazy.compactMap {
             DeltaSkinGameType.fromAnyString($0)?.systemIdentifier
         }.first
+    }
+
+    // MARK: - Activate Skin Button
+
+    @ViewBuilder
+    private func activateSkinButton(for system: SystemIdentifier) -> some View {
+        switch skinActivationState {
+        case .idle:
+            Button {
+                Task { await activateSkin(for: system) }
+            } label: {
+                HStack(spacing: 8) {
+                    Image(systemName: "checkmark.seal.fill")
+                        .font(.system(size: 16))
+                        .foregroundStyle(RetroTheme.retroHorizontalGradient)
+                    Text("SET AS ACTIVE SKIN")
+                        .font(.system(size: 15, weight: .bold, design: .rounded))
+                        .foregroundStyle(RetroTheme.retroHorizontalGradient)
+                        .tracking(1)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+                .background(
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(Color.black.opacity(0.4))
+                        .overlay(RoundedRectangle(cornerRadius: 10).strokeBorder(RetroTheme.retroGradient, lineWidth: 1.5))
+                )
+            }
+            .buttonStyle(PlainButtonStyle())
+
+        case .activating:
+            HStack(spacing: 10) {
+                ProgressView()
+                    .tint(RetroTheme.retroPink)
+                Text("ACTIVATING...")
+                    .font(.system(size: 14, weight: .bold, design: .rounded))
+                    .foregroundStyle(RetroTheme.retroHorizontalGradient)
+                    .tracking(1)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 12)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(Color.black.opacity(0.4))
+                    .overlay(RoundedRectangle(cornerRadius: 10).strokeBorder(RetroTheme.retroGradient, lineWidth: 1.5))
+            )
+
+        case .activated:
+            HStack(spacing: 8) {
+                Image(systemName: "checkmark.seal.fill")
+                    .font(.system(size: 16))
+                    .foregroundColor(.green)
+                Text("ACTIVE SKIN SET")
+                    .font(.system(size: 15, weight: .bold, design: .rounded))
+                    .foregroundColor(.green)
+                    .tracking(1)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 12)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(Color.black.opacity(0.4))
+                    .overlay(RoundedRectangle(cornerRadius: 10).strokeBorder(Color.green.opacity(0.6), lineWidth: 1.5))
+            )
+
+        case .failed(let message):
+            VStack(spacing: 6) {
+                HStack(spacing: 8) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.system(size: 14))
+                        .foregroundColor(.orange)
+                    Text("ACTIVATION FAILED")
+                        .font(.system(size: 13, weight: .bold, design: .rounded))
+                        .foregroundColor(.orange)
+                        .tracking(1)
+                }
+                Text(message)
+                    .font(.system(size: 11))
+                    .foregroundColor(.white.opacity(0.6))
+                    .multilineTextAlignment(.center)
+                Button {
+                    Task { await activateSkin(for: system) }
+                } label: {
+                    Text("RETRY")
+                        .font(.system(size: 13, weight: .bold, design: .rounded))
+                        .foregroundStyle(RetroTheme.retroHorizontalGradient)
+                        .tracking(1)
+                        .padding(.vertical, 8)
+                        .padding(.horizontal, 20)
+                        .background(
+                            RoundedRectangle(cornerRadius: 8)
+                                .fill(Color.black.opacity(0.4))
+                                .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(RetroTheme.retroGradient, lineWidth: 1))
+                        )
+                }
+                .buttonStyle(PlainButtonStyle())
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 12)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(Color.black.opacity(0.4))
+                    .overlay(RoundedRectangle(cornerRadius: 10).strokeBorder(Color.orange.opacity(0.4), lineWidth: 1))
+            )
+        }
+    }
+
+    // MARK: - Activate Skin Logic
+
+    /// Activates the just-installed skin by finding it in the skin manager
+    /// and setting it as the system default for all supported orientations.
+    private func activateSkin(for system: SystemIdentifier) async {
+        await MainActor.run {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                skinActivationState = .activating
+            }
+        }
+
+        do {
+            // Find the installed skin by matching name
+            let skins = try await DeltaSkinManager.shared.skins(for: system)
+            guard let installedSkin = skins.first(where: { $0.name == entry.name }) else {
+                throw NSError(
+                    domain: "SkinCatalog",
+                    code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "Could not find installed skin '\(entry.name)' for this system."]
+                )
+            }
+
+            let selectionManager = DeltaSkinSelectionManager.shared
+            let identifier = installedSkin.identifier
+
+            // Set the skin as active for both orientations at system scope
+            for orientation in SkinOrientation.allCases {
+                await selectionManager.setSkin(
+                    identifier,
+                    for: system,
+                    orientation: orientation,
+                    scope: .system
+                )
+            }
+
+            ILOG("SkinCatalogDetailView: Activated skin '\(entry.name)' (\(identifier ?? "no id")) for system \(system.rawValue)")
+
+            await MainActor.run {
+                withAnimation(.spring(response: 0.4, dampingFraction: 0.7)) {
+                    skinActivationState = .activated
+                }
+            }
+        } catch {
+            ELOG("SkinCatalogDetailView: Failed to activate skin '\(entry.name)': \(error)")
+            await MainActor.run {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    skinActivationState = .failed(error.localizedDescription)
+                }
+            }
+        }
+    }
+
+    // MARK: - Installed Check
+
+    /// Sets `downloadState` to `.installed` when the catalog entry matches a
+    /// locally installed skin. Uses the same multi-strategy matching as the
+    /// browser grid (identifier, filename, name).
+    private func checkIfAlreadyInstalled() {
+        // Only override when we haven't already started a download/install.
+        guard downloadState == .idle else { return }
+
+        let skins = skinManager.loadedSkins
+        guard !skins.isEmpty else { return }
+
+        let isInstalled: Bool = {
+            // 1. Identifier match
+            if skins.contains(where: { $0.identifier == entry.id }) { return true }
+
+            // 2. Filename match
+            let catalogStem = entry.downloadURL.deletingPathExtension().lastPathComponent.lowercased()
+            if !catalogStem.isEmpty,
+               skins.contains(where: { $0.fileURL.deletingPathExtension().lastPathComponent.lowercased() == catalogStem }) {
+                return true
+            }
+
+            // 3. Name match (case-insensitive)
+            let nameLower = entry.name.lowercased()
+            if skins.contains(where: { $0.name.lowercased() == nameLower }) { return true }
+
+            return false
+        }()
+
+        if isInstalled {
+            downloadState = .installed
+        }
     }
 
     // MARK: - Download & Install Logic


### PR DESCRIPTION
## Summary
- Moved JIT indicator from top-left to bottom-center
- Reduced to 6pt LED-style dot with semi-transparent capsule background
- Added 5-second auto-hide with 0.6s fade animation
- Tap-to-reveal after auto-hide, auto-reveals on status change
- Moved `PVIndicatorOverlayView` to bottom-right with matching auto-hide

Closes #3186

## Test plan
- [ ] Launch a game — JIT indicator should appear at bottom edge
- [ ] Verify it auto-hides after ~5 seconds
- [ ] Tap the indicator area — should reappear briefly
- [ ] Verify it doesn't cover game video

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>