### PR TITLE
fix(icloud): simulator entitlement check crashed unentitled builds at launch

### DIFF
--- a/PVLibrary/Sources/PVLibrary/Cloud Sync/SyncProviderFactory.swift
+++ b/PVLibrary/Sources/PVLibrary/Cloud Sync/SyncProviderFactory.swift
@@ -33,16 +33,21 @@ public class SyncProviderFactory {
         DLOG("iCloudSync=\(iCloudSyncEnabled), iCloudSyncMode=\(syncMode.description)")
         
 #if os(tvOS)
-        // Get the container identifier from the bundle
-        let containerIdentifier = iCloudConstants.containerIdentifier
-        let container = CKContainer(identifier: containerIdentifier)
+        // Use the entitlement-gated container: `CKContainer(identifier:)` traps when the
+        // container isn't entitled, so constructing it directly crashes unentitled builds.
+        guard let container = iCloudConstants.container else {
+            WLOG("CloudKit container unavailable (no entitlement) — falling back to iCloud Documents syncer")
+            return iCloudContainerSyncer(directories: directories, notificationCenter: notificationCenter, errorHandler: errorHandler)
+        }
         return CloudKitSyncer(container: container, directories: directories, notificationCenter: notificationCenter, errorHandler: errorHandler)
 #else
         // Return the appropriate syncer based on the mode
         if syncMode.isCloudKit {
-            // Get the container identifier from the bundle
-            let containerIdentifier = iCloudConstants.containerIdentifier
-            let container = CKContainer(identifier: containerIdentifier)
+            // Entitlement-gated: see the tvOS branch above.
+            guard let container = iCloudConstants.container else {
+                WLOG("CloudKit container unavailable (no entitlement) — falling back to iCloud Documents syncer")
+                return iCloudContainerSyncer(directories: directories, notificationCenter: notificationCenter, errorHandler: errorHandler)
+            }
             DLOG("Creating CloudKit syncer based on iCloudSyncMode=\(syncMode.description)")
             return CloudKitSyncer(container: container, directories: directories, notificationCenter: notificationCenter, errorHandler: errorHandler)
         } else {

--- a/PVLibrary/Sources/PVLibrary/Cloud Sync/iCloud/iCloudConstants.swift
+++ b/PVLibrary/Sources/PVLibrary/Cloud Sync/iCloud/iCloudConstants.swift
@@ -41,21 +41,28 @@ public enum iCloudConstants {
     /// - iOS / tvOS device: parses `embedded.mobileprovision` when present (sideloaded /
     ///   AdHoc / TestFlight). App Store builds strip the provisioning profile, so absence
     ///   of the file is treated as "entitlement present" (App Store validation guarantees it).
-    /// - Simulator: reads the live code signature via `SecTaskCopyValueForEntitlement`.
-    ///   Simulator builds carry no `embedded.mobileprovision`, and may carry no
-    ///   entitlements at all, so nothing may be assumed here.
+    /// - Simulator: uses `FileManager.ubiquityIdentityToken`, which is nil without the
+    ///   ubiquity entitlement. Simulator builds carry no `embedded.mobileprovision` *and*
+    ///   may carry no entitlements at all, so nothing may be assumed here — and the
+    ///   macOS `SecTask*` path is unavailable (that header ships only in the macOS SDK).
     public static let isCloudKitEntitlementPresent: Bool = {
         #if targetEnvironment(simulator)
         // `NSUbiquitousContainers` is an Info.plist *declaration*, not an entitlement.
         // It is always present in this bundle, so keying off it returned true even for
         // simulator builds signed without entitlements (CI's CODE_SIGNING_ALLOWED=NO,
         // ad-hoc re-signs, screenshot automation). `CKContainer(identifier:)` then traps
-        // on first access and the app dies at launch. Read the real code signature instead
-        // — the same source CloudKit itself validates against.
-        guard let task = SecTaskCreateFromSelf(nil),
-              let value = SecTaskCopyValueForEntitlement(task, "com.apple.developer.icloud-container-identifiers" as CFString, nil),
-              let containers = value as? [String] else { return false }
-        return !containers.isEmpty
+        // on first access and the app dies at launch.
+        //
+        // The code signature can't be read here the way the macOS branch does it:
+        // `SecTask.h` ships in the macOS SDK only, so `SecTaskCreateFromSelf` /
+        // `SecTaskCopyValueForEntitlement` don't exist for iOS/tvOS simulator targets.
+        //
+        // `ubiquityIdentityToken` is nil unless the process actually holds the ubiquity
+        // entitlement, is a plain Foundation API available on every platform, and — unlike
+        // `CKContainer(identifier:)` — returns rather than trapping. An entitled simulator
+        // build with a signed-in account still gets CloudKit; an unentitled one degrades
+        // to sync-disabled instead of crashing at launch.
+        return FileManager.default.ubiquityIdentityToken != nil
         #elseif os(macOS) || targetEnvironment(macCatalyst)
         guard let task = SecTaskCreateFromSelf(nil) else { return false }
         let key = "com.apple.developer.icloud-container-identifiers" as CFString

--- a/PVLibrary/Sources/PVLibrary/Cloud Sync/iCloud/iCloudConstants.swift
+++ b/PVLibrary/Sources/PVLibrary/Cloud Sync/iCloud/iCloudConstants.swift
@@ -10,6 +10,11 @@ import CloudKit
 #if os(macOS) || targetEnvironment(macCatalyst)
 import Security
 #endif
+#if targetEnvironment(simulator)
+/// For `_dyld_get_image_header` / `getsectiondata` — used to read the entitlements
+/// blob the linker embeds in simulator builds.
+import MachO
+#endif
 import PVLogging
 
 public enum iCloudConstants {
@@ -53,16 +58,16 @@ public enum iCloudConstants {
         // ad-hoc re-signs, screenshot automation). `CKContainer(identifier:)` then traps
         // on first access and the app dies at launch.
         //
-        // The code signature can't be read here the way the macOS branch does it:
-        // `SecTask.h` ships in the macOS SDK only, so `SecTaskCreateFromSelf` /
-        // `SecTaskCopyValueForEntitlement` don't exist for iOS/tvOS simulator targets.
+        // Neither of the obvious proxies is correct here:
+        //  - `SecTaskCopyValueForEntitlement` (used by the macOS branch below) doesn't
+        //    exist for simulator targets — `SecTask.h` ships in the macOS SDK only.
+        //  - `FileManager.ubiquityIdentityToken` reflects the *ubiquity* entitlement and
+        //    account state, not `com.apple.developer.icloud-container-identifiers`, so a
+        //    build holding one but not the other would still trap.
         //
-        // `ubiquityIdentityToken` is nil unless the process actually holds the ubiquity
-        // entitlement, is a plain Foundation API available on every platform, and — unlike
-        // `CKContainer(identifier:)` — returns rather than trapping. An entitled simulator
-        // build with a signed-in account still gets CloudKit; an unentitled one degrades
-        // to sync-disabled instead of crashing at launch.
-        return FileManager.default.ubiquityIdentityToken != nil
+        // Read the entitlements the linker embeds in `__TEXT,__entitlements` for
+        // simulator builds — the actual list CloudKit validates against.
+        return _embeddedEntitlementContainers()?.isEmpty == false
         #elseif os(macOS) || targetEnvironment(macCatalyst)
         guard let task = SecTaskCreateFromSelf(nil) else { return false }
         let key = "com.apple.developer.icloud-container-identifiers" as CFString
@@ -75,6 +80,32 @@ public enum iCloudConstants {
         return _cloudKitEntitlementFromProvisioningProfile() ?? true
         #endif
     }()
+
+#if targetEnvironment(simulator)
+    /// Returns the CloudKit container identifiers from the entitlements blob the linker
+    /// embeds in `__TEXT,__entitlements` for simulator builds, or `nil` when the section
+    /// is absent (i.e. the build carries no entitlements at all).
+    ///
+    /// Simulator apps aren't code-signed the way device builds are, so the entitlements
+    /// live in a Mach-O section rather than a signature — which is why the macOS
+    /// `SecTask*` path and the device `embedded.mobileprovision` path both miss them.
+    private static func _embeddedEntitlementContainers() -> [String]? {
+        guard let header = _dyld_get_image_header(0) else { return nil }
+        var size: UInt = 0
+        let sectionPointer = header.withMemoryRebound(to: mach_header_64.self, capacity: 1) { pointer in
+            getsectiondata(pointer, "__TEXT", "__entitlements", &size)
+        }
+        guard let sectionPointer, size > 0 else { return nil }
+
+        let data = Data(bytes: sectionPointer, count: Int(size))
+        guard let plist = try? PropertyListSerialization.propertyList(from: data, format: nil),
+              let entitlements = plist as? [String: Any],
+              let containers = entitlements["com.apple.developer.icloud-container-identifiers"] as? [String] else {
+            return nil
+        }
+        return containers
+    }
+#endif
 
     /// Parses the `embedded.mobileprovision` PKCS#7 blob to check for the CloudKit
     /// container entitlement. Returns `nil` when no provisioning profile is embedded

--- a/PVLibrary/Sources/PVLibrary/Cloud Sync/iCloud/iCloudConstants.swift
+++ b/PVLibrary/Sources/PVLibrary/Cloud Sync/iCloud/iCloudConstants.swift
@@ -41,14 +41,21 @@ public enum iCloudConstants {
     /// - iOS / tvOS device: parses `embedded.mobileprovision` when present (sideloaded /
     ///   AdHoc / TestFlight). App Store builds strip the provisioning profile, so absence
     ///   of the file is treated as "entitlement present" (App Store validation guarantees it).
-    /// - Simulator: always returns true (simulator entitlements are always present).
+    /// - Simulator: reads the live code signature via `SecTaskCopyValueForEntitlement`.
+    ///   Simulator builds carry no `embedded.mobileprovision`, and may carry no
+    ///   entitlements at all, so nothing may be assumed here.
     public static let isCloudKitEntitlementPresent: Bool = {
         #if targetEnvironment(simulator)
-        // Simulator: only claim entitlement is present if Info.plist declares CloudKit containers
-        if let containers = Bundle.main.infoDictionary?["NSUbiquitousContainers"] as? [String: AnyObject], !containers.isEmpty {
-            return true
-        }
-        return false
+        // `NSUbiquitousContainers` is an Info.plist *declaration*, not an entitlement.
+        // It is always present in this bundle, so keying off it returned true even for
+        // simulator builds signed without entitlements (CI's CODE_SIGNING_ALLOWED=NO,
+        // ad-hoc re-signs, screenshot automation). `CKContainer(identifier:)` then traps
+        // on first access and the app dies at launch. Read the real code signature instead
+        // — the same source CloudKit itself validates against.
+        guard let task = SecTaskCreateFromSelf(nil),
+              let value = SecTaskCopyValueForEntitlement(task, "com.apple.developer.icloud-container-identifiers" as CFString, nil),
+              let containers = value as? [String] else { return false }
+        return !containers.isEmpty
         #elseif os(macOS) || targetEnvironment(macCatalyst)
         guard let task = SecTaskCreateFromSelf(nil) else { return false }
         let key = "com.apple.developer.icloud-container-identifiers" as CFString

--- a/PVLibrary/Sources/PVLibrary/Cloud Sync/iCloud/iCloudConstants.swift
+++ b/PVLibrary/Sources/PVLibrary/Cloud Sync/iCloud/iCloudConstants.swift
@@ -46,10 +46,11 @@ public enum iCloudConstants {
     /// - iOS / tvOS device: parses `embedded.mobileprovision` when present (sideloaded /
     ///   AdHoc / TestFlight). App Store builds strip the provisioning profile, so absence
     ///   of the file is treated as "entitlement present" (App Store validation guarantees it).
-    /// - Simulator: uses `FileManager.ubiquityIdentityToken`, which is nil without the
-    ///   ubiquity entitlement. Simulator builds carry no `embedded.mobileprovision` *and*
-    ///   may carry no entitlements at all, so nothing may be assumed here — and the
-    ///   macOS `SecTask*` path is unavailable (that header ships only in the macOS SDK).
+    /// - Simulator: reads the entitlements blob the linker embeds in `__TEXT,__entitlements`.
+    ///   Simulator builds aren't code-signed like device builds and carry no
+    ///   `embedded.mobileprovision`, so neither the macOS `SecTask*` path (that header ships
+    ///   only in the macOS SDK) nor the device profile path applies — and they may carry no
+    ///   entitlements at all, so nothing may be assumed here.
     public static let isCloudKitEntitlementPresent: Bool = {
         #if targetEnvironment(simulator)
         // `NSUbiquitousContainers` is an Info.plist *declaration*, not an entitlement.
@@ -90,12 +91,17 @@ public enum iCloudConstants {
     /// live in a Mach-O section rather than a signature — which is why the macOS
     /// `SecTask*` path and the device `embedded.mobileprovision` path both miss them.
     private static func _embeddedEntitlementContainers() -> [String]? {
-        guard let header = _dyld_get_image_header(0) else { return nil }
+        // Validate the magic before interpreting the header as 64-bit, matching
+        // `mainExecutableMachHeader64()` in PVJIT/CodeSignatureUtils.swift. Rebinding
+        // blind would be undefined behaviour if the image were ever not 64-bit.
+        guard let machHeader = _dyld_get_image_header(0) else { return nil }
+        let rawHeader = UnsafeRawPointer(machHeader)
+        guard rawHeader.load(as: UInt32.self) == MH_MAGIC_64 else { return nil }
+        let header = rawHeader.assumingMemoryBound(to: mach_header_64.self)
+
         var size: UInt = 0
-        let sectionPointer = header.withMemoryRebound(to: mach_header_64.self, capacity: 1) { pointer in
-            getsectiondata(pointer, "__TEXT", "__entitlements", &size)
-        }
-        guard let sectionPointer, size > 0 else { return nil }
+        guard let sectionPointer = getsectiondata(header, "__TEXT", "__entitlements", &size),
+              size > 0 else { return nil }
 
         let data = Data(bytes: sectionPointer, count: Int(size))
         guard let plist = try? PropertyListSerialization.propertyList(from: data, format: nil),

--- a/PVUI/Sources/PVSwiftUI/Settings/Views/CloudSyncStatusView.swift
+++ b/PVUI/Sources/PVSwiftUI/Settings/Views/CloudSyncStatusView.swift
@@ -206,7 +206,12 @@ public struct CloudSyncStatusView: View {
 #if os(tvOS)
     /// Check CloudKit availability on tvOS
     private func checkCloudKitAvailability() {
-        let container = CKContainer(identifier: iCloudConstants.containerIdentifier)
+        // Entitlement-gated: `CKContainer(identifier:)` traps when the container
+        // isn't entitled, so constructing it directly crashes unentitled builds.
+        guard let container = iCloudConstants.container else {
+            WLOG("CloudKit container unavailable (no entitlement) — skipping availability check")
+            return
+        }
         
         Task {
             do {


### PR DESCRIPTION
## The bug

`iCloudConstants.isCloudKitEntitlementPresent` decided the simulator case from Info.plist:

```swift
if let containers = Bundle.main.infoDictionary?["NSUbiquitousContainers"] ... { return true }
```

`NSUbiquitousContainers` is a **declaration**, not an entitlement, and it's always present in `Provenance-Info.plist`. So the check returned `true` unconditionally on simulator — including for builds carrying **no entitlements at all**.

`iCloudConstants.container` then ran `CKContainer(identifier:)`, which **traps** (it can't be caught) when the container isn't entitled. The app dies at launch, before any UI:

```
CKContainer.__allocating_init(identifier:)
static iCloudConstants.container            iCloudConstants.swift:96
one-time initialization for shared          CloudSyncManager.swift:77
DirectoryWatcher.handleFileSystemEvent      DirectoryWatcher.swift:895
```

Any file-system event triggers it, so it fires during first-launch import scanning.

**Who it hits:** simulator builds signed without entitlements — CI (`CODE_SIGNING_ALLOWED=NO`), ad-hoc re-signs, screenshot automation. Developers building from Xcode with a team have real entitlements, so it never reproduced for them.

## The fix

Read the entitlements the linker embeds in `__TEXT,__entitlements` for simulator builds, via `_dyld_get_image_header` + `getsectiondata`, and look for `com.apple.developer.icloud-container-identifiers`. No section → no entitlements → `false`.

Two proxies were tried first and **both were wrong** — thanks to review for catching them:

| Attempt | Why it failed |
|---|---|
| `SecTaskCopyValueForEntitlement` (mirroring the macOS branch) | `SecTask.h` ships in the **macOS SDK only** — it doesn't exist for simulator targets, so this could not compile. `import Security` in this file is also gated to macOS/Catalyst. |
| `FileManager.ubiquityIdentityToken` | Reflects the **ubiquity** entitlement + account state, not the CloudKit container entitlement that gates `CKContainer`. A build holding one but not the other would still trap. |

Simulator apps aren't code-signed the way device builds are, which is why both the macOS `SecTask*` path and the device `embedded.mobileprovision` path miss these entitlements — the Mach-O section is where they actually live.

## Also gated

`SyncProviderFactory` (tvOS and non-tvOS branches) and `CloudSyncStatusView.checkCloudKitAvailability` constructed `CKContainer` directly and would trap the same way. They now go through `iCloudConstants.container`, falling back to the iCloud Documents syncer / skipping the check when unentitled.

**Not** included: `CloudKitDiagnosticView:477` and `CloudKitRecordsViewModel:130` hold non-optional stored properties feeding a derived `CKDatabase` (~7 and ~15 use sites). Making those optional cascades through view state — a wider refactor than belongs in a crash fix, especially since PVUIBase has no type-checking in CI (#3647). Tracked in **#3648**. Those are diagnostic/settings screens, so they can't cause the launch crash this PR fixes, but they would still trap if opened in an unentitled build.

## Verification

- Mach-O logic **type-checked standalone against the `iphonesimulator` SDK** — `-parse` is syntax-only and would not have caught the missing `SecTask` symbol, which is exactly how that slipped through.
- `swiftc -parse` + `swiftlint` clean on all changed files (`CloudSyncStatusView` parse-checked against the tvOS target, since its change is inside `#if os(tvOS)`).
- Full `Provenance (AppStore)` iOS Simulator build for a real type-check of the whole change.

## Risk

The behaviour change is confined to `#if targetEnvironment(simulator)`; device, Catalyst and App Store paths are untouched. Every `iCloudConstants.container` call site already uses `if let`/`guard let` (verified — no force-unwraps in PVLibrary or PVUI), so an unentitled build degrades to sync-disabled instead of crashing. An entitled simulator build still reports `true` and gets CloudKit as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)