### PR TITLE
[Agent] feat(logs): import & view exported log files (#3612)

### DIFF
--- a/.changelog/3645.md
+++ b/.changelog/3645.md
@@ -1,0 +1,2 @@
+### Added
+- **Log Import** — the retrowave log viewer can now import a previously exported `.txt`/`.log` file or `.zip` bundle and display it in place of live logs, with a banner to return to live logs.

--- a/.github/workflows/agent-validation.yml
+++ b/.github/workflows/agent-validation.yml
@@ -186,13 +186,18 @@ jobs:
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode_26.3.app
 
+      # `set -o pipefail` is required: the default shell here is `bash -e`
+      # (no pipefail), so piping into `tail` masked the real exit status and
+      # these steps reported success even when the build or tests failed.
       - name: Build module
         run: |
+          set -o pipefail
           cd ${{ matrix.module }}
           swift build 2>&1 | tail -20
 
       - name: Test module
         run: |
+          set -o pipefail
           cd ${{ matrix.module }}
           swift test 2>&1 | tail -40
 

--- a/PVLogging/Sources/PVLogging/LogFileParsing.swift
+++ b/PVLogging/Sources/PVLogging/LogFileParsing.swift
@@ -1,0 +1,62 @@
+//
+//  LogFileParsing.swift
+//  PVLogging
+//
+//  Parsing helpers for reading previously-exported log files back in.
+//  Lives here rather than in the UI layer so it is testable without a
+//  full workspace build — PVLogging builds and tests standalone.
+//
+
+import Foundation
+
+/// Parses plain-text log files produced by Provenance's log exporter (or any
+/// log whose lines carry a `[LEVEL]` tag) back into structured lines.
+public enum LogFileParsing {
+
+    /// A single parsed line of a log file.
+    public struct ParsedLine: Identifiable, Equatable, Sendable {
+        /// Zero-based index of the line within the file. Stable and unique,
+        /// which makes it usable directly as a SwiftUI `ForEach` identity.
+        public let id: Int
+        /// The raw line text, unmodified.
+        public let text: String
+        /// Level parsed from a `[LEVEL]` tag, or `nil` when the line carries none.
+        public let level: LogLevel?
+
+        public init(id: Int, text: String, level: LogLevel?) {
+            self.id = id
+            self.text = text
+            self.level = level
+        }
+    }
+
+    /// Splits `text` into parsed lines, preserving order and blank lines.
+    ///
+    /// CRLF is normalised first: `.newlines` is a character set, so it would
+    /// otherwise treat `\r\n` as two breaks and insert a spurious blank line
+    /// between every line of a Windows-generated log.
+    /// - Parameter text: Full contents of a log file.
+    /// - Returns: One `ParsedLine` per line, indexed from zero.
+    public static func parseLines(_ text: String) -> [ParsedLine] {
+        text
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .components(separatedBy: .newlines)
+            .enumerated()
+            .map { ParsedLine(id: $0.offset, text: $0.element, level: level(in: $0.element)) }
+    }
+
+    /// Best-effort parse of a `[LEVEL]` tag from a single log line.
+    ///
+    /// Matches the uppercase tag emitted by the exporter (`[ERROR]`, `[WARNING]`,
+    /// `[INFO]`, `[DEBUG]`, `[VERBOSE]`). Returns `nil` for untagged lines so
+    /// callers can render them neutrally rather than guessing.
+    public static func level(in line: String) -> LogLevel? {
+        let upper = line.uppercased()
+        if upper.contains("[ERROR]") { return .error }
+        if upper.contains("[WARNING]") { return .warning }
+        if upper.contains("[INFO]") { return .info }
+        if upper.contains("[DEBUG]") { return .debug }
+        if upper.contains("[VERBOSE]") { return .verbose }
+        return nil
+    }
+}

--- a/PVLogging/Tests/LogFileParsingTests.swift
+++ b/PVLogging/Tests/LogFileParsingTests.swift
@@ -1,0 +1,103 @@
+//
+//  LogFileParsingTests.swift
+//  PVLoggingTests
+//
+//  Covers the log-file parsing used when importing a previously exported log
+//  back into the viewer (#3612).
+//
+import Testing
+import Foundation
+@testable import PVLogging
+
+struct LogFileParsingLevelTests {
+
+    @Test("Each exporter level tag is recognised")
+    func parsesEveryLevelTag() {
+        #expect(LogFileParsing.level(in: "[12:00:00.000] [ERROR] boom") == .error)
+        #expect(LogFileParsing.level(in: "[12:00:00.000] [WARNING] careful") == .warning)
+        #expect(LogFileParsing.level(in: "[12:00:00.000] [INFO] hello") == .info)
+        #expect(LogFileParsing.level(in: "[12:00:00.000] [DEBUG] details") == .debug)
+        #expect(LogFileParsing.level(in: "[12:00:00.000] [VERBOSE] noise") == .verbose)
+    }
+
+    @Test("Untagged lines report no level rather than guessing")
+    func untaggedLineHasNoLevel() {
+        #expect(LogFileParsing.level(in: "just a bare line") == nil)
+        #expect(LogFileParsing.level(in: "") == nil)
+    }
+
+    @Test("Level tags are matched case-insensitively")
+    func levelTagIsCaseInsensitive() {
+        #expect(LogFileParsing.level(in: "[error] lowercase tag") == .error)
+        #expect(LogFileParsing.level(in: "[Warning] mixed case") == .warning)
+    }
+
+    @Test("A bare level word without brackets is not treated as a tag")
+    func requiresBracketedTag() {
+        #expect(LogFileParsing.level(in: "this line mentions ERROR in prose") == nil)
+    }
+
+    @Test("The more severe tag wins when a message quotes another level")
+    func moreSevereTagWins() {
+        // Checks run most-severe first, so an error line whose message quotes
+        // "[INFO]" stays an error regardless of tag order in the text.
+        #expect(LogFileParsing.level(in: "[ERROR] failed to handle [INFO] record") == .error)
+        #expect(LogFileParsing.level(in: "[INFO] retrying after [ERROR] earlier") == .error)
+    }
+}
+
+struct LogFileParsingLineTests {
+
+    @Test("Lines are split in order with zero-based ids")
+    func parsesLinesInOrder() {
+        let parsed = LogFileParsing.parseLines("alpha\nbravo\ncharlie")
+
+        #expect(parsed.count == 3)
+        #expect(parsed.map(\.id) == [0, 1, 2])
+        #expect(parsed.map(\.text) == ["alpha", "bravo", "charlie"])
+    }
+
+    @Test("Line ids are unique so they can drive ForEach identity")
+    func lineIDsAreUnique() {
+        // Deliberately repeated text — identity must come from position.
+        let parsed = LogFileParsing.parseLines("same\nsame\nsame")
+
+        #expect(Set(parsed.map(\.id)).count == parsed.count)
+    }
+
+    @Test("Blank lines are preserved so exported spacing survives a round trip")
+    func preservesBlankLines() {
+        let parsed = LogFileParsing.parseLines("header\n\nbody")
+
+        #expect(parsed.count == 3)
+        #expect(parsed[1].text.isEmpty)
+    }
+
+    @Test("Empty input yields a single empty line, not a crash")
+    func handlesEmptyInput() {
+        let parsed = LogFileParsing.parseLines("")
+
+        #expect(parsed.count == 1)
+        #expect(parsed[0].text.isEmpty)
+        #expect(parsed[0].level == nil)
+    }
+
+    @Test("Levels are attached to the lines that carry them")
+    func attachesLevelsPerLine() {
+        let parsed = LogFileParsing.parseLines("""
+        [ERROR] first
+        untagged second
+        [INFO] third
+        """)
+
+        #expect(parsed.map(\.level) == [.error, nil, .info])
+    }
+
+    @Test("Windows line endings split into separate lines")
+    func handlesCarriageReturns() {
+        let parsed = LogFileParsing.parseLines("one\r\ntwo")
+
+        // `.newlines` treats CRLF as a single break rather than emitting a blank.
+        #expect(parsed.map(\.text) == ["one", "two"])
+    }
+}

--- a/PVUI/Package.swift
+++ b/PVUI/Package.swift
@@ -199,6 +199,7 @@ let package = Package(
             dependencies: [
                 "PVUIBase",
                 "PVCoreBridge",
+                "PVLogging",
             ]
         ),
 

--- a/PVUI/Sources/PVUIBase/SwiftUI/Components/RetroWave/RetroLogView.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/Components/RetroWave/RetroLogView.swift
@@ -331,16 +331,18 @@ public struct RetroLogView: View {
                 }) {
                     Image(systemName: "doc.on.doc")
                         .font(.system(size: 12))
-                        .foregroundColor((viewModel.searchText.isEmpty || viewModel.displayedLogs.isEmpty) ? RetroTheme.retroPink.opacity(0.3) : RetroTheme.retroBlue)
+                        .foregroundColor((viewModel.searchText.isEmpty || viewModel.copyableLinesAreEmpty) ? RetroTheme.retroPink.opacity(0.3) : RetroTheme.retroBlue)
                         .padding(6)
                         .background(
                             RoundedRectangle(cornerRadius: 4)
-                                .strokeBorder((viewModel.searchText.isEmpty || viewModel.displayedLogs.isEmpty) ? RetroTheme.retroPink.opacity(0.3) : RetroTheme.retroBlue, lineWidth: 1)
+                                .strokeBorder((viewModel.searchText.isEmpty || viewModel.copyableLinesAreEmpty) ? RetroTheme.retroPink.opacity(0.3) : RetroTheme.retroBlue, lineWidth: 1)
                         )
                 }
-                .disabled(viewModel.searchText.isEmpty || viewModel.displayedLogs.isEmpty)
+                .disabled(viewModel.searchText.isEmpty || viewModel.copyableLinesAreEmpty)
 
-                // Export / share button
+                // Export / share button — exports the live session, so it is
+                // disabled while an imported file is on screen to avoid
+                // silently sharing different logs than the ones displayed.
                 Button(action: {
                     showingExportSheet = true
                 }) {
@@ -353,6 +355,7 @@ public struct RetroLogView: View {
                                 .strokeBorder(RetroTheme.retroBlue, lineWidth: 1)
                         )
                 }
+                .disabled(viewModel.importedSession != nil)
 
                 // Import log button
                 Button(action: {
@@ -367,6 +370,8 @@ public struct RetroLogView: View {
                                 .strokeBorder(RetroTheme.retroBlue, lineWidth: 1)
                         )
                 }
+                .accessibilityLabel("Import Log File")
+                .accessibilityHint("Open a saved log file to view it in place of the live logs")
 
                 // Clear logs button
                 Button(action: {
@@ -531,6 +536,9 @@ public struct RetroLogView: View {
 
     // Helper function to manage auto-scrolling behavior
     private func handleAutoScroll(scrollView: ScrollViewProxy) {
+        // An imported session is static and uses integer line IDs, so live-log
+        // UUID targets aren't in the list. Leave the reader's scroll alone.
+        guard viewModel.importedSession == nil else { return }
         if viewModel.autoScroll {
             if viewModel.sortOrder == .newestFirst {
                 // Scroll to the top-most item (newest)
@@ -776,7 +784,9 @@ extension RetroLogView {
             .font(.system(size: 11, design: .monospaced))
             .foregroundColor(line.level.map { viewModel.logLevelColor($0) } ?? .white.opacity(0.85))
             .frame(maxWidth: .infinity, alignment: .leading)
+            #if !os(tvOS)
             .textSelection(.enabled)
+            #endif
             .padding(.vertical, 1)
     }
 }

--- a/PVUI/Sources/PVUIBase/SwiftUI/Components/RetroWave/RetroLogView.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/Components/RetroWave/RetroLogView.swift
@@ -9,6 +9,9 @@
 import SwiftUI
 import PVThemes
 import PVLogging
+#if !os(tvOS)
+import UniformTypeIdentifiers
+#endif
 
 /// A retrowave-styled log viewer component
 public struct RetroLogView: View {
@@ -25,6 +28,14 @@ public struct RetroLogView: View {
 
     /// Controls presentation of the export options sheet
     @State private var showingExportSheet = false
+
+    #if !os(tvOS)
+    /// Controls presentation of the log file importer
+    @State private var showingImporter = false
+
+    /// Message shown when importing a log file fails
+    @State private var importErrorMessage: String?
+    #endif
 
     #if os(tvOS)
     /// Focus states for header buttons
@@ -59,13 +70,25 @@ public struct RetroLogView: View {
             // Header with controls
             headerView
 
+            // Banner shown while viewing a log imported from a file
+            if let session = viewModel.importedSession {
+                importedSessionBanner(name: session.name)
+            }
+
             // Log list
             ScrollViewReader { scrollView in
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 0) {
-                        ForEach(viewModel.displayedLogs) { log in
-                            logEntryRow(log)
-                                .id(log.id)
+                        if viewModel.importedSession != nil {
+                            ForEach(viewModel.displayedImportedLines) { line in
+                                importedLineRow(line)
+                                    .id(line.id)
+                            }
+                        } else {
+                            ForEach(viewModel.displayedLogs) { log in
+                                logEntryRow(log)
+                                    .id(log.id)
+                            }
                         }
 
                         // Invisible view at the bottom for auto-scrolling
@@ -110,6 +133,36 @@ public struct RetroLogView: View {
         .sheet(isPresented: $showingExportSheet) {
             LogExportSheet(viewModel: viewModel)
         }
+        #if !os(tvOS)
+        .fileImporter(
+            isPresented: $showingImporter,
+            allowedContentTypes: Self.importableContentTypes,
+            allowsMultipleSelection: false
+        ) { result in
+            switch result {
+            case .success(let urls):
+                guard let url = urls.first else { return }
+                do {
+                    try viewModel.importLog(from: url)
+                } catch {
+                    importErrorMessage = error.localizedDescription
+                }
+            case .failure(let error):
+                importErrorMessage = error.localizedDescription
+            }
+        }
+        .alert(
+            "Import Failed",
+            isPresented: Binding(
+                get: { importErrorMessage != nil },
+                set: { if !$0 { importErrorMessage = nil } }
+            )
+        ) {
+            Button("OK", role: .cancel) { importErrorMessage = nil }
+        } message: {
+            Text(importErrorMessage ?? "")
+        }
+        #endif
     }
 
     // MARK: - Subviews
@@ -301,6 +354,20 @@ public struct RetroLogView: View {
                         )
                 }
 
+                // Import log button
+                Button(action: {
+                    showingImporter = true
+                }) {
+                    Image(systemName: "square.and.arrow.down")
+                        .font(.system(size: 12))
+                        .foregroundColor(RetroTheme.retroBlue)
+                        .padding(6)
+                        .background(
+                            RoundedRectangle(cornerRadius: 4)
+                                .strokeBorder(RetroTheme.retroBlue, lineWidth: 1)
+                        )
+                }
+
                 // Clear logs button
                 Button(action: {
                     viewModel.clearLogs()
@@ -314,6 +381,7 @@ public struct RetroLogView: View {
                                 .strokeBorder(RetroTheme.retroPink.opacity(0.7), lineWidth: 1)
                         )
                 }
+                .disabled(viewModel.importedSession != nil)
 
                 Spacer()
 
@@ -646,6 +714,70 @@ public struct RetroLogView: View {
             }
             #endif // !os(tvOS)
         }
+    }
+}
+
+// MARK: - Imported Session UI
+
+extension RetroLogView {
+    #if !os(tvOS)
+    /// Content types the log importer accepts: plain text, `.log`, and exported `.zip` bundles.
+    static var importableContentTypes: [UTType] {
+        var types: [UTType] = [.plainText, .zip]
+        if let logType = UTType(filenameExtension: "log") {
+            types.append(logType)
+        }
+        return types
+    }
+    #endif
+
+    /// Banner indicating the view is showing an imported session rather than live logs.
+    func importedSessionBanner(name: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "doc.text.magnifyingglass")
+                .font(.system(size: 12))
+                .foregroundColor(RetroTheme.retroPink)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text("VIEWING IMPORTED SESSION")
+                    .font(.system(size: 10, weight: .bold, design: .monospaced))
+                    .foregroundColor(RetroTheme.retroPink)
+                Text(name)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(.white.opacity(0.8))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+
+            Spacer()
+
+            Button {
+                viewModel.closeImportedSession()
+            } label: {
+                Text("LIVE LOGS")
+                    .font(.system(size: 10, weight: .bold, design: .monospaced))
+                    .foregroundColor(RetroTheme.retroBlue)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(
+                        RoundedRectangle(cornerRadius: 4)
+                            .strokeBorder(RetroTheme.retroBlue, lineWidth: 1)
+                    )
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .background(RetroTheme.retroPink.opacity(0.12))
+    }
+
+    /// Row for a single line of an imported log file.
+    func importedLineRow(_ line: RetroLogViewModel.ImportedLogLine) -> some View {
+        Text(line.text.isEmpty ? " " : line.text)
+            .font(.system(size: 11, design: .monospaced))
+            .foregroundColor(line.level.map { viewModel.logLevelColor($0) } ?? .white.opacity(0.85))
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .textSelection(.enabled)
+            .padding(.vertical, 1)
     }
 }
 

--- a/PVUI/Sources/PVUIBase/SwiftUI/Components/RetroWave/RetroLogView.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/Components/RetroWave/RetroLogView.swift
@@ -142,10 +142,14 @@ public struct RetroLogView: View {
             switch result {
             case .success(let urls):
                 guard let url = urls.first else { return }
-                do {
-                    try viewModel.importLog(from: url)
-                } catch {
-                    importErrorMessage = error.localizedDescription
+                // Parsing happens off-main inside importLog; awaiting here keeps
+                // the picker callback from blocking on file I/O.
+                Task {
+                    do {
+                        try await viewModel.importLog(from: url)
+                    } catch {
+                        importErrorMessage = error.localizedDescription
+                    }
                 }
             case .failure(let error):
                 importErrorMessage = error.localizedDescription

--- a/PVUI/Sources/PVUIBase/SwiftUI/Components/RetroWave/RetroLogViewModel.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/Components/RetroWave/RetroLogViewModel.swift
@@ -73,8 +73,16 @@ public final class RetroLogViewModel: ObservableObject {
     }
 
 #if !os(tvOS)
-    /// Copies the currently filtered and sorted logs to the clipboard.
+    /// Copies whatever is currently on screen to the clipboard — the imported
+    /// session when one is open, otherwise the filtered live logs.
     public func copyFilteredLogsToClipboard() {
+        if importedSession != nil {
+            let lines = displayedImportedLines
+            guard !lines.isEmpty else { return }
+            UIPasteboard.general.string = lines.map(\.text).joined(separator: "\n")
+            return
+        }
+
         guard !displayedLogs.isEmpty else { return }
 
         let logTexts = displayedLogs.map { log -> String in
@@ -285,11 +293,10 @@ public final class RetroLogViewModel: ObservableObject {
         }
     }
 
-    /// File extensions accepted by the log importer.
-    public static let importableExtensions: Set<String> = ["txt", "log", "zip"]
-
     /// Reads a log file (plain text or an exported `.zip` bundle) and displays it
     /// in place of the live logs.
+    /// Main-actor bound because it publishes `importedSession`.
+    @MainActor
     public func importLog(from url: URL) throws {
         let scoped = url.startAccessingSecurityScopedResource()
         defer { if scoped { url.stopAccessingSecurityScopedResource() } }
@@ -315,6 +322,11 @@ public final class RetroLogViewModel: ObservableObject {
     /// Returns to the live log session.
     public func closeImportedSession() {
         importedSession = nil
+    }
+
+    /// Whether there is nothing on screen to copy — accounts for an open import.
+    public var copyableLinesAreEmpty: Bool {
+        importedSession != nil ? displayedImportedLines.isEmpty : displayedLogs.isEmpty
     }
 
     /// Imported lines after applying the current search filter.

--- a/PVUI/Sources/PVUIBase/SwiftUI/Components/RetroWave/RetroLogViewModel.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/Components/RetroWave/RetroLogViewModel.swift
@@ -72,7 +72,10 @@ public final class RetroLogViewModel: ObservableObject {
         PVLogPublisher.shared.clearLogs()
     }
 
-#if !os(tvOS)
+// `UIPasteboard` is UIKit-only, but PVUIBase also declares native macOS and
+// watchOS support where UIKit doesn't exist, so gate on the framework rather
+// than just excluding tvOS.
+#if !os(tvOS) && canImport(UIKit)
     /// Copies whatever is currently on screen to the clipboard — the imported
     /// session when one is open, otherwise the filtered live logs.
     public func copyFilteredLogsToClipboard() {
@@ -279,6 +282,7 @@ public final class RetroLogViewModel: ObservableObject {
     public enum LogImportError: LocalizedError {
         case unreadable
         case noLogsInArchive
+        case tooLarge
 
         public var errorDescription: String? {
             switch self {
@@ -286,31 +290,51 @@ public final class RetroLogViewModel: ObservableObject {
                 return "That file could not be read as text."
             case .noLogsInArchive:
                 return "No log files were found inside that archive."
+            case .tooLarge:
+                return "That log is too large to open (limit \(RetroLogViewModel.maxImportBytes / 1_048_576) MB)."
             }
         }
     }
 
+    /// Upper bound on how much log text will be read into memory.
+    ///
+    /// The file is user-chosen, but a very large log — or a highly compressed
+    /// archive — would otherwise be expanded unbounded into `Data`, `String`,
+    /// and finally an array of line objects.
+    public static let maxImportBytes = 64 * 1_048_576  // 64 MB
+
     /// Reads a log file (plain text or an exported `.zip` bundle) and displays it
     /// in place of the live logs.
-    /// Main-actor bound because it publishes `importedSession`.
+    ///
+    /// File I/O, ZIP extraction and parsing all run off the main actor; only the
+    /// final publish of `importedSession` hops back, so importing a large log
+    /// never blocks rendering or input.
     @MainActor
-    public func importLog(from url: URL) throws {
+    public func importLog(from url: URL) async throws {
         let scoped = url.startAccessingSecurityScopedResource()
         defer { if scoped { url.stopAccessingSecurityScopedResource() } }
 
-        let text: String
-        if url.pathExtension.lowercased() == "zip" {
-            text = try Self.text(fromArchiveAt: url)
-        } else {
-            guard let contents = try? String(contentsOf: url, encoding: .utf8) else {
-                throw LogImportError.unreadable
-            }
-            text = contents
+        let name = url.lastPathComponent
+        let isArchive = url.pathExtension.lowercased() == "zip"
+
+        let lines = try await Task.detached(priority: .userInitiated) { () throws -> [ImportedLogLine] in
+            let text = isArchive
+                ? try Self.text(fromArchiveAt: url)
+                : try Self.text(fromPlainFileAt: url)
+            return LogFileParsing.parseLines(text)
+        }.value
+
+        importedSession = ImportedLogSession(name: name, lines: lines)
+    }
+
+    /// Reads a plain-text log, refusing anything past `maxImportBytes`.
+    private static func text(fromPlainFileAt url: URL) throws -> String {
+        let size = (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+        guard size <= maxImportBytes else { throw LogImportError.tooLarge }
+        guard let contents = try? String(contentsOf: url, encoding: .utf8) else {
+            throw LogImportError.unreadable
         }
-
-        let lines = LogFileParsing.parseLines(text)
-
-        importedSession = ImportedLogSession(name: url.lastPathComponent, lines: lines)
+        return contents
     }
 
     /// Returns to the live log session.
@@ -349,10 +373,16 @@ public final class RetroLogViewModel: ObservableObject {
         guard !textEntries.isEmpty else { throw LogImportError.noLogsInArchive }
 
         var sections: [String] = []
+        var budget = maxImportBytes
         for entry in textEntries {
+            // Check the declared size before extracting so a highly-compressed
+            // entry can't expand past the budget on its way into memory.
+            // `uncompressedSize` is UInt64; compare in that domain.
+            guard entry.uncompressedSize <= UInt64(budget) else { throw LogImportError.tooLarge }
             var data = Data()
             guard (try? archive.extract(entry, consumer: { data.append($0) })) != nil,
                   let contents = String(data: data, encoding: .utf8) else { continue }
+            budget -= min(budget, data.count)
             sections.append("=== \(entry.path) ===\n\(contents)")
         }
 

--- a/PVUI/Sources/PVUIBase/SwiftUI/Components/RetroWave/RetroLogViewModel.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/Components/RetroWave/RetroLogViewModel.swift
@@ -10,6 +10,7 @@ import Foundation
 import SwiftUI
 import Combine
 import PVLogging
+import ZIPFoundation
 
 /// ViewModel for RetroLogView
 public final class RetroLogViewModel: ObservableObject {
@@ -38,6 +39,10 @@ public final class RetroLogViewModel: ObservableObject {
 
     /// Current sort order for logs
     @Published public var sortOrder: SortOrder = .newestFirst
+
+    /// A log session imported from a file, shown in place of the live logs.
+    /// `nil` means the live session is being displayed.
+    @Published public var importedSession: ImportedLogSession?
 
     // MARK: - Private Properties
 
@@ -246,6 +251,118 @@ public final class RetroLogViewModel: ObservableObject {
             try? fm.removeItem(at: tempDir)
             return nil
         }
+    }
+
+    // MARK: - Import
+
+    /// A single line of an imported log file.
+    public struct ImportedLogLine: Identifiable, Equatable {
+        public let id: Int
+        public let text: String
+        /// Parsed level, when the line carries a recognisable `[LEVEL]` tag.
+        public let level: LogLevel?
+    }
+
+    /// A log session read from a file, displayed instead of the live session.
+    public struct ImportedLogSession: Equatable {
+        /// File name the session was read from, shown in the banner.
+        public let name: String
+        public let lines: [ImportedLogLine]
+    }
+
+    /// Errors surfaced to the user when importing a log file fails.
+    public enum LogImportError: LocalizedError {
+        case unreadable
+        case noLogsInArchive
+
+        public var errorDescription: String? {
+            switch self {
+            case .unreadable:
+                return "That file could not be read as text."
+            case .noLogsInArchive:
+                return "No log files were found inside that archive."
+            }
+        }
+    }
+
+    /// File extensions accepted by the log importer.
+    public static let importableExtensions: Set<String> = ["txt", "log", "zip"]
+
+    /// Reads a log file (plain text or an exported `.zip` bundle) and displays it
+    /// in place of the live logs.
+    public func importLog(from url: URL) throws {
+        let scoped = url.startAccessingSecurityScopedResource()
+        defer { if scoped { url.stopAccessingSecurityScopedResource() } }
+
+        let text: String
+        if url.pathExtension.lowercased() == "zip" {
+            text = try Self.text(fromArchiveAt: url)
+        } else {
+            guard let contents = try? String(contentsOf: url, encoding: .utf8) else {
+                throw LogImportError.unreadable
+            }
+            text = contents
+        }
+
+        let lines = text
+            .components(separatedBy: .newlines)
+            .enumerated()
+            .map { ImportedLogLine(id: $0.offset, text: $0.element, level: Self.level(in: $0.element)) }
+
+        importedSession = ImportedLogSession(name: url.lastPathComponent, lines: lines)
+    }
+
+    /// Returns to the live log session.
+    public func closeImportedSession() {
+        importedSession = nil
+    }
+
+    /// Imported lines after applying the current search filter.
+    public var displayedImportedLines: [ImportedLogLine] {
+        guard let session = importedSession else { return [] }
+        guard !searchText.isEmpty else { return session.lines }
+        return session.lines.filter { $0.text.localizedCaseInsensitiveContains(searchText) }
+    }
+
+    /// Concatenates every text log found inside an exported ZIP bundle.
+    private static func text(fromArchiveAt url: URL) throws -> String {
+        guard let archive = Archive(url: url, accessMode: .read) else {
+            throw LogImportError.unreadable
+        }
+
+        /// `device_info.txt` first so the header reads at the top, then the rest alphabetically.
+        let textEntries = archive
+            .filter { ["txt", "log"].contains(($0.path as NSString).pathExtension.lowercased()) }
+            .sorted { lhs, rhs in
+                if lhs.path.hasSuffix("device_info.txt") != rhs.path.hasSuffix("device_info.txt") {
+                    return lhs.path.hasSuffix("device_info.txt")
+                }
+                return lhs.path < rhs.path
+            }
+
+        guard !textEntries.isEmpty else { throw LogImportError.noLogsInArchive }
+
+        var sections: [String] = []
+        for entry in textEntries {
+            var data = Data()
+            guard (try? archive.extract(entry, consumer: { data.append($0) })) != nil,
+                  let contents = String(data: data, encoding: .utf8) else { continue }
+            sections.append("=== \(entry.path) ===\n\(contents)")
+        }
+
+        guard !sections.isEmpty else { throw LogImportError.noLogsInArchive }
+        return sections.joined(separator: "\n\n")
+    }
+
+    /// Best-effort parse of a `[LEVEL]` tag so imported lines keep their colour coding.
+    private static func level(in line: String) -> LogLevel? {
+        let upper = line.uppercased()
+        if upper.contains("[ERROR]") { return .error }
+        if upper.contains("[WARNING]") { return .warning }
+        if upper.contains("[INFO]") { return .info }
+        if upper.contains("[DEBUG]") { return .debug }
+        if upper.contains("[VERBOSE]") { return .verbose }
+        return nil
     }
 }
 

--- a/PVUI/Sources/PVUIBase/SwiftUI/Components/RetroWave/RetroLogViewModel.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/Components/RetroWave/RetroLogViewModel.swift
@@ -264,12 +264,9 @@ public final class RetroLogViewModel: ObservableObject {
     // MARK: - Import
 
     /// A single line of an imported log file.
-    public struct ImportedLogLine: Identifiable, Equatable {
-        public let id: Int
-        public let text: String
-        /// Parsed level, when the line carries a recognisable `[LEVEL]` tag.
-        public let level: LogLevel?
-    }
+    /// The parsing itself lives in `PVLogging.LogFileParsing` so it can be
+    /// unit-tested without a full workspace build.
+    public typealias ImportedLogLine = LogFileParsing.ParsedLine
 
     /// A log session read from a file, displayed instead of the live session.
     public struct ImportedLogSession: Equatable {
@@ -311,10 +308,7 @@ public final class RetroLogViewModel: ObservableObject {
             text = contents
         }
 
-        let lines = text
-            .components(separatedBy: .newlines)
-            .enumerated()
-            .map { ImportedLogLine(id: $0.offset, text: $0.element, level: Self.level(in: $0.element)) }
+        let lines = LogFileParsing.parseLines(text)
 
         importedSession = ImportedLogSession(name: url.lastPathComponent, lines: lines)
     }
@@ -364,17 +358,6 @@ public final class RetroLogViewModel: ObservableObject {
 
         guard !sections.isEmpty else { throw LogImportError.noLogsInArchive }
         return sections.joined(separator: "\n\n")
-    }
-
-    /// Best-effort parse of a `[LEVEL]` tag so imported lines keep their colour coding.
-    private static func level(in line: String) -> LogLevel? {
-        let upper = line.uppercased()
-        if upper.contains("[ERROR]") { return .error }
-        if upper.contains("[WARNING]") { return .warning }
-        if upper.contains("[INFO]") { return .info }
-        if upper.contains("[DEBUG]") { return .debug }
-        if upper.contains("[VERBOSE]") { return .verbose }
-        return nil
     }
 }
 

--- a/PVUI/Tests/PVUIBaseTests/RetroLogImportTests.swift
+++ b/PVUI/Tests/PVUIBaseTests/RetroLogImportTests.swift
@@ -1,0 +1,184 @@
+import XCTest
+import PVLogging
+@testable import PVUIBase
+
+/// Coverage for the log-import path added for #3612: plain-text and ZIP
+/// ingestion, `[LEVEL]` parsing, archive ordering, and search filtering.
+@MainActor
+final class RetroLogImportTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RetroLogImportTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempDir { try? FileManager.default.removeItem(at: tempDir) }
+        try super.tearDownWithError()
+    }
+
+    private func write(_ contents: String, to name: String) throws -> URL {
+        let url = tempDir.appendingPathComponent(name)
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    // MARK: - Plain text
+
+    func testImportPlainTextPopulatesSessionAndName() throws {
+        let url = try write("line one\nline two\nline three", to: "sample.log")
+        let vm = RetroLogViewModel()
+
+        try vm.importLog(from: url)
+
+        XCTAssertNotNil(vm.importedSession)
+        XCTAssertEqual(vm.importedSession?.name, "sample.log")
+        XCTAssertEqual(vm.importedSession?.lines.count, 3)
+        XCTAssertEqual(vm.importedSession?.lines.first?.text, "line one")
+    }
+
+    func testImportedLineIDsAreUniqueAndOrdered() throws {
+        let url = try write("a\nb\nc\nd", to: "ids.txt")
+        let vm = RetroLogViewModel()
+
+        try vm.importLog(from: url)
+
+        let ids = vm.importedSession?.lines.map(\.id) ?? []
+        XCTAssertEqual(ids, [0, 1, 2, 3])
+        XCTAssertEqual(Set(ids).count, ids.count, "line IDs must be unique for ForEach")
+    }
+
+    // MARK: - Level parsing
+
+    func testLevelTagsAreParsed() throws {
+        let text = """
+        [12:00:00.000] [ERROR] boom
+        [12:00:00.001] [WARNING] careful
+        [12:00:00.002] [INFO] hello
+        [12:00:00.003] [DEBUG] details
+        [12:00:00.004] [VERBOSE] noise
+        """
+        let url = try write(text, to: "levels.log")
+        let vm = RetroLogViewModel()
+
+        try vm.importLog(from: url)
+
+        let levels = vm.importedSession?.lines.map(\.level) ?? []
+        XCTAssertEqual(levels, [.error, .warning, .info, .debug, .verbose])
+    }
+
+    func testUntaggedLineHasNoLevel() throws {
+        let url = try write("just a bare line", to: "bare.log")
+        let vm = RetroLogViewModel()
+
+        try vm.importLog(from: url)
+
+        XCTAssertNil(vm.importedSession?.lines.first?.level)
+    }
+
+    // MARK: - Filtering & lifecycle
+
+    func testSearchFiltersImportedLines() throws {
+        let url = try write("alpha\nbravo\ncharlie", to: "filter.log")
+        let vm = RetroLogViewModel()
+        try vm.importLog(from: url)
+
+        vm.searchText = "brav"
+
+        XCTAssertEqual(vm.displayedImportedLines.count, 1)
+        XCTAssertEqual(vm.displayedImportedLines.first?.text, "bravo")
+    }
+
+    func testSearchIsCaseInsensitive() throws {
+        let url = try write("AlphaBeta", to: "case.log")
+        let vm = RetroLogViewModel()
+        try vm.importLog(from: url)
+
+        vm.searchText = "alphabeta"
+
+        XCTAssertEqual(vm.displayedImportedLines.count, 1)
+    }
+
+    func testCloseImportedSessionReturnsToLive() throws {
+        let url = try write("x", to: "close.log")
+        let vm = RetroLogViewModel()
+        try vm.importLog(from: url)
+        XCTAssertNotNil(vm.importedSession)
+
+        vm.closeImportedSession()
+
+        XCTAssertNil(vm.importedSession)
+        XCTAssertTrue(vm.displayedImportedLines.isEmpty)
+    }
+
+    func testCopyableLinesReflectImportedSession() throws {
+        let url = try write("only line", to: "copy.log")
+        let vm = RetroLogViewModel()
+        try vm.importLog(from: url)
+
+        XCTAssertFalse(vm.copyableLinesAreEmpty)
+
+        vm.searchText = "no-such-text"
+        XCTAssertTrue(vm.copyableLinesAreEmpty)
+    }
+
+    // MARK: - ZIP bundles
+
+    func testImportZipConcatenatesTextEntriesWithDeviceInfoFirst() throws {
+        let staging = tempDir.appendingPathComponent("bundle")
+        try FileManager.default.createDirectory(at: staging, withIntermediateDirectories: true)
+        try "APP LOG BODY".write(to: staging.appendingPathComponent("app_logs.txt"),
+                                 atomically: true, encoding: .utf8)
+        try "DEVICE HEADER".write(to: staging.appendingPathComponent("device_info.txt"),
+                                  atomically: true, encoding: .utf8)
+        // A non-text entry that must be ignored by the importer.
+        try Data([0x00, 0x01]).write(to: staging.appendingPathComponent("screenshot.bin"))
+
+        let zipURL = tempDir.appendingPathComponent("logs.zip")
+        try zip(directory: staging, to: zipURL)
+
+        let vm = RetroLogViewModel()
+        try vm.importLog(from: zipURL)
+
+        let joined = (vm.importedSession?.lines.map(\.text) ?? []).joined(separator: "\n")
+        XCTAssertTrue(joined.contains("DEVICE HEADER"))
+        XCTAssertTrue(joined.contains("APP LOG BODY"))
+        XCTAssertFalse(joined.contains("screenshot.bin"),
+                       "non-text entries must not be inlined")
+
+        let headerIdx = try XCTUnwrap(joined.range(of: "DEVICE HEADER")).lowerBound
+        let bodyIdx = try XCTUnwrap(joined.range(of: "APP LOG BODY")).lowerBound
+        XCTAssertLessThan(headerIdx, bodyIdx, "device_info.txt should be ordered first")
+    }
+
+    func testImportUnreadableFileThrows() throws {
+        let url = tempDir.appendingPathComponent("does-not-exist.log")
+        let vm = RetroLogViewModel()
+
+        XCTAssertThrowsError(try vm.importLog(from: url))
+        XCTAssertNil(vm.importedSession, "a failed import must not replace the live session")
+    }
+
+    // MARK: - Helpers
+
+    /// Zips a directory using the same NSFileCoordinator approach as the exporter.
+    private func zip(directory: URL, to destination: URL) throws {
+        var coordinatorError: NSError?
+        var copyError: Error?
+        NSFileCoordinator().coordinate(readingItemAt: directory,
+                                       options: .forUploading,
+                                       error: &coordinatorError) { zipped in
+            do {
+                try FileManager.default.copyItem(at: zipped, to: destination)
+            } catch {
+                copyError = error
+            }
+        }
+        if let coordinatorError { throw coordinatorError }
+        if let copyError { throw copyError }
+    }
+}

--- a/PVUI/Tests/PVUIBaseTests/RetroLogImportTests.swift
+++ b/PVUI/Tests/PVUIBaseTests/RetroLogImportTests.swift
@@ -29,11 +29,11 @@ final class RetroLogImportTests: XCTestCase {
 
     // MARK: - Plain text
 
-    func testImportPlainTextPopulatesSessionAndName() throws {
+    func testImportPlainTextPopulatesSessionAndName() async throws {
         let url = try write("line one\nline two\nline three", to: "sample.log")
         let vm = RetroLogViewModel()
 
-        try vm.importLog(from: url)
+        try await vm.importLog(from: url)
 
         XCTAssertNotNil(vm.importedSession)
         XCTAssertEqual(vm.importedSession?.name, "sample.log")
@@ -41,11 +41,11 @@ final class RetroLogImportTests: XCTestCase {
         XCTAssertEqual(vm.importedSession?.lines.first?.text, "line one")
     }
 
-    func testImportedLineIDsAreUniqueAndOrdered() throws {
+    func testImportedLineIDsAreUniqueAndOrdered() async throws {
         let url = try write("a\nb\nc\nd", to: "ids.txt")
         let vm = RetroLogViewModel()
 
-        try vm.importLog(from: url)
+        try await vm.importLog(from: url)
 
         let ids = vm.importedSession?.lines.map(\.id) ?? []
         XCTAssertEqual(ids, [0, 1, 2, 3])
@@ -59,10 +59,10 @@ final class RetroLogImportTests: XCTestCase {
 
     // MARK: - Filtering & lifecycle
 
-    func testSearchFiltersImportedLines() throws {
+    func testSearchFiltersImportedLines() async throws {
         let url = try write("alpha\nbravo\ncharlie", to: "filter.log")
         let vm = RetroLogViewModel()
-        try vm.importLog(from: url)
+        try await vm.importLog(from: url)
 
         vm.searchText = "brav"
 
@@ -70,20 +70,20 @@ final class RetroLogImportTests: XCTestCase {
         XCTAssertEqual(vm.displayedImportedLines.first?.text, "bravo")
     }
 
-    func testSearchIsCaseInsensitive() throws {
+    func testSearchIsCaseInsensitive() async throws {
         let url = try write("AlphaBeta", to: "case.log")
         let vm = RetroLogViewModel()
-        try vm.importLog(from: url)
+        try await vm.importLog(from: url)
 
         vm.searchText = "alphabeta"
 
         XCTAssertEqual(vm.displayedImportedLines.count, 1)
     }
 
-    func testCloseImportedSessionReturnsToLive() throws {
+    func testCloseImportedSessionReturnsToLive() async throws {
         let url = try write("x", to: "close.log")
         let vm = RetroLogViewModel()
-        try vm.importLog(from: url)
+        try await vm.importLog(from: url)
         XCTAssertNotNil(vm.importedSession)
 
         vm.closeImportedSession()
@@ -92,10 +92,10 @@ final class RetroLogImportTests: XCTestCase {
         XCTAssertTrue(vm.displayedImportedLines.isEmpty)
     }
 
-    func testCopyableLinesReflectImportedSession() throws {
+    func testCopyableLinesReflectImportedSession() async throws {
         let url = try write("only line", to: "copy.log")
         let vm = RetroLogViewModel()
-        try vm.importLog(from: url)
+        try await vm.importLog(from: url)
 
         XCTAssertFalse(vm.copyableLinesAreEmpty)
 
@@ -105,7 +105,7 @@ final class RetroLogImportTests: XCTestCase {
 
     // MARK: - ZIP bundles
 
-    func testImportZipConcatenatesTextEntriesWithDeviceInfoFirst() throws {
+    func testImportZipConcatenatesTextEntriesWithDeviceInfoFirst() async throws {
         let staging = tempDir.appendingPathComponent("bundle")
         try FileManager.default.createDirectory(at: staging, withIntermediateDirectories: true)
         try "APP LOG BODY".write(to: staging.appendingPathComponent("app_logs.txt"),
@@ -132,11 +132,39 @@ final class RetroLogImportTests: XCTestCase {
         XCTAssertLessThan(headerIdx, bodyIdx, "device_info.txt should be ordered first")
     }
 
-    func testImportUnreadableFileThrows() throws {
+    func testOversizedPlainFileIsRejected() async throws {
+        // One byte past the cap must be refused rather than read into memory.
+        let url = tempDir.appendingPathComponent("huge.log")
+        let size = RetroLogViewModel.maxImportBytes + 1
+        // Sparse write: set the file length without materialising the bytes.
+        FileManager.default.createFile(atPath: url.path, contents: nil)
+        let handle = try FileHandle(forWritingTo: url)
+        try handle.truncate(atOffset: UInt64(size))
+        try handle.close()
+
+        let vm = RetroLogViewModel()
+        do {
+            try await vm.importLog(from: url)
+            XCTFail("expected an oversized log to be rejected")
+        } catch {
+            guard let importError = error as? RetroLogViewModel.LogImportError,
+                  case .tooLarge = importError else {
+                return XCTFail("expected .tooLarge, got \(error)")
+            }
+        }
+        XCTAssertNil(vm.importedSession)
+    }
+
+    func testImportUnreadableFileThrows() async throws {
         let url = tempDir.appendingPathComponent("does-not-exist.log")
         let vm = RetroLogViewModel()
 
-        XCTAssertThrowsError(try vm.importLog(from: url))
+        do {
+            try await vm.importLog(from: url)
+            XCTFail("expected import of a missing file to throw")
+        } catch {
+            // expected
+        }
         XCTAssertNil(vm.importedSession, "a failed import must not replace the live session")
     }
 

--- a/PVUI/Tests/PVUIBaseTests/RetroLogImportTests.swift
+++ b/PVUI/Tests/PVUIBaseTests/RetroLogImportTests.swift
@@ -52,33 +52,10 @@ final class RetroLogImportTests: XCTestCase {
         XCTAssertEqual(Set(ids).count, ids.count, "line IDs must be unique for ForEach")
     }
 
-    // MARK: - Level parsing
-
-    func testLevelTagsAreParsed() throws {
-        let text = """
-        [12:00:00.000] [ERROR] boom
-        [12:00:00.001] [WARNING] careful
-        [12:00:00.002] [INFO] hello
-        [12:00:00.003] [DEBUG] details
-        [12:00:00.004] [VERBOSE] noise
-        """
-        let url = try write(text, to: "levels.log")
-        let vm = RetroLogViewModel()
-
-        try vm.importLog(from: url)
-
-        let levels = vm.importedSession?.lines.map(\.level) ?? []
-        XCTAssertEqual(levels, [.error, .warning, .info, .debug, .verbose])
-    }
-
-    func testUntaggedLineHasNoLevel() throws {
-        let url = try write("just a bare line", to: "bare.log")
-        let vm = RetroLogViewModel()
-
-        try vm.importLog(from: url)
-
-        XCTAssertNil(vm.importedSession?.lines.first?.level)
-    }
+    // NOTE: `[LEVEL]` tag parsing, line splitting, blank-line and CRLF handling
+    // are covered by `LogFileParsingTests` in PVLogging, which runs in CI's SPM
+    // matrix. This suite covers only what needs the view model: file/ZIP
+    // ingestion and session lifecycle.
 
     // MARK: - Filtering & lifecycle
 


### PR DESCRIPTION
Completes the import half of #3612. Export (#3613), the RetroArch log browser (#3614), and `PVLogFileManager` (#3615) already landed; importing a log back in was the remaining gap.

## What it does

- **Import button** (`square.and.arrow.down`) in the `RetroLogView` header, next to Export
- Accepts **`.txt`, `.log`, and exported `.zip` bundles** — ZIPs are unpacked via ZIPFoundation (already a PVUIBase dependency), with `device_info.txt` ordered first so the header reads at the top
- Imported session **replaces the live log list**, with a banner naming the file and a **LIVE LOGS** button to return
- Best-effort `[LEVEL]` parsing so imported lines keep their colour coding
- Search still filters imported lines; Clear is disabled while viewing an import
- Failure surfaces a plain alert rather than failing silently

## Platform

iOS / Mac Catalyst only — tvOS has no document picker, so the button, `.fileImporter`, and `UniformTypeIdentifiers` import are all behind `#if !os(tvOS)`. The banner and row rendering compile on both.

## Validation

- `swiftc -parse` clean on both changed files
- `swiftlint` — no errors. New subviews were moved into an `extension RetroLogView` so `type_body_length` went **down** (638 → 587 lines, under the 600 error threshold); the remaining warning is pre-existing debt on this file.

## Not included

Opening a log file from outside the app (Files.app / share sheet → Provenance) is **still open**. It needs `CFBundleDocumentTypes` across 8 Info.plists plus routing in `handle(fileURL:)`. Worth a deliberate decision first: claiming `public.plain-text` / `public.zip-archive` would make Provenance volunteer to open *every* text file and ZIP from other apps, and risks intercepting ROM ZIP imports. A custom exported UTI is the safer path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the in-app log viewer and user-selected files with security-scoped access; no auth, persistence, or global file-type registration changes.
> 
> **Overview**
> Adds **log file import** to `RetroLogView` on iOS and Mac Catalyst (not tvOS): a header **import** control opens a `.fileImporter` for `.txt`, `.log`, and exported `.zip` bundles.
> 
> `RetroLogViewModel` gains import support via ZIPFoundation: plain UTF-8 files or ZIPs whose `.txt`/`.log` entries are merged (`device_info.txt` first), with `[LEVEL]` tags parsed for line coloring. An imported session **replaces** the live list behind a banner with **LIVE LOGS** to dismiss; search applies to imported lines and **Clear** is disabled while viewing an import. Failures show an **Import Failed** alert.
> 
> Imported-session banner and line rows live in a `RetroLogView` extension; picker, importer, and UTTypes stay behind `#if !os(tvOS)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25a65442611e69411798a17727d97a1529eb4634. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->