### PR TITLE
feat(cores): store custom-built dylibs in a private release store

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,6 +154,28 @@ jobs:
           fi
           echo "Submodule init complete."
 
+      # Cores marked `local: true` in cores.yml are custom Provenance builds that do
+      # not exist on the libretro buildbot, so get-modules.sh deliberately never
+      # downloads them. Nothing else fetched them either, and the failure mode is
+      # SILENT: make_frameworks_retroarch.sh iterates the dylibs that are present in
+      # modules/, so an absent one is simply never packaged — no error, no warning,
+      # just a core missing from the IPA. virtualjaguar (Jaguar) has been affected.
+      #
+      # Not hard-failing when DYLIBS_TOKEN is unset, because that would break every
+      # build the moment this lands. A named warning is still strictly better than
+      # today's silence: it says exactly which cores the artifact will lack.
+      # GITHUB_TOKEN cannot read another private repo, hence a dedicated PAT.
+      - name: Fetch locally-built core dylibs
+        env:
+          GH_TOKEN: ${{ secrets.DYLIBS_TOKEN }}
+        run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::warning::DYLIBS_TOKEN not set — skipping locally-built cores. This IPA will be MISSING:"
+            ./CoresRetro/RetroArch/scripts/local-dylibs.sh list || true
+            exit 0
+          fi
+          ./CoresRetro/RetroArch/scripts/local-dylibs.sh fetch
+
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1.6.0
         with:

--- a/CoresRetro/RetroArch/scripts/local-dylibs.sh
+++ b/CoresRetro/RetroArch/scripts/local-dylibs.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# local-dylibs.sh — publish/fetch the custom-built libretro dylibs.
+#
+# Some cores are NOT on the libretro buildbot: they are custom Provenance builds
+# (flycast-jitless, virtualjaguar). cores.yml marks them `local: true`, which stops
+# get-modules.sh downloading or pruning them — but says nothing about where they
+# live. They are gitignored (modules/.gitignore is `*`), so until now they existed
+# only on the machine that built them and were one `rm -rf modules/` from gone.
+#
+# They are stored as release assets on a PRIVATE repo rather than committed:
+#   - a 13 MB binary per rebuild is not something to put in git history
+#   - private, because these are unreleased custom builds
+#
+# Usage:
+#   ./local-dylibs.sh upload [core...]   # after building locally — push to the store
+#   ./local-dylibs.sh fetch  [core...]   # on a fresh clone / CI — pull into modules/
+#   ./local-dylibs.sh list               # what cores.yml marks local, and what is on disk
+#
+# With no core names, acts on every `local: true` core in cores.yml.
+#
+# Auth: uses `gh`, so locally it just works. In CI, GITHUB_TOKEN cannot read another
+# private repo — set DYLIBS_TOKEN to a PAT with `repo` scope and export it as GH_TOKEN
+# for this step only.
+#
+# Config (env overrides):
+#   DYLIBS_REPO  default Provenance-Emu/provenance-dylibs
+#   DYLIBS_TAG   default latest
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULES_DIR="$(cd "$SCRIPT_DIR/.." && pwd)/modules"
+CORES_YML="$SCRIPT_DIR/cores.yml"
+
+DYLIBS_REPO="${DYLIBS_REPO:-Provenance-Emu/provenance-dylibs}"
+DYLIBS_TAG="${DYLIBS_TAG:-latest}"
+
+die() { echo "error: $*" >&2; exit 1; }
+info() { echo "  $*"; }
+
+command -v gh >/dev/null 2>&1 || die "gh CLI is required"
+[ -f "$CORES_YML" ] || die "cores.yml not found at $CORES_YML"
+mkdir -p "$MODULES_DIR"
+
+# Parse cores.yml for `local: true` entries, emitting "<name>\t<filename-or-empty>".
+# Deliberately not using a YAML library: this script has to run on a bare CI runner
+# and on a fresh clone, where PyYAML may not be installed.
+local_cores() {
+    awk '
+        /^[[:space:]]*-[[:space:]]*name:[[:space:]]*/ {
+            if (name != "" && islocal) print name "\t" fname
+            name = $0
+            sub(/^[[:space:]]*-[[:space:]]*name:[[:space:]]*/, "", name)
+            gsub(/["\047]/, "", name)
+            islocal = 0; fname = ""
+            next
+        }
+        /^[[:space:]]*local:[[:space:]]*true/ { islocal = 1 }
+        /^[[:space:]]*filename:[[:space:]]*/ {
+            fname = $0
+            sub(/^[[:space:]]*filename:[[:space:]]*/, "", fname)
+            gsub(/["\047]/, "", fname)
+        }
+        END { if (name != "" && islocal) print name "\t" fname }
+    ' "$CORES_YML"
+}
+
+# A core may ship one platform-neutral dylib (filename: set) or the _ios/_tvos pair.
+dylibs_for() {
+    local name="$1" fname="$2"
+    if [ -n "$fname" ]; then
+        echo "$fname"
+    else
+        echo "${name}_libretro_ios.dylib"
+        echo "${name}_libretro_tvos.dylib"
+    fi
+}
+
+selected_cores() {
+    if [ "$#" -gt 0 ]; then
+        for want in "$@"; do
+            local row; row=$(local_cores | awk -F'\t' -v w="$want" '$1==w')
+            [ -n "$row" ] || die "'$want' is not a local: true core in cores.yml"
+            echo "$row"
+        done
+    else
+        local_cores
+    fi
+}
+
+ensure_release() {
+    gh release view "$DYLIBS_TAG" --repo "$DYLIBS_REPO" >/dev/null 2>&1 && return 0
+    info "creating release '$DYLIBS_TAG' on $DYLIBS_REPO"
+    gh release create "$DYLIBS_TAG" --repo "$DYLIBS_REPO" \
+        --title "Custom libretro dylibs" \
+        --notes "Custom Provenance builds of libretro cores that are not on the buildbot. Rolling — assets are replaced in place by local-dylibs.sh upload." \
+        >/dev/null
+}
+
+cmd_list() {
+    echo "local: true cores in cores.yml  (store: $DYLIBS_REPO @ $DYLIBS_TAG)"
+    while IFS=$'\t' read -r name fname; do
+        [ -n "$name" ] || continue
+        while read -r d; do
+            [ -n "$d" ] || continue
+            if [ -f "$MODULES_DIR/$d" ]; then
+                printf "  %-40s present  %s\n" "$d" "$(du -h "$MODULES_DIR/$d" | cut -f1)"
+            else
+                printf "  %-40s MISSING\n" "$d"
+            fi
+        done < <(dylibs_for "$name" "$fname")
+    done < <(local_cores)
+}
+
+cmd_upload() {
+    ensure_release
+    local n=0
+    while IFS=$'\t' read -r name fname; do
+        [ -n "$name" ] || continue
+        while read -r d; do
+            [ -n "$d" ] || continue
+            local src="$MODULES_DIR/$d"
+            if [ ! -f "$src" ]; then
+                info "skip $d (not present locally)"
+                continue
+            fi
+            local tmp; tmp=$(mktemp -d)
+            # Zip from inside modules/ so the archive contains a bare dylib, matching
+            # the buildbot layout that get-modules.sh already knows how to unzip.
+            ( cd "$MODULES_DIR" && zip -q -j "$tmp/$d.zip" "$d" )
+            info "uploading $d.zip ($(du -h "$tmp/$d.zip" | cut -f1))"
+            gh release upload "$DYLIBS_TAG" "$tmp/$d.zip" --repo "$DYLIBS_REPO" --clobber
+            rm -rf "$tmp"
+            n=$((n + 1))
+        done < <(dylibs_for "$name" "$fname")
+    done < <(selected_cores "$@")
+    echo "uploaded $n dylib(s) to $DYLIBS_REPO @ $DYLIBS_TAG"
+}
+
+cmd_fetch() {
+    local n=0 missing=0
+    while IFS=$'\t' read -r name fname; do
+        [ -n "$name" ] || continue
+        while read -r d; do
+            [ -n "$d" ] || continue
+            local tmp; tmp=$(mktemp -d)
+            if gh release download "$DYLIBS_TAG" --repo "$DYLIBS_REPO" \
+                 --pattern "$d.zip" --dir "$tmp" >/dev/null 2>&1; then
+                unzip -q -o "$tmp/$d.zip" -d "$MODULES_DIR"
+                info "fetched $d"
+                n=$((n + 1))
+            else
+                echo "  WARNING: $d.zip not found on $DYLIBS_REPO @ $DYLIBS_TAG" >&2
+                missing=$((missing + 1))
+            fi
+            rm -rf "$tmp"
+        done < <(dylibs_for "$name" "$fname")
+    done < <(selected_cores "$@")
+    # Not ${missing:+...}: that expands whenever the var is non-EMPTY, and "0" is
+    # non-empty, so a clean run reported "0 missing".
+    if [ "$missing" -gt 0 ]; then
+        echo "fetched $n dylib(s), $missing missing"
+    else
+        echo "fetched $n dylib(s)"
+    fi
+    # Missing assets are a real problem for a build that expects them (they are in the
+    # xcfilelists), so fail rather than let the build die later with a vaguer error.
+    [ "$missing" -eq 0 ] || exit 1
+}
+
+case "${1:-}" in
+    upload) shift; cmd_upload "$@" ;;
+    fetch)  shift; cmd_fetch "$@" ;;
+    list)   cmd_list ;;
+    *)      sed -n '2,29p' "$0" | sed 's/^# \{0,1\}//'; exit 1 ;;
+esac


### PR DESCRIPTION
`flycast-jitless` and `virtualjaguar` are custom Provenance builds, not on the libretro buildbot. `cores.yml` marks them `local: true`, which stops `get-modules.sh` downloading or overwriting them — but says nothing about **where they live**.

Since `modules/.gitignore` is `*`, they existed only on the machine that built them: no way to move to a new checkout, no way for CI to obtain them, and one `rm -rf modules/` from unrecoverable.

## Approach

`local-dylibs.sh` with `upload` / `fetch` / `list`, backed by release assets on the private **`Provenance-Emu/provenance-dylibs`**.

Release assets rather than committing: these are 2–13 MB binaries that get rebuilt regularly, which doesn't belong in git history. Private because they're unreleased custom builds.

```bash
CoresRetro/RetroArch/scripts/local-dylibs.sh upload   # after building locally
CoresRetro/RetroArch/scripts/local-dylibs.sh fetch    # fresh clone / CI
CoresRetro/RetroArch/scripts/local-dylibs.sh list     # expected vs on disk
```

## Design notes

- **Reads `cores.yml` for `local: true`**, so the store follows the manifest automatically instead of duplicating a list that would drift out of sync.
- **Handles both dylib shapes**: a platform-neutral `filename` (flycast-jitless) and the `_ios`/`_tvos` pair (virtualjaguar).
- **Zips with `zip -j` from inside `modules/`**, so archives contain a bare dylib matching the buildbot layout `get-modules.sh` already unzips.
- **Parses YAML with awk, not PyYAML** — this has to run on a bare runner and a fresh clone, where a pip dependency is exactly what isn't available.
- **`fetch` exits nonzero on a missing asset.** These dylibs are in the xcfilelists, so a silent miss just fails the build later with a vaguer error.

## Verification

Round-trip tested against the real store: uploaded both virtualjaguar dylibs, deleted one from `modules/`, ran `fetch`, and confirmed the restored files are **byte-identical** by sha256. The missing-asset path was verified to exit `1` (my first check of that was masked by a pipe — the exit code was `tail`'s, not the script's).

## Open question

CI can't use this yet: `GITHUB_TOKEN` can't read another private repo, so a workflow step would need a PAT with `repo` scope exported as `GH_TOKEN`. Worth deciding whether CI should pull these at all, or whether this stays a local-developer tool — the `Provenance-CI` smoke target doesn't build emulator cores, so it may not need them.

## Note

`flycast-jitless` isn't in the store yet — `cores.yml` only learns about it in #3638. Re-running `upload` after that merges will include it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-tooling only; no app runtime, auth, or data-path changes. CI still needs a PAT if workflows call `fetch`.
> 
> **Overview**
> Adds **`local-dylibs.sh`** so gitignored `local: true` cores (e.g. **virtualjaguar**, future **flycast-jitless**) can be **uploaded**, **fetched**, and **listed** via zipped release assets on **`Provenance-Emu/provenance-dylibs`** instead of living only on one machine.
> 
> The script **reads `cores.yml`** for `local: true` entries (awk, no PyYAML), supports a single **`filename`** dylib or the usual **`_ios` / `_tvos`** pair, zips dylibs like the buildbot layout, and uses **`gh`** with optional **`DYLIBS_REPO` / `DYLIBS_TAG`**. **`fetch`** fails the run if any expected asset is missing so builds don’t fail later on empty xcfilelists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ff5c9646781462c4dffb704bea9db4315b2b62f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->