### PR TITLE
fix(release): stop leaking the ASC private key world-readable

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -136,10 +136,23 @@ jobs:
           if [ -n "${{ inputs.version }}" ]; then
             ARGS+=(--version "${{ inputs.version }}")
           fi
+          # xcbeautify is installed with `|| true` because it is purely cosmetic —
+          # the authoritative output is the raw log captured by tee. Piping into
+          # it unconditionally under `set -o pipefail` meant a Homebrew hiccup
+          # (or a runner image without it) failed the whole upload with
+          # "xcbeautify: command not found" instead of a real build error. Fall
+          # back to cat so only genuine failures fail this job.
+          FORMATTER=cat
+          if command -v xcbeautify >/dev/null 2>&1; then
+            FORMATTER=xcbeautify
+          else
+            echo "::warning::xcbeautify unavailable — using unformatted output (raw log is unaffected)"
+          fi
+
           # Build number: release.sh defaults to epoch seconds, which is unique
           # and strictly increasing, so App Store Connect never rejects a
           # redundant binary. Left as the default deliberately.
-          ./Scripts/release.sh "${ARGS[@]}" 2>&1 | tee /tmp/testflight.log | xcbeautify
+          ./Scripts/release.sh "${ARGS[@]}" 2>&1 | tee /tmp/testflight.log | "$FORMATTER"
 
       # Same rationale as build.yml: xcbeautify hides Run Script phase output,
       # so the raw log is the only place some failures appear.

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -136,18 +136,38 @@ inject_build_number() {
     # Back up the EXACT current file (not HEAD) so restore preserves any unrelated
     # uncommitted edits — a blanket `git checkout` here would silently wipe them.
     cp "$XCCONFIG" "$XCCONFIG_BAK"
+    _injected=true
     # BSD sed (macOS): -i '' for in-place, matching Scripts/bump-version.sh.
     sed -i '' "s/^CURRENT_PROJECT_VERSION[[:space:]]*=.*/CURRENT_PROJECT_VERSION = ${BUILD_NUMBER}/" "$XCCONFIG"
 }
 
+# Whether THIS run injected a build number (and therefore owns the backup).
+# Restoring must be conditional on this, not merely on the backup existing: a
+# leftover backup from a previously killed run is NOT ours, and a --dry-run that
+# restored it would both mutate the working tree and consume the one chance the
+# next real run had to self-heal.
+_injected=false
+
 restore_build_number() {
     # Restore the pre-inject file so the build number isn't left in the working tree.
-    # `return 0` so this EXIT-trap never sets a nonzero exit code when there's no backup
-    # (e.g. dry-run, which skips injection) — the trap's status becomes the script's.
+    # `return 0` so this EXIT-trap never sets a nonzero exit code — the trap's
+    # status becomes the script's.
+    $_injected || return 0
     [[ -f "$XCCONFIG_BAK" ]] && mv -f "$XCCONFIG_BAK" "$XCCONFIG"
     return 0
 }
-trap restore_build_number EXIT
+
+# Set by resolve_asc_key only when it had to materialise ASC_API_KEY_CONTENT.
+# A key we wrote ourselves must not outlive the run; a key the user pointed us
+# at via ASC_API_KEY_PATH is theirs and is left alone.
+_asc_key_tmpdir=""
+
+cleanup() {
+    restore_build_number
+    [[ -n "$_asc_key_tmpdir" && -d "$_asc_key_tmpdir" ]] && rm -rf "$_asc_key_tmpdir"
+    return 0
+}
+trap cleanup EXIT
 
 # Ctrl-C / SIGTERM: kill any xcodebuild we spawned, then let the EXIT trap
 # restore the xcconfig. Without this, interrupting a run left the injected
@@ -171,9 +191,17 @@ trap on_interrupt INT TERM
 # number in the xcconfig. Restore it before injecting a new one, otherwise the
 # backup gets overwritten with an already-poisoned file and the real value is
 # lost permanently.
+#
+# Gated on dry-run: `mv` here is a working-tree mutation, and --dry-run promises
+# not to make any. It also CONSUMES the backup, so a dry-run would silently use
+# up the one chance the next real run had to self-heal. Report and leave it.
 if [[ -f "$XCCONFIG_BAK" ]]; then
-    warn "Found leftover $(basename "$XCCONFIG_BAK") from an interrupted run — restoring it first"
-    mv -f "$XCCONFIG_BAK" "$XCCONFIG"
+    if $DRY_RUN; then
+        warn "Found leftover $(basename "$XCCONFIG_BAK") from an interrupted run — leaving it untouched (--dry-run); the next real run will restore it"
+    else
+        warn "Found leftover $(basename "$XCCONFIG_BAK") from an interrupted run — restoring it first"
+        mv -f "$XCCONFIG_BAK" "$XCCONFIG"
+    fi
 fi
 
 # Dry-run must not mutate the working tree at all (no inject, nothing to restore).
@@ -198,8 +226,17 @@ TVOS_ARCHIVE="$ARCHIVES_DIR/Provenance-tvOS.xcarchive"
 # Without this, `xcodebuild -exportArchive` (destination=upload) falls back to
 # Xcode's signed-in accounts and dies with "Failed to Use Accounts" in CLI.
 _asc_key_path=""
+# Sets the GLOBAL _asc_key_path; callers read that, they do not capture stdout.
+#
+# This used to `echo` the path, and both call sites used
+# `key="$(resolve_asc_key)"` — a command-substitution SUBSHELL. Every global the
+# function assigned was therefore written in a child process and lost on return,
+# which broke it two ways: the `_asc_key_path` memo never persisted, so the key
+# was re-materialised from ASC_API_KEY_CONTENT on EVERY call (once per platform
+# during archive, again at export), and the temp-dir bookkeeping the EXIT trap
+# needs never reached the parent, so each of those copies leaked.
 resolve_asc_key() {
-    [[ -n "$_asc_key_path" ]] && { echo "$_asc_key_path"; return 0; }
+    [[ -n "$_asc_key_path" ]] && return 0
     [[ -n "${ASC_API_KEY_ID:-}" ]]   || err "ASC_API_KEY_ID is not set (App Store Connect API key ID)"
     [[ -n "${ASC_API_ISSUER_ID:-}" ]] || err "ASC_API_ISSUER_ID is not set (App Store Connect issuer ID)"
     if [[ -n "${ASC_API_KEY_PATH:-}" ]]; then
@@ -211,18 +248,30 @@ resolve_asc_key() {
     elif [[ -f "$HOME/private_keys/AuthKey_${ASC_API_KEY_ID}.p8" ]]; then
         _asc_key_path="$HOME/private_keys/AuthKey_${ASC_API_KEY_ID}.p8"
     elif [[ -n "${ASC_API_KEY_CONTENT:-}" ]]; then
-        _asc_key_path="$(mktemp -t "AuthKey_${ASC_API_KEY_ID}").p8"
+        # Materialise into a 0700 temp DIRECTORY, not a temp file.
+        #
+        # This was `_asc_key_path="$(mktemp -t "AuthKey_${ID}").p8"`, which is a
+        # trap: mktemp creates its file and returns that path, then `.p8` is
+        # appended to the STRING. So the key was written to a path mktemp never
+        # created — meaning it was created by the shell redirect at the default
+        # umask, i.e. 0644 WORLD-READABLE, in a shared temp dir, while mktemp's
+        # actual 0600 file was left behind empty. That is an App Store Connect
+        # signing key readable by every user on the machine.
+        #
+        # mktemp -d is 0700, so the key inside it is unreachable by other users
+        # regardless of umask; the umask 077 keeps the file itself 0600 too.
+        _asc_key_tmpdir="$(mktemp -d -t provenance-asc)"
+        _asc_key_path="$_asc_key_tmpdir/AuthKey_${ASC_API_KEY_ID}.p8"
         # Accept either base64-encoded or raw PEM .p8 content.
         if printf '%s' "$ASC_API_KEY_CONTENT" | grep -q "BEGIN PRIVATE KEY"; then
-            printf '%s' "$ASC_API_KEY_CONTENT" > "$_asc_key_path"
+            ( umask 077; printf '%s' "$ASC_API_KEY_CONTENT" > "$_asc_key_path" )
         else
-            printf '%s' "$ASC_API_KEY_CONTENT" | base64 --decode > "$_asc_key_path" 2>/dev/null \
+            ( umask 077; printf '%s' "$ASC_API_KEY_CONTENT" | base64 --decode > "$_asc_key_path" ) 2>/dev/null \
                 || err "ASC_API_KEY_CONTENT is neither a valid .p8 nor base64"
         fi
     else
         err "No App Store Connect API key: set ASC_API_KEY_PATH or ASC_API_KEY_CONTENT"
     fi
-    echo "$_asc_key_path"
 }
 
 do_archive() {
@@ -248,7 +297,7 @@ do_archive() {
         # separately). Locally these vars are usually unset and Xcode uses the
         # signed-in account, so only add the flags when a key is available.
         if [[ -n "${ASC_API_KEY_ID:-}" && -n "${ASC_API_ISSUER_ID:-}" ]]; then
-            local archive_key; archive_key="$(resolve_asc_key)"
+            local archive_key; resolve_asc_key; archive_key="$_asc_key_path"
             cmd+=(-allowProvisioningUpdates
                   -authenticationKeyPath "$archive_key"
                   -authenticationKeyID "$ASC_API_KEY_ID"
@@ -272,7 +321,7 @@ do_appstore_upload() {
     local label="$1" archive="$2" exportdir="$3"
     log "Exporting + uploading $label to TestFlight (App Store)..."
     info "Build number $BUILD_NUMBER (forced — CLI export won't auto-increment)."
-    local keypath; keypath="$(resolve_asc_key)"
+    local keypath; resolve_asc_key; keypath="$_asc_key_path"
     run mkdir -p "$exportdir"
     run xcodebuild -exportArchive \
         -archivePath "$archive" \


### PR DESCRIPTION
Review follow-up on #3633. The bots flagged these against that PR, but the files live on `develop` already — `release.sh` and `testflight.yml` were never in #3633's diff (Qodo and Copilot's first pass diffed a stale base). Split out here so #3633 stays scoped to the feed.

## 1. The ASC private key was written world-readable, four times per run

Copilot noticed the materialised `.p8` is never cleaned up. Chasing that surfaced three compounding bugs in `resolve_asc_key`:

**Subshell state loss.** The function `echo`ed the path and both call sites used `key="$(resolve_asc_key)"` — a command-substitution subshell. Every global it assigned was written in a child process and lost on return. So the `_asc_key_path` memo never persisted and the key was re-materialised on *every* call.

**Wrong file gets the key.** `_asc_key_path="$(mktemp -t "AuthKey_${ID}").p8"` appends `.p8` to the *string* mktemp returned. The key is written to a path mktemp never created — so it's created by shell redirect at the default umask (**0644**, in a shared temp dir) while mktemp's actual 0600 file is orphaned empty.

**No cleanup.** The EXIT trap only restored the build number.

Measured on one `--platform all --dry-run`, instrumenting `mktemp`:

```
OLD — mktemp calls: 4
-rw-r--r--  33  /var/folders/.../AuthKey_TESTKEY.iWbrj5FXxb.p8   <- key, world-readable
-rw-r--r--  33  /var/folders/.../AuthKey_TESTKEY.cg8p8cV1l1.p8
-rw-r--r--  33  /var/folders/.../AuthKey_TESTKEY.RwaV3M3OEo.p8
-rw-r--r--  33  /var/folders/.../AuthKey_TESTKEY.BOnkmW0JPS.p8
-rw-------   0  ...iWbrj5FXxb   <- orphaned empty mktemp files
-rw-------   0  ...cg8p8cV1l1
-rw-------   0  ...RwaV3M3OEo
-rw-------   0  ...BOnkmW0JPS
```

Four copies of an App Store Connect signing key readable by every user on the machine, none removed. `testflight.yml` feeds `ASC_API_KEY_CONTENT`, so this is the CI path.

Fixed: `resolve_asc_key` sets the global directly (callers read it), materialises into a `mktemp -d` (0700) with `umask 077` on the write, and the EXIT trap removes the directory.

```
NEW — mktemp calls: 1
drwx------  /var/folders/.../provenance-asc.g8ZDCOoD7U
-rw-------  AuthKey_TESTKEY.p8
-> removed on exit
```

## 2. `--dry-run` mutated the working tree — via two paths

Copilot spotted the self-heal `mv` running under `--dry-run`. Gating that alone wasn't enough: the EXIT trap then consumed the leftover backup anyway, because `restore_build_number` keyed off *"a backup exists"* rather than *"this run made one"*. A dry-run both mutated the tree and used up the one chance the next real run had to self-heal.

Now tracks `_injected` and restores only then. Verified:

| | live xcconfig | leftover backup |
|---|---|---|
| `--dry-run` (before) | reverted to 9951 | **consumed** |
| `--dry-run` (after) | untouched (999999) | untouched |
| real run (after) | self-heals → injects → restores, tree clean | consumed correctly |

## 3. `xcbeautify` optional to install, mandatory to use

Qodo: installed with `|| true`, piped into unconditionally under `set -o pipefail` — a Homebrew hiccup or a runner image change fails the upload with `xcbeautify: command not found` instead of a real build error. Falls back to `cat`; the authoritative output is the raw log from `tee` either way.

## Verification

`bash -n` clean; `testflight.yml` parses. Each fix exercised directly rather than reasoned about — instrumented `mktemp` for the key paths and counts, a poisoned `Build.xcconfig` plus leftover `.release-bak` for both dry-run and real paths, and a stubbed PATH for the formatter fallback. `git status` clean after every run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)