### PR TITLE
fix(ci): point testflight.yml at the signing secrets that actually exist

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -96,24 +96,33 @@ jobs:
       # PROFILES are fetched by -allowProvisioningUpdates using the ASC API key
       # (release.sh passes it to the archive step), so only the cert is imported
       # here — no .mobileprovision juggling.
+      # Secret names match what this repo ALREADY has (CERT_P12 / P12_PASS), rather
+      # than inventing BUILD_CERTIFICATE_BASE64 / P12_PASSWORD, which were never set
+      # and would have failed the first real run for no reason.
+      #
+      # KEYCHAIN_PASSWORD is deliberately NOT a secret. It only ever protects a
+      # throwaway keychain created and deleted inside this one job, so a stored
+      # secret bought nothing and was a third thing to configure. Generated per-run
+      # instead, which is also stronger than a fixed reused value.
       - name: Import signing certificate
         env:
-          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
-          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
-          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+          CERT_P12: ${{ secrets.CERT_P12 }}
+          P12_PASS: ${{ secrets.P12_PASS }}
         run: |
           set -euo pipefail
-          if [ -z "${BUILD_CERTIFICATE_BASE64}" ]; then
-            echo "::error::BUILD_CERTIFICATE_BASE64 secret is not set — cannot sign."
+          if [ -z "${CERT_P12}" ]; then
+            echo "::error::CERT_P12 secret is not set — cannot sign."
             exit 1
           fi
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
+          echo "::add-mask::$KEYCHAIN_PASSWORD"
           CERT_PATH="$RUNNER_TEMP/dist.p12"
           KEYCHAIN="$RUNNER_TEMP/signing.keychain-db"
-          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o "$CERT_PATH"
+          echo -n "$CERT_P12" | base64 --decode -o "$CERT_PATH"
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
           security set-keychain-settings -lut 21600 "$KEYCHAIN"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
-          security import "$CERT_PATH" -P "$P12_PASSWORD" -A \
+          security import "$CERT_PATH" -P "$P12_PASS" -A \
             -t cert -f pkcs12 -k "$KEYCHAIN"
           # Let codesign use the key without an interactive prompt.
           security set-key-partition-list -S apple-tool:,apple:,codesign: \


### PR DESCRIPTION
`testflight.yml` referenced three secrets that are **not set on this repo** — so its first real run would have failed on missing configuration rather than anything real.

| Workflow referenced | Repo actually has | Resolution |
|---|---|---|
| `BUILD_CERTIFICATE_BASE64` | `CERT_P12` | renamed |
| `P12_PASSWORD` | `P12_PASS` | renamed |
| `KEYCHAIN_PASSWORD` | — | **dropped as a secret** |

`KEYCHAIN_PASSWORD` is generated per-run rather than renamed. It only protects a throwaway keychain created and deleted inside this one job, so storing it bought nothing and made a third thing to configure — and a freshly generated value is stronger than one fixed string reused across every run. Masked with `::add-mask::`.

**Net effect:** the only secrets still outstanding for TestFlight are the three App Store Connect API values, which have to come from the ASC portal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only signing configuration with no app runtime or data-handling changes; misconfigured secrets would fail the job at import time.
> 
> **Overview**
> Fixes the **TestFlight** workflow’s **Import signing certificate** step so it uses repository secrets that are already configured instead of names that were never set.
> 
> **Secret renames:** `BUILD_CERTIFICATE_BASE64` → `CERT_P12`, `P12_PASSWORD` → `P12_PASS`, with matching updates to decode/import and the missing-secret error message.
> 
> **Keychain password:** `KEYCHAIN_PASSWORD` is no longer read from GitHub secrets; each run generates a random value with `openssl rand`, masks it via `::add-mask::`, and uses it only for the ephemeral job keychain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d3a13b6ea7e71fb81caf883ab13682a4dd5d968. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->