### PR TITLE
[Agent] fix(hatari): prevent --acsi "" crash + add verbose debug logging (#3282)

### DIFF
--- a/CoresRetro/RetroArch/PVRetroArchCore/Core/PVRetroArchCore+BIOS+AtariST.m
+++ b/CoresRetro/RetroArch/PVRetroArchCore/Core/PVRetroArchCore+BIOS+AtariST.m
@@ -592,11 +592,36 @@ static NSArray<NSString *> *TOSAllFilenames(void) {
     NSString *cfgSource = [[NSBundle bundleForClass:[PVRetroArchCoreBridge class]]
                            pathForResource:@"hatari.cfg" ofType:nil];
 
+    DLOG(@"Hatari: writeHatariConfigForSystemDir — systemDir: %@", systemDir);
+    DLOG(@"Hatari: config destinations: hatari/hatari.cfg=%@, hatari.cfg=%@", hatariWorkCfgPath, hatariCfgPath);
+
+    // Log any pre-existing on-disk hatari.cfg so we can compare before vs after.
+    NSString *existingWorkCfg = [NSString stringWithContentsOfFile:hatariWorkCfgPath
+                                                          encoding:NSUTF8StringEncoding
+                                                             error:nil];
+    if (existingWorkCfg) {
+        // Extract relevant HD/ACSI lines for the debug log (avoids dumping the whole file).
+        NSMutableArray<NSString *> *hdLines = [NSMutableArray array];
+        for (NSString *line in [existingWorkCfg componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]]) {
+            NSString *lower = line.lowercaseString;
+            if ([lower containsString:@"harddisk"] || [lower containsString:@"bootfrom"] ||
+                [lower containsString:@"acsi"] || [lower containsString:@"devicefile"] ||
+                [lower containsString:@"devicetype"]) {
+                [hdLines addObject:line];
+            }
+        }
+        DLOG(@"Hatari: BEFORE write — HD/ACSI lines in hatari/hatari.cfg:\n%@",
+             hdLines.count ? [hdLines componentsJoinedByString:@"\n"] : @"(none found)");
+    } else {
+        DLOG(@"Hatari: BEFORE write — hatari/hatari.cfg does not exist yet at %@", hatariWorkCfgPath);
+    }
+
     if (!cfgSource) {
         ELOG(@"Hatari: bundled hatari.cfg not found — cannot write config");
         return;
     }
 
+    DLOG(@"Hatari: reading bundled hatari.cfg template from %@", cfgSource);
     NSError *readErr = nil;
     NSString *cfgContent = [NSString stringWithContentsOfFile:cfgSource
                                                       encoding:NSUTF8StringEncoding
@@ -608,6 +633,19 @@ static NSArray<NSString *> *TOSAllFilenames(void) {
         [self syncResource:cfgSource to:hatariCfgPath];
         [self syncResource:cfgSource to:hatariWorkCfgPath];
         return;
+    }
+
+    // Verify the template contains HD/ACSI sections (regression guard).
+    BOOL hasHardDiskSection = [cfgContent containsString:@"[HardDisk]"];
+    BOOL hasAcsiSection     = [cfgContent containsString:@"[ACSI]"];
+    BOOL hasBootFromHD      = [cfgContent containsString:@"bBootFromHardDisk"];
+    BOOL hasHDImageDisabled = [cfgContent containsString:@"bUseHardDiskImage = FALSE"];
+    DLOG(@"Hatari: template validation — [HardDisk]=%d [ACSI]=%d bBootFromHardDisk=%d bUseHardDiskImage=FALSE: %d",
+         hasHardDiskSection, hasAcsiSection, hasBootFromHD, hasHDImageDisabled);
+    if (!hasHardDiskSection || !hasAcsiSection || !hasBootFromHD || !hasHDImageDisabled) {
+        ELOG(@"Hatari: bundled hatari.cfg template is MISSING required HD/ACSI disable keys! "
+             @"--acsi \"\" crash may still occur. [HardDisk]=%d [ACSI]=%d bBootFromHardDisk=%d bUseHardDiskImage=FALSE:%d",
+             hasHardDiskSection, hasAcsiSection, hasBootFromHD, hasHDImageDisabled);
     }
 
     // Embed absolute TOS path so Hatari finds the ROM regardless of cwd.
@@ -657,6 +695,18 @@ static NSArray<NSString *> *TOSAllFilenames(void) {
                                       error:&legacyWriteErr];
     if (workOK && legacyOK) {
         ILOG(@"Hatari: hatari.cfg written — TOS: %@, ROMs: %@", sysTosPath, romsDirectory);
+        // Log the AFTER state so we can confirm HD/ACSI sections were written.
+        NSMutableArray<NSString *> *afterLines = [NSMutableArray array];
+        for (NSString *line in [cfgContent componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]]) {
+            NSString *lower = line.lowercaseString;
+            if ([lower containsString:@"harddisk"] || [lower containsString:@"bootfrom"] ||
+                [lower containsString:@"acsi"] || [lower containsString:@"devicefile"] ||
+                [lower containsString:@"devicetype"]) {
+                [afterLines addObject:line];
+            }
+        }
+        DLOG(@"Hatari: AFTER write — HD/ACSI lines in hatari/hatari.cfg:\n%@",
+             afterLines.count ? [afterLines componentsJoinedByString:@"\n"] : @"(none found — template missing sections!)");
     } else {
         if (!workOK) ELOG(@"Hatari: failed to write hatari.cfg to %@: %@", hatariWorkCfgPath, workWriteErr);
         if (!legacyOK) ELOG(@"Hatari: failed to write hatari.cfg to %@: %@", hatariCfgPath, legacyWriteErr);

--- a/CoresRetro/RetroArch/PVRetroArchCore/Core/PVRetroArchCore+BIOS+AtariST.m
+++ b/CoresRetro/RetroArch/PVRetroArchCore/Core/PVRetroArchCore+BIOS+AtariST.m
@@ -639,7 +639,21 @@ static NSArray<NSString *> *TOSAllFilenames(void) {
     BOOL hasHardDiskSection = [cfgContent containsString:@"[HardDisk]"];
     BOOL hasAcsiSection     = [cfgContent containsString:@"[ACSI]"];
     BOOL hasBootFromHD      = [cfgContent containsString:@"bBootFromHardDisk"];
-    BOOL hasHDImageDisabled = [cfgContent containsString:@"bUseHardDiskImage = FALSE"];
+
+    // Allow for harmless whitespace/formatting changes around the assignment.
+    BOOL hasHDImageDisabled = NO;
+    NSError *hdRegexError = nil;
+    NSRegularExpression *hdRegex = [NSRegularExpression
+        regularExpressionWithPattern:@"bUseHardDiskImage\\s*=\\s*FALSE"
+                             options:NSRegularExpressionCaseInsensitive
+                               error:&hdRegexError];
+    if (hdRegex != nil) {
+        NSRange fullRange = NSMakeRange(0, (NSUInteger)cfgContent.length);
+        hasHDImageDisabled = [hdRegex firstMatchInString:cfgContent
+                                                 options:0
+                                                   range:fullRange] != nil;
+    }
+
     DLOG(@"Hatari: template validation — [HardDisk]=%d [ACSI]=%d bBootFromHardDisk=%d bUseHardDiskImage=FALSE: %d",
          hasHardDiskSection, hasAcsiSection, hasBootFromHD, hasHDImageDisabled);
     if (!hasHardDiskSection || !hasAcsiSection || !hasBootFromHD || !hasHDImageDisabled) {

--- a/CoresRetro/RetroArch/PVRetroArchCore/Core/PVRetroArchCore+RetroArchUI.m
+++ b/CoresRetro/RetroArch/PVRetroArchCore/Core/PVRetroArchCore+RetroArchUI.m
@@ -695,9 +695,26 @@ void extract_bundles();
                                                                      error:nil];
                 if (prevContent) {
                     NSRange bootHdRange = [prevContent rangeOfString:@"hatari_boot_hd"];
-                    NSString *prevBootHd = (bootHdRange.location != NSNotFound)
-                        ? [prevContent substringWithRange:bootHdRange]
-                        : @"(key absent)";
+                    NSString *prevBootHd = nil;
+                    if (bootHdRange.location != NSNotFound) {
+                        NSUInteger lineStart = bootHdRange.location;
+                        NSRange beforeNewlineRange = [prevContent rangeOfString:@"\n"
+                                                                         options:NSBackwardsSearch
+                                                                           range:NSMakeRange(0, bootHdRange.location)];
+                        if (beforeNewlineRange.location != NSNotFound) {
+                            lineStart = beforeNewlineRange.location + beforeNewlineRange.length;
+                        }
+                        NSRange afterNewlineRange = [prevContent rangeOfString:@"\n"
+                                                                        options:0
+                                                                          range:NSMakeRange(bootHdRange.location,
+                                                                                            prevContent.length - bootHdRange.location)];
+                        NSUInteger lineEnd = (afterNewlineRange.location != NSNotFound)
+                            ? afterNewlineRange.location
+                            : prevContent.length;
+                        prevBootHd = [prevContent substringWithRange:NSMakeRange(lineStart, lineEnd - lineStart)];
+                    } else {
+                        prevBootHd = @"(key absent)";
+                    }
                     DLOG(@"Hatari opts BEFORE overwrite — hatari_boot_hd: %@, file: %@", prevBootHd, fileName);
                 } else {
                     DLOG(@"Hatari opts BEFORE overwrite — file did not exist at %@", fileName);

--- a/CoresRetro/RetroArch/PVRetroArchCore/Core/PVRetroArchCore+RetroArchUI.m
+++ b/CoresRetro/RetroArch/PVRetroArchCore/Core/PVRetroArchCore+RetroArchUI.m
@@ -1,5 +1,5 @@
 //
-//  PVRetroArchCoreBridge.m
+//  PVRetroArchCore+RetroArchUI.m
 //  PVRetroArch
 //
 //  Created by Joseph Mattiello on 4/6/18.
@@ -688,11 +688,44 @@ void extract_bundles();
         fileName = [NSString stringWithFormat:@"%@/RetroArch/config/%@", self.documentsDirectory, self.coreOptionConfigPath];
         if (![fm fileExistsAtPath: fileName] || self.coreOptionOverwrite) {
             [fm createDirectoryAtPath:[fileName stringByDeletingLastPathComponent] withIntermediateDirectories:YES attributes:nil error:nil];
-            [self.coreOptionConfig writeToFile:fileName
+            // Log BEFORE state for Hatari to confirm what was on disk previously.
+            if ([self pv_isHatariSystem]) {
+                NSString *prevContent = [NSString stringWithContentsOfFile:fileName
+                                                                  encoding:NSUTF8StringEncoding
+                                                                     error:nil];
+                if (prevContent) {
+                    NSRange bootHdRange = [prevContent rangeOfString:@"hatari_boot_hd"];
+                    NSString *prevBootHd = (bootHdRange.location != NSNotFound)
+                        ? [prevContent substringWithRange:bootHdRange]
+                        : @"(key absent)";
+                    DLOG(@"Hatari opts BEFORE overwrite — hatari_boot_hd: %@, file: %@", prevBootHd, fileName);
+                } else {
+                    DLOG(@"Hatari opts BEFORE overwrite — file did not exist at %@", fileName);
+                }
+            }
+            NSError *optWriteErr = nil;
+            BOOL optWriteOK = [self.coreOptionConfig writeToFile:fileName
                                     atomically:NO
                                     encoding:NSStringEncodingConversionAllowLossy
-                                        error:nil];
-            ILOG(@"Core option config written to %@", fileName);
+                                        error:&optWriteErr];
+            if (optWriteOK) {
+                ILOG(@"Core option config written to %@", fileName);
+                if ([self pv_isHatariSystem]) {
+                    // Log AFTER state so we can confirm hatari_boot_hd was written correctly.
+                    NSString *afterContent = [NSString stringWithContentsOfFile:fileName
+                                                                       encoding:NSUTF8StringEncoding
+                                                                          error:nil] ?: @"(read failed)";
+                    NSRange afterRange = [afterContent rangeOfString:@"hatari_boot_hd"];
+                    NSString *afterBootHd = (afterRange.location != NSNotFound)
+                        ? [afterContent substringWithRange:NSMakeRange(afterRange.location,
+                            MIN(40u, afterContent.length - afterRange.location))]
+                        : @"(key absent — write may have failed)";
+                    ILOG(@"Hatari opts AFTER overwrite — hatari_boot_hd: %@, file: %@", afterBootHd, fileName);
+                }
+            } else {
+                ELOG(@"Core option config write failed for %@: %@",
+                     fileName, optWriteErr.localizedDescription);
+            }
         } else if ([self pv_isHatariSystem]) {
             /// The Hatari opts file already exists — do a targeted in-place key repair so we
             /// never wipe user-configured options.  The hatari core uses "disabled"/"enabled"
@@ -703,6 +736,7 @@ void extract_bundles();
                                                            encoding:NSUTF8StringEncoding
                                                               error:&hatariReadErr];
             if (!hatariReadErr && existing) {
+                DLOG(@"Hatari opts BEFORE in-place repair — full content of %@:\n%@", fileName, existing);
                 NSString *correct = @"hatari_boot_hd = \"disabled\"";
                 NSString *updated = nil;
                 /// Replace ANY invalid hatari_boot_hd value. The hatari core ONLY accepts
@@ -727,6 +761,8 @@ void extract_bundles();
                                                                     withString:correct];
                         updated = existing;
                         ILOG(@"Hatari opts: corrected invalid hatari_boot_hd line (%@) → \"disabled\"", line);
+                    } else {
+                        DLOG(@"Hatari opts: hatari_boot_hd line already valid (%@) — no repair needed", line);
                     }
                 }
                 if (!updated && ![existing containsString:@"hatari_boot_hd"]) {
@@ -745,8 +781,15 @@ void extract_bundles();
                     if (hatariWriteErr) {
                         ELOG(@"Hatari opts repair write failed for %@: %@",
                              fileName, hatariWriteErr.localizedDescription);
+                    } else {
+                        ILOG(@"Hatari opts AFTER in-place repair — successfully wrote updated hatari_boot_hd to %@", fileName);
                     }
+                } else {
+                    DLOG(@"Hatari opts: no repair was needed for %@ — hatari_boot_hd is already correct", fileName);
                 }
+            } else if (hatariReadErr) {
+                ELOG(@"Hatari opts: failed to read %@ for in-place repair: %@",
+                     fileName, hatariReadErr.localizedDescription);
             }
         }
     } else if (self.coreOptionConfig.length > 0) {

--- a/CoresRetro/RetroArch/PVRetroArchCore/Core/runloop.c
+++ b/CoresRetro/RetroArch/PVRetroArchCore/Core/runloop.c
@@ -1422,10 +1422,17 @@ bool runloop_environment_cb(unsigned cmd, void *data)
 
             if (!var->value)
             {
-               /* Provenance: supply safe defaults for keys that crash when NULL */
+               /* Provenance: supply safe defaults for keys that crash when NULL.
+                * hatari_boot_hd: if this is NULL the Hatari core unconditionally
+                * appends "--acsi <sDeviceFile>" with an empty string, causing a
+                * fatal "Error: --acsi parameter MUST be a file name or '0'" abort.
+                * Forcing "disabled" here is the last-resort fallback; the primary
+                * fix is the [HardDisk]/[ACSI] sections in the bundled hatari.cfg. */
                if (var->key && strcmp(var->key, "hatari_boot_hd") == 0)
                {
-                  RARCH_WARN("[Environ]: GET_VARIABLE: %s had no valid value, defaulting to \"disabled\"\n", var->key);
+                  RARCH_WARN("[Environ]: GET_VARIABLE: %s had no valid value — "
+                             "ACSI crash guard: forcing \"disabled\" to prevent "
+                             "--acsi \"\" fatal error\n", var->key);
                   var->value = "disabled";
                }
                else

--- a/CoresRetro/RetroArch/PVRetroArchCore/Swift/PVRetroArchCore+Options.swift
+++ b/CoresRetro/RetroArch/PVRetroArchCore/Swift/PVRetroArchCore+Options.swift
@@ -719,9 +719,19 @@ extension PVRetroArchCoreBridge: CoreOptional, SubCoreOptional {
                 /// 2. A stale invalid value in the file corrupts the in-memory variable store
                 /// 3. The in-memory repair never takes effect for the current session
                 /// By always overwriting, we guarantee a clean state every launch.
+                ///
+                /// NOTE: The primary fix for --acsi "" is in the bundled hatari.cfg template
+                /// (Resources/hatari.cfg) which now includes [HardDisk] and [ACSI] sections
+                /// with all HD/ACSI emulation disabled.  This .opt file write is a secondary
+                /// defence that ensures the core option variable also reads "disabled".
+                let hatariOptPath = (self.documentsDirectory ?? "") + "/RetroArch/config/Hatari/Hatari.opt"
+                let optBefore = (try? String(contentsOfFile: hatariOptPath, encoding: .utf8)) ?? "(not found)"
+                DLOG("Hatari: hatari_boot_hd BEFORE fix in \(hatariOptPath):\n\(optBefore)")
                 optionValues += "hatari_boot_hd = \"disabled\"\n"
                 optionValuesFile = "Hatari/Hatari.opt"
                 optionOverwrite = true
+                ILOG("Hatari: queued hatari_boot_hd = \"disabled\" → will overwrite \(hatariOptPath)")
+                DLOG("Hatari: hatari_boot_hd AFTER scheduled write — new content will be:\n\(optionValues)")
             }
             if (coreIdentifier.contains("prboom")) {
                 optionValues += "prboom-rumble = \"enabled\"\n"

--- a/CoresRetro/RetroArch/Resources/hatari.cfg
+++ b/CoresRetro/RetroArch/Resources/hatari.cfg
@@ -64,3 +64,32 @@ nVdiColors = 16
 nVdiWidth = 640
 nVdiHeight = 480
 nVdiPlanes = 4
+
+[HardDisk]
+; Disable all hard disk emulation so --acsi "" is never passed on boot.
+; bUseHardDiskImage maps to Acsi[0].bUseDevice; szHardDiskImage maps to
+; Acsi[0].sDeviceFile.  Both must be clear to prevent the --acsi "" crash.
+bBootFromHardDisk = FALSE
+bUseHardDiskDirectory = FALSE
+bUseHardDiskImage = FALSE
+nHardDiskDrive = 0
+szHardDiskDirectory =
+szHardDiskImage =
+
+[ACSI]
+; Slots 1-7 have their own keys (slot 0 is covered by szHardDiskImage above).
+; bUseDevice must be FALSE and sDeviceFile must be empty for every slot.
+bUseDevice1 = FALSE
+sDeviceFile1 =
+bUseDevice2 = FALSE
+sDeviceFile2 =
+bUseDevice3 = FALSE
+sDeviceFile3 =
+bUseDevice4 = FALSE
+sDeviceFile4 =
+bUseDevice5 = FALSE
+sDeviceFile5 =
+bUseDevice6 = FALSE
+sDeviceFile6 =
+bUseDevice7 = FALSE
+sDeviceFile7 =


### PR DESCRIPTION
## Summary

- **Root cause fix**: Add `[HardDisk]` and `[ACSI]` sections to the bundled `hatari.cfg` template (`CoresRetro/RetroArch/Resources/hatari.cfg`) with all HD/ACSI emulation explicitly disabled. The binary reads this config at startup — when `bUseHardDiskImage = FALSE` and `szHardDiskImage =` (empty), `Acsi[0].sDeviceFile` stays empty and `--acsi ""` is never generated.
- **Verbose debug logging**: Added `DLOG`/`ILOG`/`ELOG` before and after every existing fix point so boot crashes are diagnosable in logs.
- **Regression guard**: `writeHatariConfigForSystemDir:` now validates that the bundled template contains required `[HardDisk]`/`[ACSI]` keys and logs an `ELOG` if they are missing.

## Root Cause Analysis

The `hatari_libretro_ios.dylib` binary unconditionally calls `--acsi <ConfigureParams.Acsi[0].sDeviceFile>`. `Acsi[0].sDeviceFile` is loaded from two places in `hatari.cfg`:
- `[HardDisk] szHardDiskImage` → maps to `Acsi[0].sDeviceFile` (slot 0)
- `[ACSI] sDeviceFile1`…`sDeviceFile7` → slots 1–7

The previous bundled `hatari.cfg` had neither section, so the binary used its compiled-in defaults (working directory path → non-empty string) → `--acsi <non-empty garbage>` or, after being cleared by GEMDOS init, `--acsi ""` → fatal error.

## Fix Layers (defense in depth)

| Layer | Where | What |
|-------|-------|------|
| **1 (primary)** | `Resources/hatari.cfg` | Add `[HardDisk]` + `[ACSI]` with all HD/ACSI disabled |
| **2** | `PVRetroArchCore+Options.swift` | Write `hatari_boot_hd = "disabled"` to `Hatari/Hatari.opt` (overwrite every launch) |
| **3** | `PVRetroArchCore+RetroArchUI.m` | In-place repair of `Hatari.opt` if it wasn't overwritten |
| **4** | `runloop.c` | Last-resort: if `GET_VARIABLE hatari_boot_hd` returns NULL, force `"disabled"` |

## Files Changed

- `CoresRetro/RetroArch/Resources/hatari.cfg` — add `[HardDisk]` and `[ACSI]` sections
- `CoresRetro/RetroArch/PVRetroArchCore/Core/PVRetroArchCore+BIOS+AtariST.m` — verbose before/after logging + template validation
- `CoresRetro/RetroArch/PVRetroArchCore/Core/PVRetroArchCore+RetroArchUI.m` — verbose before/after for both overwrite and in-place repair paths
- `CoresRetro/RetroArch/PVRetroArchCore/Swift/PVRetroArchCore+Options.swift` — log Hatari.opt before/after queued write
- `CoresRetro/RetroArch/PVRetroArchCore/Core/runloop.c` — expand crash guard comment to explain ACSI failure mode

## Test plan

- [ ] Boot an Atari ST ROM without any HD image configured — no crash
- [ ] Verify logs show `[HardDisk]` and `[ACSI]` sections written to `hatari/hatari.cfg`
- [ ] Verify logs show `hatari_boot_hd = "disabled"` confirmed in `Hatari/Hatari.opt`
- [ ] Boot with a ROM previously crashing — confirm it loads

Closes #3282

🤖 Generated with [Claude Code](https://claude.com/claude-code)