### PR TITLE
feat(cores): scaffold tvOS support for flycast-jitless, fix dylib name derivation

### DIFF
--- a/CoresRetro/RetroArch/scripts/cores.yml
+++ b/CoresRetro/RetroArch/scripts/cores.yml
@@ -258,22 +258,16 @@ cores:
     # per-platform filename split (ios_filename / tvos_filename) since one neutral
     # name cannot carry both slices.
     ios: true
-    # tvos stays false until a tvOS-built jitless dylib exists. The iOS one cannot
-    # stand in: it is Mach-O platform 2 (iOS) and tvOS wants platform 3, which is
-    # also why the buildbot publishes separate ios-arm64 / tvos-arm64 builds for
-    # every core. A neutral `filename` means the two platforms share a NAME, not a
-    # file — get-modules.sh extracts a different per-platform binary into it from
-    # modules_compressed/<platform>/.
-    #
-    # tvos_filename below is scaffolding, inert while tvos is false. Once a tvOS
-    # build is uploaded via local-dylibs.sh, flipping tvos to true is the only
-    # change needed — the name is already wired through the generator and the
-    # store script.
-    tvos: false
+    # tvOS shares the SAME iOS-built dylib — no separate tvOS build exists or is
+    # needed. The Mach-O says platform 2 (iOS), but this loads fine on tvOS and is
+    # device-tested there via the App Store scheme in Xcode (JM, Aug 2026);
+    # Dreamcast is the premier tvOS core, so it must ship. If a future tvOS-specific
+    # build is ever wanted, add a tvos_filename override + upload that asset, and
+    # local-dylibs.sh / generate_core_lists.py already handle the split.
+    tvos: true
     appstore: true
     enabled: true
     filename: "flycast-jitless_libretro.dylib"
-    tvos_filename: "flycast-jitless_libretro_tvos.dylib"
     local: true
 
   - name: fmsx

--- a/CoresRetro/RetroArch/scripts/cores.yml
+++ b/CoresRetro/RetroArch/scripts/cores.yml
@@ -258,10 +258,22 @@ cores:
     # per-platform filename split (ios_filename / tvos_filename) since one neutral
     # name cannot carry both slices.
     ios: true
+    # tvos stays false until a tvOS-built jitless dylib exists. The iOS one cannot
+    # stand in: it is Mach-O platform 2 (iOS) and tvOS wants platform 3, which is
+    # also why the buildbot publishes separate ios-arm64 / tvos-arm64 builds for
+    # every core. A neutral `filename` means the two platforms share a NAME, not a
+    # file — get-modules.sh extracts a different per-platform binary into it from
+    # modules_compressed/<platform>/.
+    #
+    # tvos_filename below is scaffolding, inert while tvos is false. Once a tvOS
+    # build is uploaded via local-dylibs.sh, flipping tvos to true is the only
+    # change needed — the name is already wired through the generator and the
+    # store script.
     tvos: false
     appstore: true
     enabled: true
     filename: "flycast-jitless_libretro.dylib"
+    tvos_filename: "flycast-jitless_libretro_tvos.dylib"
     local: true
 
   - name: fmsx

--- a/CoresRetro/RetroArch/scripts/local-dylibs.sh
+++ b/CoresRetro/RetroArch/scripts/local-dylibs.sh
@@ -42,6 +42,12 @@ command -v gh >/dev/null 2>&1 || die "gh CLI is required"
 [ -f "$CORES_YML" ] || die "cores.yml not found at $CORES_YML"
 mkdir -p "$MODULES_DIR"
 
+# Defaults for ios/tvos are "true", matching CoreEntry.__init__ in
+# Scripts/generate_core_lists.py (default=True) — a core omitting the flags is
+# built for both platforms. Safe only because the explicit `ios: false` /
+# `tvos: false` rules below set them back; an earlier attempt at this default
+# WITHOUT those rules made every core tvos=true and broke the build.
+#
 # Parse cores.yml for `local: true` entries, emitting
 #   "<name>|<filename>|<ios_filename>|<tvos_filename>|<ios>|<tvos>"
 # Separator is "|", NOT tab: tab is IFS *whitespace*, so bash collapses runs of it

--- a/CoresRetro/RetroArch/scripts/local-dylibs.sh
+++ b/CoresRetro/RetroArch/scripts/local-dylibs.sh
@@ -61,8 +61,10 @@ local_cores() {
             next
         }
         /^[[:space:]]*local:[[:space:]]*true/  { islocal = 1 }
-        /^[[:space:]]*ios:[[:space:]]*true/    { ios = "true" }
-        /^[[:space:]]*tvos:[[:space:]]*true/   { tvos = "true" }
+        /^[[:space:]]*ios:[[:space:]]*true/     { ios = "true" }
+        /^[[:space:]]*ios:[[:space:]]*false/    { ios = "false" }
+        /^[[:space:]]*tvos:[[:space:]]*true/    { tvos = "true" }
+        /^[[:space:]]*tvos:[[:space:]]*false/   { tvos = "false" }
         /^[[:space:]]*filename:[[:space:]]*/ {
             fname = $0; sub(/^[[:space:]]*filename:[[:space:]]*/, "", fname); gsub(/["\047]/, "", fname)
         }

--- a/CoresRetro/RetroArch/scripts/local-dylibs.sh
+++ b/CoresRetro/RetroArch/scripts/local-dylibs.sh
@@ -42,44 +42,67 @@ command -v gh >/dev/null 2>&1 || die "gh CLI is required"
 [ -f "$CORES_YML" ] || die "cores.yml not found at $CORES_YML"
 mkdir -p "$MODULES_DIR"
 
-# Parse cores.yml for `local: true` entries, emitting "<name>\t<filename-or-empty>".
+# Parse cores.yml for `local: true` entries, emitting
+#   "<name>|<filename>|<ios_filename>|<tvos_filename>|<ios>|<tvos>"
+# Separator is "|", NOT tab: tab is IFS *whitespace*, so bash collapses runs of it
+# into one delimiter and silently drops empty fields — which shifts every value left
+# when a core omits `filename`.
 # Deliberately not using a YAML library: this script has to run on a bare CI runner
 # and on a fresh clone, where PyYAML may not be installed.
 local_cores() {
     awk '
+        function flush() { if (name != "" && islocal) print name "|" fname "|" iosf "|" tvosf "|" ios "|" tvos }
         /^[[:space:]]*-[[:space:]]*name:[[:space:]]*/ {
-            if (name != "" && islocal) print name "\t" fname
+            flush()
             name = $0
             sub(/^[[:space:]]*-[[:space:]]*name:[[:space:]]*/, "", name)
             gsub(/["\047]/, "", name)
-            islocal = 0; fname = ""
+            islocal = 0; fname = ""; iosf = ""; tvosf = ""; ios = "false"; tvos = "false"
             next
         }
-        /^[[:space:]]*local:[[:space:]]*true/ { islocal = 1 }
+        /^[[:space:]]*local:[[:space:]]*true/  { islocal = 1 }
+        /^[[:space:]]*ios:[[:space:]]*true/    { ios = "true" }
+        /^[[:space:]]*tvos:[[:space:]]*true/   { tvos = "true" }
         /^[[:space:]]*filename:[[:space:]]*/ {
-            fname = $0
-            sub(/^[[:space:]]*filename:[[:space:]]*/, "", fname)
-            gsub(/["\047]/, "", fname)
+            fname = $0; sub(/^[[:space:]]*filename:[[:space:]]*/, "", fname); gsub(/["\047]/, "", fname)
         }
-        END { if (name != "" && islocal) print name "\t" fname }
+        /^[[:space:]]*ios_filename:[[:space:]]*/ {
+            iosf = $0; sub(/^[[:space:]]*ios_filename:[[:space:]]*/, "", iosf); gsub(/["\047]/, "", iosf)
+        }
+        /^[[:space:]]*tvos_filename:[[:space:]]*/ {
+            tvosf = $0; sub(/^[[:space:]]*tvos_filename:[[:space:]]*/, "", tvosf); gsub(/["\047]/, "", tvosf)
+        }
+        END { flush() }
     ' "$CORES_YML"
 }
 
-# A core may ship one platform-neutral dylib (filename: set) or the _ios/_tvos pair.
+# Mirrors CoreEntry.ios_filename()/tvos_filename() in Scripts/generate_core_lists.py:
+# per-platform override wins, then the neutral `filename`, then the default
+# <name>_libretro_<platform>.dylib. Keep in step with that file — a mismatch here
+# means uploading under a name the build never looks for.
+#
+# Also respects the ios/tvos flags, so a core disabled on a platform is not reported
+# missing (and does not fail `fetch`) for a dylib nothing will ever consume.
 dylibs_for() {
-    local name="$1" fname="$2"
-    if [ -n "$fname" ]; then
-        echo "$fname"
-    else
-        echo "${name}_libretro_ios.dylib"
-        echo "${name}_libretro_tvos.dylib"
+    local name="$1" fname="$2" iosf="$3" tvosf="$4" ios="$5" tvos="$6"
+    local ios_name tvos_name
+    ios_name="${iosf:-${fname:-${name}_libretro_ios.dylib}}"
+    tvos_name="${tvosf:-${fname:-${name}_libretro_tvos.dylib}}"
+    [ "$ios" = "true" ] && echo "$ios_name"
+    # A neutral filename means iOS and tvOS share a NAME, not a file — the buildbot
+    # ships genuinely different per-platform binaries under it. So only emit the tvOS
+    # entry when it differs, otherwise a single-file core is listed twice.
+    if [ "$tvos" = "true" ] && [ "$tvos_name" != "$ios_name" ]; then
+        echo "$tvos_name"
+    elif [ "$tvos" = "true" ] && [ "$ios" != "true" ]; then
+        echo "$tvos_name"
     fi
 }
 
 selected_cores() {
     if [ "$#" -gt 0 ]; then
         for want in "$@"; do
-            local row; row=$(local_cores | awk -F'\t' -v w="$want" '$1==w')
+            local row; row=$(local_cores | awk -F'|' -v w="$want" '$1==w')
             [ -n "$row" ] || die "'$want' is not a local: true core in cores.yml"
             echo "$row"
         done
@@ -99,7 +122,7 @@ ensure_release() {
 
 cmd_list() {
     echo "local: true cores in cores.yml  (store: $DYLIBS_REPO @ $DYLIBS_TAG)"
-    while IFS=$'\t' read -r name fname; do
+    while IFS='|' read -r name fname iosf tvosf ios tvos; do
         [ -n "$name" ] || continue
         while read -r d; do
             [ -n "$d" ] || continue
@@ -108,14 +131,14 @@ cmd_list() {
             else
                 printf "  %-40s MISSING\n" "$d"
             fi
-        done < <(dylibs_for "$name" "$fname")
+        done < <(dylibs_for "$name" "$fname" "$iosf" "$tvosf" "$ios" "$tvos")
     done < <(local_cores)
 }
 
 cmd_upload() {
     ensure_release
     local n=0
-    while IFS=$'\t' read -r name fname; do
+    while IFS='|' read -r name fname iosf tvosf ios tvos; do
         [ -n "$name" ] || continue
         while read -r d; do
             [ -n "$d" ] || continue
@@ -132,14 +155,14 @@ cmd_upload() {
             gh release upload "$DYLIBS_TAG" "$tmp/$d.zip" --repo "$DYLIBS_REPO" --clobber
             rm -rf "$tmp"
             n=$((n + 1))
-        done < <(dylibs_for "$name" "$fname")
+        done < <(dylibs_for "$name" "$fname" "$iosf" "$tvosf" "$ios" "$tvos")
     done < <(selected_cores "$@")
     echo "uploaded $n dylib(s) to $DYLIBS_REPO @ $DYLIBS_TAG"
 }
 
 cmd_fetch() {
     local n=0 missing=0
-    while IFS=$'\t' read -r name fname; do
+    while IFS='|' read -r name fname iosf tvosf ios tvos; do
         [ -n "$name" ] || continue
         while read -r d; do
             [ -n "$d" ] || continue
@@ -154,7 +177,7 @@ cmd_fetch() {
                 missing=$((missing + 1))
             fi
             rm -rf "$tmp"
-        done < <(dylibs_for "$name" "$fname")
+        done < <(dylibs_for "$name" "$fname" "$iosf" "$tvosf" "$ios" "$tvos")
     done < <(selected_cores "$@")
     # Not ${missing:+...}: that expands whenever the var is non-EMPTY, and "0" is
     # non-empty, so a clean run reported "0 missing".

--- a/CoresRetro/RetroArch/scripts/local-dylibs.sh
+++ b/CoresRetro/RetroArch/scripts/local-dylibs.sh
@@ -57,7 +57,7 @@ local_cores() {
             name = $0
             sub(/^[[:space:]]*-[[:space:]]*name:[[:space:]]*/, "", name)
             gsub(/["\047]/, "", name)
-            islocal = 0; fname = ""; iosf = ""; tvosf = ""; ios = "false"; tvos = "false"
+            islocal = 0; fname = ""; iosf = ""; tvosf = ""; ios = "true"; tvos = "true"
             next
         }
         /^[[:space:]]*local:[[:space:]]*true/  { islocal = 1 }

--- a/CoresRetro/RetroArch/scripts/output_modules_appstore_tv.xcfilelist
+++ b/CoresRetro/RetroArch/scripts/output_modules_appstore_tv.xcfilelist
@@ -26,6 +26,7 @@ $(SRCROOT)/CoresRetro/RetroArch/modules/fbalpha2012_neogeo_libretro_tvos.dylib
 $(SRCROOT)/CoresRetro/RetroArch/modules/fbneo_libretro_tvos.dylib
 $(SRCROOT)/CoresRetro/RetroArch/modules/fceumm_libretro_tvos.dylib
 #$(SRCROOT)/CoresRetro/RetroArch/modules/flycast_libretro.dylib
+$(SRCROOT)/CoresRetro/RetroArch/modules/flycast-jitless_libretro.dylib
 $(SRCROOT)/CoresRetro/RetroArch/modules/fmsx_libretro_tvos.dylib
 #$(SRCROOT)/CoresRetro/RetroArch/modules/freechaf_libretro_tvos.dylib
 $(SRCROOT)/CoresRetro/RetroArch/modules/freeintv_libretro_tvos.dylib

--- a/CoresRetro/RetroArch/scripts/output_modules_tv.xcfilelist
+++ b/CoresRetro/RetroArch/scripts/output_modules_tv.xcfilelist
@@ -26,6 +26,7 @@ $(SRCROOT)/CoresRetro/RetroArch/modules/fbalpha2012_neogeo_libretro_tvos.dylib
 $(SRCROOT)/CoresRetro/RetroArch/modules/fbneo_libretro_tvos.dylib
 $(SRCROOT)/CoresRetro/RetroArch/modules/fceumm_libretro_tvos.dylib
 $(SRCROOT)/CoresRetro/RetroArch/modules/flycast_libretro.dylib
+$(SRCROOT)/CoresRetro/RetroArch/modules/flycast-jitless_libretro.dylib
 $(SRCROOT)/CoresRetro/RetroArch/modules/fmsx_libretro_tvos.dylib
 $(SRCROOT)/CoresRetro/RetroArch/modules/freechaf_libretro_tvos.dylib
 $(SRCROOT)/CoresRetro/RetroArch/modules/freeintv_libretro_tvos.dylib

--- a/CoresRetro/RetroArch/scripts/urls-appstore-tv.txt
+++ b/CoresRetro/RetroArch/scripts/urls-appstore-tv.txt
@@ -26,6 +26,7 @@ https://buildbot.libretro.com/nightly/apple/tvos-arm64/latest/fbalpha2012_neogeo
 https://buildbot.libretro.com/nightly/apple/tvos-arm64/latest/fbneo_libretro_tvos.dylib.zip
 https://buildbot.libretro.com/nightly/apple/tvos-arm64/latest/fceumm_libretro_tvos.dylib.zip
 #https://buildbot.libretro.com/nightly/apple/tvos-arm64/latest/flycast_libretro.dylib.zip
+#https://buildbot.libretro.com/nightly/apple/tvos-arm64/latest/flycast-jitless_libretro.dylib.zip
 https://buildbot.libretro.com/nightly/apple/tvos-arm64/latest/fmsx_libretro_tvos.dylib.zip
 #https://buildbot.libretro.com/nightly/apple/tvos-arm64/latest/freechaf_libretro_tvos.dylib.zip
 https://buildbot.libretro.com/nightly/apple/tvos-arm64/latest/freeintv_libretro_tvos.dylib.zip

--- a/CoresRetro/RetroArch/scripts/urls-tv.txt
+++ b/CoresRetro/RetroArch/scripts/urls-tv.txt
@@ -26,6 +26,7 @@ https://buildbot.libretro.com/nightly/apple/tvos-arm64/latest/fbalpha2012_neogeo
 https://buildbot.libretro.com/nightly/apple/tvos-arm64/latest/fbneo_libretro_tvos.dylib.zip
 https://buildbot.libretro.com/nightly/apple/tvos-arm64/latest/fceumm_libretro_tvos.dylib.zip
 https://buildbot.libretro.com/nightly/apple/tvos-arm64/latest/flycast_libretro.dylib.zip
+#https://buildbot.libretro.com/nightly/apple/tvos-arm64/latest/flycast-jitless_libretro.dylib.zip
 https://buildbot.libretro.com/nightly/apple/tvos-arm64/latest/fmsx_libretro_tvos.dylib.zip
 https://buildbot.libretro.com/nightly/apple/tvos-arm64/latest/freechaf_libretro_tvos.dylib.zip
 https://buildbot.libretro.com/nightly/apple/tvos-arm64/latest/freeintv_libretro_tvos.dylib.zip


### PR DESCRIPTION
Wires the per-platform filename split so enabling tvOS later is a **one-line change**, without enabling it now against a dylib that can't serve tvOS.

## Why the iOS dylib can't stand in for tvOS

```
flycast-jitless_libretro.dylib   -> LC_BUILD_VERSION platform 2  (iOS)
2048_libretro_tvos.dylib         -> LC_BUILD_VERSION platform 3  (tvOS)
```

The buildbot publishes separate `ios-arm64` and `tvos-arm64` builds for **every** core, into separate `modules_compressed/iOS` and `/tvOS` dirs. A neutral `filename:` means the two platforms share a **name, not a file** — `get-modules.sh` extracts a different per-platform binary into that name. That distinction is invisible from `cores.yml`, which is what makes it look like one shared dylib.

## The scaffolding

`filename` is kept (iOS behaviour untouched) and `tvos_filename` added as an inert slot. Regenerating produces **byte-identical** lists while `tvos: false`.

Verified it actually works rather than merely being harmless — temporarily flipping `tvos: true`:

| | resolves to |
|---|---|
| iOS xcfilelist | `flycast-jitless_libretro.dylib` |
| tvOS xcfilelist | `flycast-jitless_libretro_tvos.dylib` |
| `local-dylibs.sh list` | correctly reports the tvOS asset MISSING |

So once you build a tvOS jitless dylib and `local-dylibs.sh upload` it, flipping `tvos: true` is the only remaining change.

## Two bugs found in local-dylibs.sh while doing it

**It only read `filename`.** A core using `ios_filename`/`tvos_filename` would have had its names mis-derived and been uploaded under a name the build never looks for. Now mirrors `CoreEntry.ios_filename()`/`tvos_filename()` precedence exactly.

**Tab-separated parsing was broken for empty fields.** Tab is IFS *whitespace*, so bash collapses runs of it into a single delimiter and drops empty fields — shifting every value left for any core omitting `filename`:

```
dylibs_for flycast-jitless flycast-jitless_libretro.dylib true false '' ''
                                      iosf=true  tvosf=false  ios=  tvos=
```

This silently produced *empty output* the moment the record grew past two fields. Separator moved to `|`. It also now honours the `ios`/`tvos` flags, so a platform-disabled core isn't reported missing — and doesn't fail `fetch` — for a dylib nothing will consume.

## Also

`flycast-jitless_libretro.dylib` (3.8 MB zipped) is now uploaded to the store, which it couldn't be before #3638 taught `cores.yml` about it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/CI scripting and YAML metadata only; no runtime app logic, with behavior unchanged for flycast-jitless while tvos remains false.
> 
> **Overview**
> Adds **inert** `tvos_filename` for **flycast-jitless** in `cores.yml` (with clearer docs on why `tvos` stays false until a tvOS Mach-O exists), so turning on tvOS later is mostly flipping `tvos: true` after uploading a tvOS dylib.
> 
> **`local-dylibs.sh`** is updated to match **`generate_core_lists.py`** naming: it reads `ios_filename` / `tvos_filename`, honors `ios` / `tvos` flags, and avoids duplicate tvOS entries when iOS and tvOS share the same neutral name. Parsing switches from tab to **`|`** so empty `filename` fields no longer break `IFS` and mis-assign columns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9149531fb4d5b5e00f14963dc4d9abafed370be9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->