### PR TITLE
fix(importer): resolve import hang deadlock + 5 bugs it was hiding

### DIFF
--- a/PVHashing/Sources/PVHashing/NSFileManager+Hashing.swift
+++ b/PVHashing/Sources/PVHashing/NSFileManager+Hashing.swift
@@ -131,28 +131,40 @@ private func calculateMD5Attempt(fileURL: URL, offset: UInt64, promise: @escapin
     }
 }
 
+/// Computes the MD5 of a file on the **calling thread**.
+///
+/// This must never hand the work to another thread and wait for it. It used to
+/// wrap the Combine pipeline above: it blocked the caller on a `DispatchSemaphore`
+/// while the hashing was dispatched to `DispatchQueue.global(.utility)` and the
+/// completion hopped again to `.userInitiated`. Callers on the Swift cooperative
+/// pool — notably `GameImporter.preProcessQueue`'s `withTaskGroup`, via
+/// `isBIOS` → `ImportQueueItem.md5` — parked every worker thread in
+/// `semaphore_wait_trap`, leaving nothing to run the continuation that would
+/// signal the semaphore. That deadlocked the importer permanently (proven by a
+/// stack sample of the hung app on 2026-08-05: 10 threads, identical stack).
+///
+/// Hashing directly on the caller keeps the same blocking duration and the exact
+/// same result, but makes the deadlock structurally impossible: no second thread
+/// is required for this call to finish.
 func calculateMD5Synchronously(of fileURL: URL, startingAt offset: UInt64 = 0) throws -> String {
-    let semaphore = DispatchSemaphore(value: 0)
     var md5Hash: String = ""
     var returnedError: Error?
 
-    // The publisher now handles retries internally
-    let subscription = calculateMD5(of: fileURL, startingAt: offset)
-        .receive(on: DispatchQueue.global(qos: .userInitiated)) // Ensure completion/value are handled off the main thread if caller is main
-        .sink(receiveCompletion: { completion in
-            switch completion {
-            case .finished:
-                break // Success handled in receiveValue
-            case .failure(let error):
-                returnedError = error
-            }
-            semaphore.signal()
-        }, receiveValue: { hash in
-            md5Hash = hash
-        })
-
-    semaphore.wait()
-    subscription.cancel() // Clean up subscription
+    // Mirrors the previous pipeline's `.retry(2)`: three attempts total, with a
+    // 1 second pause before retrying, and only for retryable errors.
+    let maxAttempts = 3
+    for attempt in 1...maxAttempts {
+        do {
+            md5Hash = try _computeMD5(of: fileURL, startingAt: offset)
+            returnedError = nil
+            break
+        } catch {
+            VLOG("calculateMD5 attempt \(attempt) failed for \(fileURL.lastPathComponent): \(error.localizedDescription)")
+            returnedError = error
+            guard attempt < maxAttempts, isRetryableError(error as NSError) else { break }
+            Thread.sleep(forTimeInterval: 1)
+        }
+    }
 
     if let error = returnedError {
         // Log the final error after retries (if any) have failed

--- a/PVHashing/Tests/PVHashingTests/MD5ConcurrencyRegressionTests.swift
+++ b/PVHashing/Tests/PVHashingTests/MD5ConcurrencyRegressionTests.swift
@@ -1,0 +1,135 @@
+//
+//  MD5ConcurrencyRegressionTests.swift
+//  PVHashing
+//
+//  Regression coverage for the importer hang proven on 2026-08-05.
+//
+//  `calculateMD5Synchronously` used to block the *calling* thread on a
+//  DispatchSemaphore while the hashing itself was dispatched to
+//  DispatchQueue.global(.utility) and the completion hopped again to
+//  DispatchQueue.global(.userInitiated). Called from inside a `withTaskGroup`
+//  (as GameImporter.preProcessQueue does), that parks every Swift cooperative
+//  pool thread — leaving nothing to run the continuation that would signal the
+//  semaphore. A stack sample of the hung app showed 10 threads in the identical
+//  stack, all in semaphore_wait_trap, and the importer never recovered.
+//
+//  These tests saturate the cooperative pool on purpose. On the broken
+//  implementation they deadlock; the `.timeLimit` trait turns that into a
+//  failure instead of an infinite hang.
+//
+
+import Foundation
+import Testing
+#if canImport(CryptoKit)
+import CryptoKit
+#else
+import Crypto
+#endif
+@testable import PVHashing
+
+@Suite("MD5 concurrency regression")
+struct MD5ConcurrencyRegressionTests {
+
+    /// Deliberately oversubscribe the cooperative pool: the deadlock only
+    /// manifests when concurrent hashers outnumber the available worker threads.
+    private static var oversubscribedCount: Int {
+        max(ProcessInfo.processInfo.activeProcessorCount * 4, 16)
+    }
+
+    /// Writes `count` distinct files and returns their URLs alongside the
+    /// expected uppercase MD5 of each, computed in-process from the same bytes.
+    private func makeFixtures(count: Int) throws -> (directory: URL, files: [(url: URL, expected: String)]) {
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("md5-concurrency-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        var files: [(URL, String)] = []
+        for index in 0..<count {
+            // Large enough to span several read chunks, small enough to stay fast.
+            var bytes = Data(repeating: UInt8(index % 251), count: 320 * 1024)
+            // Make every file's content unique so identical hashes can't mask a bug.
+            bytes.append(contentsOf: Array("seed-\(index)".utf8))
+
+            let url = directory.appendingPathComponent("fixture-\(index).bin")
+            try bytes.write(to: url)
+
+            let digest = Insecure.MD5.hash(data: bytes)
+            let expected = digest.map { String(format: "%02x", $0) }.joined().uppercased()
+            files.append((url, expected))
+        }
+        return (directory, files)
+    }
+
+    @Test("Concurrent hashing from the cooperative pool completes and is correct",
+          .timeLimit(.minutes(1)))
+    func concurrentHashingDoesNotStarveCooperativePool() async throws {
+        let count = Self.oversubscribedCount
+        let (directory, files) = try makeFixtures(count: count)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        // This mirrors GameImporter.preProcessQueue's chunked withTaskGroup:
+        // many concurrent child tasks each calling the synchronous hash.
+        let results = await withTaskGroup(of: (Int, String?).self) { group in
+            for (index, file) in files.enumerated() {
+                group.addTask {
+                    (index, FileManager.default.md5ForFile(at: file.url, fromOffset: 0))
+                }
+            }
+            var collected: [(Int, String?)] = []
+            for await result in group {
+                collected.append(result)
+            }
+            return collected
+        }
+
+        #expect(results.count == count)
+        for (index, hash) in results {
+            #expect(hash == files[index].expected,
+                    "MD5 mismatch for fixture-\(index)")
+        }
+    }
+
+    @Test("Offset hashing is correct and non-blocking under concurrency",
+          .timeLimit(.minutes(1)))
+    func concurrentOffsetHashing() async throws {
+        let offset = 16
+        let (directory, files) = try makeFixtures(count: Self.oversubscribedCount)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let expectedAtOffset: [String] = try files.map { file in
+            let data = try Data(contentsOf: file.url).dropFirst(offset)
+            return Insecure.MD5.hash(data: data)
+                .map { String(format: "%02x", $0) }.joined().uppercased()
+        }
+
+        let results = await withTaskGroup(of: (Int, String?).self) { group in
+            for (index, file) in files.enumerated() {
+                group.addTask {
+                    (index, FileManager.default.md5ForFile(at: file.url, fromOffset: UInt(offset)))
+                }
+            }
+            var collected: [(Int, String?)] = []
+            for await result in group {
+                collected.append(result)
+            }
+            return collected
+        }
+
+        for (index, hash) in results {
+            #expect(hash == expectedAtOffset[index],
+                    "Offset MD5 mismatch for fixture-\(index)")
+        }
+    }
+
+    @Test("A missing file returns nil rather than hanging", .timeLimit(.minutes(1)))
+    func missingFileReturnsNil() async throws {
+        let missing = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("definitely-absent-\(UUID().uuidString).bin")
+
+        let hash = await Task.detached {
+            FileManager.default.md5ForFile(at: missing, fromOffset: 0)
+        }.value
+
+        #expect(hash == nil)
+    }
+}

--- a/PVHashing/Tests/PVHashingTests/NSFileManager+HashingTests.swift
+++ b/PVHashing/Tests/PVHashingTests/NSFileManager+HashingTests.swift
@@ -49,7 +49,10 @@ class ChecksumTests: XCTestCase {
                 case .finished:
                     break
                 case .failure(let error):
+                    // Fulfil here too: without it a failure surfaces as a 5s timeout
+                    // whose message hides the actual error.
                     XCTFail("Failed with error: \(error)")
+                    expectation.fulfill()
                 }
             }, receiveValue: { md5Hash in
                 // The hashing APIs return UPPERCASE hex (see calculateMD5Attempt and

--- a/PVHashing/Tests/PVHashingTests/NSFileManager+HashingTests.swift
+++ b/PVHashing/Tests/PVHashingTests/NSFileManager+HashingTests.swift
@@ -39,7 +39,11 @@ class ChecksumTests: XCTestCase {
     func testCalculateMD5Asynchronously() throws {
         let expectation = XCTestExpectation(description: "Calculate MD5 asynchronously")
 
-        _ = calculateMD5(of: testFileURL)
+        // The cancellable must be retained for the duration of the wait: discarding
+        // it (`_ = ...sink`) cancels the subscription immediately, so the value never
+        // arrives and this test times out unconditionally — which is exactly how it
+        // sat broken on develop, unnoticed because CI only tests changed modules.
+        let subscription = calculateMD5(of: testFileURL)
             .sink(receiveCompletion: { completion in
                 switch completion {
                 case .finished:
@@ -48,17 +52,21 @@ class ChecksumTests: XCTestCase {
                     XCTFail("Failed with error: \(error)")
                 }
             }, receiveValue: { md5Hash in
-                XCTAssertEqual(md5Hash, "746308829575e17c3331bbcb00c0898b")
+                // The hashing APIs return UPPERCASE hex (see calculateMD5Attempt and
+                // the async-await tests below asserting the same hash uppercased).
+                XCTAssertEqual(md5Hash, "746308829575E17C3331BBCB00C0898B")
                 expectation.fulfill()
             })
 
         wait(for: [expectation], timeout: 5.0)
+        subscription.cancel()
     }
     #endif
 
     func testCalculateMD5Synchronously() {
-        // This hash corresponds to "Hello, world!" with MD5
-        let expectedHash = "746308829575e17c3331bbcb00c0898b"
+        // MD5 of the test file — the API contract is UPPERCASE hex, matching
+        // testCalculateMD5WithAsyncAwait / testURLMD5Async above this same hash.
+        let expectedHash = "746308829575E17C3331BBCB00C0898B"
         do {
             let md5Hash = try calculateMD5Synchronously(of: testFileURL)
             XCTAssertEqual(md5Hash, expectedHash, "The MD5 hash did not match the expected value.")

--- a/PVLibrary/Sources/PVLibrary/Cheat/CheatDatabase.swift
+++ b/PVLibrary/Sources/PVLibrary/Cheat/CheatDatabase.swift
@@ -237,7 +237,10 @@ public actor CheatDatabase {
         // conn.prepare(_:_:) binds the parameter safely, preventing SQL injection.
         let stmt = try conn.prepare(query, binding)
         var results: [CheatDatabaseEntry] = []
-        for row in stmt {
+        // failableNext() instead of `for row in stmt`: the Sequence conformance's
+        // next() is `try! failableNext()`, so a mid-iteration SQLite error would
+        // SIGTRAP rather than throw. See PVSQLiteDatabase for the proven crash.
+        while let row = try stmt.failableNext() {
             guard
                 let cheatID    = row[0] as? Int64,
                 let cheatName  = row[1] as? String,

--- a/PVLibrary/Sources/PVLibrary/DirectoryWatcher/DirectoryWatcher.swift
+++ b/PVLibrary/Sources/PVLibrary/DirectoryWatcher/DirectoryWatcher.swift
@@ -1078,6 +1078,14 @@ fileprivate extension DirectoryWatcher {
     /// Watch a file
     private func watchFile(at path: URL) {
         Task {
+            // Cheap early-out before opening any descriptor. This is best-effort —
+            // concurrent watchFile calls can still both pass it, which is why
+            // addWatcher below is the authoritative, atomic gate.
+            if await watcherManager.isWatching(path) {
+                VLOG("Already watching file, skipping duplicate watch: \(path.lastPathComponent)")
+                return
+            }
+
             ILOG("Starting to watch file: \(path.lastPathComponent)")
 
             // Get initial file attributes
@@ -1109,10 +1117,18 @@ fileprivate extension DirectoryWatcher {
             )
 
             source.resume()
-            await watcherManager.addWatcher(source,
-                                          for: path,
-                                          initialSize: initialSize,
-                                          modificationDate: initialModDate)
+            let added = await watcherManager.addWatcher(source,
+                                                        for: path,
+                                                        initialSize: initialSize,
+                                                        modificationDate: initialModDate)
+            guard added else {
+                // Another watcher won the race for this path. Cancel OUR source so its
+                // cancel handler closes OUR descriptor — dropping it without cancel is
+                // exactly the fd leak that exhausted the process during large imports.
+                VLOG("Duplicate watcher for \(path.lastPathComponent) — cancelling redundant source")
+                source.cancel()
+                return
+            }
 
             // Start monitoring file changes
             await monitorFileChanges(for: path)
@@ -1381,16 +1397,30 @@ private actor FileWatcherManager: Sendable {
         self.serialQueue = DispatchQueue(label: label)
     }
 
+    /// Registers a watcher for `path`, refusing duplicates.
+    ///
+    /// Returns `false` when an ACTIVE watcher already exists — the caller must then
+    /// cancel its just-created source so the cancel handler closes the descriptor.
+    /// This used to be `fileStatuses[path] = status` unconditionally: rapid directory
+    /// events race the `isWatchingFile` pre-check (it's separated from `watchFile` by
+    /// awaits), so several sources were created for one file and the displaced ones
+    /// were silently dropped WITHOUT cancel — leaking one open fd each. During a
+    /// 392-file import that exhausted the process fd table (mktemp → errno 24 EMFILE)
+    /// and broke unrelated zip extraction.
     func addWatcher(_ source: DispatchSourceFileSystemObject,
-                   for path: URL,
-                   initialSize: Int64,
-                   modificationDate: Date) {
+                    for path: URL,
+                    initialSize: Int64,
+                    modificationDate: Date) -> Bool {
+        if let existing = fileStatuses[path], !existing.watcher.isCancelled {
+            return false
+        }
         let status = FileStatus(
             watcher: source,
             size: initialSize,
             modificationDate: modificationDate
         )
         fileStatuses[path] = status
+        return true
     }
 
     func removeWatcher(for path: URL) {

--- a/PVLibrary/Sources/PVLibrary/DirectoryWatcher/DirectoryWatcher.swift
+++ b/PVLibrary/Sources/PVLibrary/DirectoryWatcher/DirectoryWatcher.swift
@@ -1116,7 +1116,8 @@ fileprivate extension DirectoryWatcher {
                 }
             )
 
-            source.resume()
+            // Register BEFORE resuming: a resumed-then-rejected source could deliver
+            // events (spurious handleFileChange) in the window before cancellation.
             let added = await watcherManager.addWatcher(source,
                                                         for: path,
                                                         initialSize: initialSize,
@@ -1125,10 +1126,15 @@ fileprivate extension DirectoryWatcher {
                 // Another watcher won the race for this path. Cancel OUR source so its
                 // cancel handler closes OUR descriptor — dropping it without cancel is
                 // exactly the fd leak that exhausted the process during large imports.
+                // Order matters: a suspended source never fires its cancel handler, so
+                // cancel first (no events can be delivered post-cancel), THEN resume
+                // to let the cancel handler run and close the fd.
                 VLOG("Duplicate watcher for \(path.lastPathComponent) — cancelling redundant source")
                 source.cancel()
+                source.resume()
                 return
             }
+            source.resume()
 
             // Start monitoring file changes
             await monitorFileChanges(for: path)

--- a/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
+++ b/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
@@ -440,6 +440,19 @@ public final class GameImporter: GameImporting, ObservableObject {
     private var processingStartTime: Date?
     private var autoRestartAvailableAt: Date?
     private var lastPreprocessedQueueGeneration: UInt64?
+    /// Reserves the right to spawn the processing task, guarded by `processingTaskLock`.
+    ///
+    /// `startProcessingSafely` used to check `currentProcessingTask` in one lock
+    /// acquisition and assign it in a LATER one, with several `await`s in between.
+    /// Every concurrent caller passed the "no existing task" check before anyone
+    /// stored a task, so a 371-file drop spawned 243 concurrent `processQueue`
+    /// loops (verified by log counts on 2026-08-05). Each loop snapshotted the
+    /// queue and re-processed items another loop had already imported — the
+    /// visible symptom was thousands of "couldn't be moved because the former
+    /// doesn't exist" failures for files that had ALREADY imported successfully.
+    /// This flag is set in the SAME lock acquisition as the check and cleared when
+    /// the real task is stored (or on any bail-out path), closing the window.
+    private var processingStartReserved = false
 
     // Actor to manage the import queue with thread safety
     public let importQueueActor: ImportQueueActor
@@ -1001,31 +1014,22 @@ public final class GameImporter: GameImporting, ObservableObject {
         await importQueueActor.removeImports(at: offsets)
     }
 
-    // Public method to manually start processing if needed
+    // Public method to manually start processing if needed.
+    //
+    // Despite the historical "BEGIN button" name, this is called PROGRAMMATICALLY all
+    // over the app (PVGameLibraryUpdatesController on new-file events, library views on
+    // appear, iCloud syncer, …) — 112 calls were logged during a single 371-file import.
+    // It used to force-kill the current processing task before restarting. While task
+    // cancellation was broken that kill was a silent no-op; once the processing loops
+    // started honoring Task.isCancelled, every call aborted a HEALTHY in-flight import
+    // mid-item (observed as spurious "Unable to verify file integrity" failures — the
+    // cancelled MD5 read returned nil). Safe-start semantics are correct for every
+    // caller: no-op while a task is running, start when idle. Genuine hangs are the
+    // 600s timeout watchdog's job, and users can pause/resume for manual control.
     public func startProcessing() {
         Task {
-            ILOG("GameImporter: startProcessing() called (manual BEGIN button)")
-
-            // Force kill any stuck tasks first
-            processingTaskLock.withLock {
-                if let existingTask = currentProcessingTask {
-                    let isRunning = !existingTask.isCancelled
-                    ILOG("GameImporter: BEGIN button - killing existing task (running: \(isRunning))")
-                    existingTask.cancel()
-                    currentProcessingTask = nil
-                    currentTimeoutTask?.cancel()
-                    currentTimeoutTask = nil
-                    processingStartTime = nil
-                }
-            }
-
-            // Reset state to idle so we can start fresh
-            await MainActor.run {
-                self.processingState = .idle
-            }
-
-            // Now start processing
-            await startProcessingSafely(trigger: "manual-begin")
+            ILOG("GameImporter: startProcessing() called")
+            await startProcessingSafely(trigger: "public-start")
         }
     }
 
@@ -1045,10 +1049,6 @@ public final class GameImporter: GameImporting, ObservableObject {
         // Check if we have an active task
         let hasActiveTask = hasActiveProcessingTask()
 
-        // Also check if we have queued items - if we do and task seems stuck, kill it
-        let queueSnapshot = await importQueueActor.getQueue()
-        let queuedItems = queueSnapshot.filter { $0.status == .queued }
-
         if !hasActiveTask {
             await MainActor.run {
                 self.processingState = .idle
@@ -1058,34 +1058,18 @@ public final class GameImporter: GameImporting, ObservableObject {
             return .idle
         }
 
-        // If we have queued items but task has been running for a while, check if it's stuck
-        if !queuedItems.isEmpty {
-            let startTime = processingTaskLock.withLock { processingStartTime }
-
-            if let startTime = startTime {
-                let elapsed = Date().timeIntervalSince(startTime)
-                // If task has been running for more than 30 seconds with queued items, it's probably stuck
-                if elapsed > 30 {
-                    ILOG("GameImporter: Detected stuck processing task (running for \(String(format: "%.1f", elapsed))s with \(queuedItems.count) queued items) - killing and restarting")
-
-                    // Kill the stuck task
-                    processingTaskLock.withLock {
-                        currentProcessingTask?.cancel()
-                        currentProcessingTask = nil
-                        currentTimeoutTask?.cancel()
-                        currentTimeoutTask = nil
-                        processingStartTime = nil
-                    }
-
-                    await MainActor.run {
-                        self.processingState = .idle
-                    }
-
-                    return .idle
-                }
-            }
-        }
-
+        // NOTE: there used to be a second heuristic here — "running >30s with queued
+        // items ⇒ stuck ⇒ kill and restart". That condition is trivially true for the
+        // whole duration of any large import (a few hundred files takes minutes), so
+        // every auto-start trigger arriving after the 30s mark killed a HEALTHY task
+        // and spawned a replacement. Together with its 10s sibling in
+        // startProcessingSafely it was the engine of the duplicate-processing storm
+        // (dozens of concurrent processQueue loops re-importing each other's items).
+        // Both heuristics were symptom patches for the pre-2026-08 MD5 semaphore
+        // deadlock; with that fixed at the root, elapsed-time-with-queued-items is
+        // not evidence of anything. Genuine hangs are covered by the 600s
+        // processingTimeoutDuration watchdog (whose cancellation now works — the
+        // processing loops honor Task.isCancelled).
         return state
     }
 
@@ -1144,40 +1128,35 @@ public final class GameImporter: GameImporting, ObservableObject {
             return
         }
 
-        // Check queue before checking task status
-        let queueSnapshot = await importQueueActor.getQueue()
-        let queuedCount = queueSnapshot.filter { $0.status == .queued }.count
-
-        // Use lock ONLY for checking/setting task reference - release before async operations
+        // Atomically check AND reserve in a single lock acquisition. The reservation
+        // (`processingStartReserved`) is what prevents two concurrent callers from both
+        // passing this check during the awaits below — see the property's doc comment.
         let shouldStart: Bool = processingTaskLock.withLock {
-            // Double-check we don't already have a processing task
+            if processingStartReserved {
+                ILOG("GameImporter: Another caller is already starting processing")
+                return false
+            }
+
+            // Double-check we don't already have a processing task.
+            // NOTE: there used to be a "running >10s with queued items ⇒ stuck ⇒ kill
+            // and restart" heuristic here (sibling of the removed 30s one in
+            // normalizedProcessingState). That condition holds for the entire duration
+            // of any large import, so it killed healthy tasks on every auto-start
+            // trigger — the duplicate-processing storm. Genuine hangs are the 600s
+            // watchdog's job.
             if let existingTask = currentProcessingTask {
                 let isRunning = !existingTask.isCancelled
                 ILOG("GameImporter: Existing processing task found (running: \(isRunning))")
 
-                // Check if task is actually making progress
-                if let startTime = processingStartTime {
-                    let elapsed = Date().timeIntervalSince(startTime)
-
-                    // If task has been running for more than 10 seconds with queued items, it's stuck
-                    if elapsed > 10 && queuedCount > 0 {
-                        ILOG("GameImporter: Task appears stuck (running \(String(format: "%.1f", elapsed))s with \(queuedCount) queued) - killing it")
-                        existingTask.cancel()
-                        currentProcessingTask = nil
-                        currentTimeoutTask?.cancel()
-                        currentTimeoutTask = nil
-                        processingStartTime = nil
-                        return true
-                    }
-                }
-
                 if !isRunning {
                     // Task exists but is cancelled/completed - clear it
                     currentProcessingTask = nil
+                    processingStartReserved = true
                     return true
                 }
                 return false
             }
+            processingStartReserved = true
             return true
         }
 
@@ -1209,6 +1188,7 @@ public final class GameImporter: GameImporting, ObservableObject {
                     self.currentTimeoutTask?.cancel()
                     self.currentTimeoutTask = nil
                     self.processingStartTime = nil
+                    self.processingStartReserved = false
                 }
 
                 Task { [weak self] in
@@ -1238,11 +1218,14 @@ public final class GameImporter: GameImporting, ObservableObject {
             await self.handleProcessingTimeout()
         }
 
-        // Store task references while holding lock (minimal lock scope)
+        // Store task references while holding lock (minimal lock scope).
+        // Clearing the reservation here (not earlier) keeps the window closed for
+        // the whole check → store span.
         processingTaskLock.withLock {
             currentProcessingTask = processingTask
             currentTimeoutTask = timeoutTask
             processingStartTime = startTime
+            processingStartReserved = false
         }
     }
 
@@ -1308,6 +1291,10 @@ public final class GameImporter: GameImporting, ObservableObject {
         let maxRetries = 10 // Prevent infinite loops
 
         while retryCount < maxRetries {
+            if Task.isCancelled {
+                ILOG("GameImporter: preProcessQueue() cancelled, exiting")
+                return
+            }
             retryCount += 1
             if retryCount > 1 {
                 ILOG("GameImporter: preProcessQueue() retry #\(retryCount)")
@@ -1332,20 +1319,43 @@ public final class GameImporter: GameImporting, ObservableObject {
                 let processorCount = max(ProcessInfo.processInfo.activeProcessorCount, 2)
                 let chunkSize = max(workQueue.count / processorCount, 16)
 
-                await withTaskGroup(of: Void.self) { group in
+                // Each child task classifies its own chunk into a LOCAL array and
+                // returns it; the results are merged below on this task. Mutating the
+                // captured `workQueue` from concurrent children (as this used to do)
+                // is a data race on the array's storage — unsynchronised concurrent
+                // writes plus copy-on-write reallocation. It was previously masked by
+                // the cooperative-pool deadlock in `determineImportType`; with that
+                // fixed, this loop actually runs to completion, so the race is live.
+                let classifiedChunks = await withTaskGroup(
+                    of: (offset: Int, types: [ImportQueueItem.FileType?]).self
+                ) { group in
                     for chunkStart in stride(from: 0, to: workQueue.count, by: chunkSize) {
                         let chunkEnd = min(chunkStart + chunkSize, workQueue.count)
+                        let chunk = Array(workQueue[chunkStart..<chunkEnd])
                         group.addTask { [self] in
-                            for i in chunkStart..<chunkEnd {
-                                let currentType = workQueue[i].fileType
+                            let types: [ImportQueueItem.FileType?] = chunk.map { item in
+                                let currentType = item.fileType
                                 if currentType == .skin || currentType == .artwork || currentType == .bios {
-                                    continue
+                                    return nil // leave the existing classification untouched
                                 }
-                                workQueue[i].fileType = self.determineImportType(workQueue[i])
+                                return self.determineImportType(item)
                             }
+                            return (offset: chunkStart, types: types)
                         }
                     }
-                    await group.waitForAll()
+
+                    var collected: [(offset: Int, types: [ImportQueueItem.FileType?])] = []
+                    for await result in group {
+                        collected.append(result)
+                    }
+                    return collected
+                }
+
+                for chunk in classifiedChunks {
+                    for (indexInChunk, type) in chunk.types.enumerated() {
+                        guard let type else { continue }
+                        workQueue[chunk.offset + indexInChunk].fileType = type
+                    }
                 }
             } else {
         for i in 0..<workQueue.count {
@@ -2167,8 +2177,19 @@ public final class GameImporter: GameImporting, ObservableObject {
         let semaphore = AsyncSemaphore(value: maxConcurrentImports)
         var processedCount = 0
 
-        // Process queue in a loop until empty or paused
+        // Process queue in a loop until empty, paused, or cancelled
         while true {
+            // Honor cancellation: the stuck-task killers and timeout watchdog cancel
+            // superseded processing tasks, but this loop used to ignore that —
+            // `try? await Task.sleep` swallows the CancellationError, so "killed"
+            // loops kept running forever and re-processed items the replacement
+            // loop had already imported (the source of the mass "couldn't be moved
+            // because the former doesn't exist" failures).
+            if Task.isCancelled {
+                ILOG("GameImportQueue - processing task cancelled, exiting loop")
+                break
+            }
+
             // Check if paused
             if await checkIfPaused() {
                 ILOG("GameImportQueue - processing paused")
@@ -2193,8 +2214,10 @@ public final class GameImporter: GameImporting, ObservableObject {
         // Prioritize groups: small files first, CD-ROMs last
         let prioritizedGroups = prioritizeImportGroups(groupedItems)
 
-            // Process all groups
-        await withTaskGroup(of: Void.self) { group in
+            // Process all groups. Each child task returns its own count; summing the
+            // results avoids the data race of `processedCount += 1` from up to
+            // `maxConcurrentImports` concurrent children.
+            processedCount += await withTaskGroup(of: Int.self) { group in
             for fileGroup in prioritizedGroups {
                 if await checkIfPaused() {
                     break
@@ -2204,17 +2227,24 @@ public final class GameImporter: GameImporting, ObservableObject {
 
                     group.addTask { [weak self] in
                         defer { Task { await semaphore.signal() } }
-                        guard let self else { return }
+                        guard let self else { return 0 }
 
+                        var groupProcessed = 0
                     for item in fileGroup {
+                            if Task.isCancelled { break }
                             if await self.checkIfPaused() { break }
                         await self.processItem(item)
-                            processedCount += 1
+                            groupProcessed += 1
                     }
+                        return groupProcessed
                 }
             }
 
-            await group.waitForAll()
+                var total = 0
+                for await groupProcessed in group {
+                    total += groupProcessed
+                }
+                return total
         }
 
             // Small delay to allow new items to be added
@@ -4316,17 +4346,25 @@ public final class GameImporter: GameImporting, ObservableObject {
     }
 
     /// Safely cleans up failed import files with proper error handling
+    /// Called when an import fails. Deliberately does NOT delete anything.
+    ///
+    /// This used to `removeItem` the file when it was in /Imports/ — which destroyed
+    /// the user's only copy whenever classification failed for a perfectly good file:
+    /// a valid CHIP-8 zip whose name collided with a MAME title was deleted after
+    /// "unsupported"; any ROM the lookup couldn't match hit `noSystemMatched` → gone.
+    /// (Its other call site passes the DESTINATION after a DB-import failure, where
+    /// deleting would drop a successfully-moved ROM the moment a transient DB error
+    /// occurred — only the /Imports/ guard prevented that.)
+    ///
+    /// Failed imports now leave the file in place: the queue records the `.failure`
+    /// status, the user can retry after a fix, and the only safe deletion — a
+    /// byte-identical duplicate — is handled where content is actually compared,
+    /// in GameImporterFileService.
     private func cleanupFailedImportFile(_ fileURL: URL) async {
         guard fileURL.path.contains("/Imports/") && FileManager.default.fileExists(atPath: fileURL.path) else {
-            return // Only clean up files in imports directory that actually exist
+            return
         }
-
-        do {
-            try await FileManager.default.removeItem(at: fileURL)
-            ILOG("Cleaned up failed import file: \(fileURL.path)")
-        } catch {
-            ELOG("Failed to clean up import file \(fileURL.path): \(error.localizedDescription)")
-        }
+        ILOG("Keeping failed import file in Imports for user retry: \(fileURL.lastPathComponent)")
     }
 }
 

--- a/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
+++ b/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
@@ -363,6 +363,7 @@ public protocol GameImporting {
 }
 
 //@Observable
+// swiftlint:disable:next type_body_length
 public final class GameImporter: GameImporting, ObservableObject {
 
     /// Publisher that emits the current import queue whenever it changes

--- a/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
+++ b/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
@@ -455,6 +455,17 @@ public final class GameImporter: GameImporting, ObservableObject {
     /// the real task is stored (or on any bail-out path), closing the window.
     private var processingStartReserved = false
 
+    /// Identifies the processing run that currently owns `currentProcessingTask`,
+    /// `currentTimeoutTask` and `processingStartTime`.
+    ///
+    /// A cancelled run can take arbitrarily long to unwind (it only observes
+    /// cancellation at the next loop boundary), so a replacement run may already have
+    /// stored ITS references by the time the old run's cleanup finally executes.
+    /// Without this token the stale cleanup would clear the new run's task pointer and
+    /// cancel the new run's watchdog — wedging auto-restart and disabling the hang
+    /// detector. Cleanup is therefore only performed when the token still matches.
+    private var currentRunToken: UUID?
+
     // Actor to manage the import queue with thread safety
     public let importQueueActor: ImportQueueActor
 
@@ -1150,8 +1161,15 @@ public final class GameImporter: GameImporting, ObservableObject {
                 ILOG("GameImporter: Existing processing task found (running: \(isRunning))")
 
                 if !isRunning {
-                    // Task exists but is cancelled/completed - clear it
+                    // Task exists but is cancelled/completed — clear it, AND tear down
+                    // its watchdog. Leaving the old timeout task alive let it fire
+                    // later and cancel the healthy run we're about to start, aborting
+                    // an import mid-flight for no reason.
                     currentProcessingTask = nil
+                    currentTimeoutTask?.cancel()
+                    currentTimeoutTask = nil
+                    processingStartTime = nil
+                    currentRunToken = nil
                     processingStartReserved = true
                     return true
                 }
@@ -1186,6 +1204,9 @@ public final class GameImporter: GameImporting, ObservableObject {
         let refsStored = AsyncSemaphore(value: 1)
         await refsStored.wait() // take the sole permit; released after refs are stored
 
+        // Identifies THIS run for the duration of its lifetime (see currentRunToken).
+        let runToken = UUID()
+
         // Create and store the processing task
         let processingTask = Task.detached { [weak self] in
             guard let self = self else { return }
@@ -1194,13 +1215,23 @@ public final class GameImporter: GameImporting, ObservableObject {
             await refsStored.signal() // restore for any future waiter (none today)
 
             defer {
-                // Clean up task references when done
+                // Clean up task references when done — but ONLY if this run still owns
+                // them. A cancelled run unwinds lazily (cancellation is observed at the
+                // next loop boundary), so a replacement run may already have installed
+                // its own task and watchdog; clearing those here would wedge auto-restart
+                // and silently disable the hang detector for the run that is actually
+                // working.
                 self.processingTaskLock.withLock {
+                    guard self.currentRunToken == runToken else {
+                        ILOG("GameImporter: Skipping cleanup — a newer processing run owns the task refs")
+                        return
+                    }
                     self.currentProcessingTask = nil
                     self.currentTimeoutTask?.cancel()
                     self.currentTimeoutTask = nil
                     self.processingStartTime = nil
                     self.processingStartReserved = false
+                    self.currentRunToken = nil
                 }
 
                 Task { [weak self] in
@@ -1237,6 +1268,7 @@ public final class GameImporter: GameImporting, ObservableObject {
             currentProcessingTask = processingTask
             currentTimeoutTask = timeoutTask
             processingStartTime = startTime
+            currentRunToken = runToken
             processingStartReserved = false
         }
 
@@ -1254,6 +1286,10 @@ public final class GameImporter: GameImporting, ObservableObject {
             currentProcessingTask = nil
             currentTimeoutTask = nil
             processingStartTime = nil
+            // Release ownership so the cancelled run's lazy cleanup becomes a no-op
+            // rather than clobbering the replacement run scheduled below.
+            currentRunToken = nil
+            processingStartReserved = false
             return elapsed
         }
 
@@ -4427,6 +4463,10 @@ extension GameImporter: PausableService {
                 currentTimeoutTask?.cancel()
                 currentTimeoutTask = nil
                 processingStartTime = nil
+                // See currentRunToken: drop ownership so the cancelled run's cleanup
+                // can't clobber a run started after resume.
+                currentRunToken = nil
+                processingStartReserved = false
             }
 
             workQueue.cancelAllOperations()

--- a/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
+++ b/PVLibrary/Sources/PVLibrary/Importer/Services/GameImporter/GameImporter.swift
@@ -1178,9 +1178,20 @@ public final class GameImporter: GameImporting, ObservableObject {
         // Record processing start time and create tasks (lock released, safe to do async work)
         let startTime = Date()
 
+        // Gate the worker on the creator having stored the task references. A fast
+        // completion (empty queue) could otherwise run the defer BEFORE
+        // currentProcessingTask was assigned below; the creator then stored an
+        // already-completed task, which hasActiveProcessingTask treats as active
+        // forever (isCancelled == false) — wedging auto-start until the 600s watchdog.
+        let refsStored = AsyncSemaphore(value: 1)
+        await refsStored.wait() // take the sole permit; released after refs are stored
+
         // Create and store the processing task
         let processingTask = Task.detached { [weak self] in
             guard let self = self else { return }
+
+            await refsStored.wait() // creator signals once refs are stored
+            await refsStored.signal() // restore for any future waiter (none today)
 
             defer {
                 // Clean up task references when done
@@ -1228,6 +1239,9 @@ public final class GameImporter: GameImporting, ObservableObject {
             processingStartTime = startTime
             processingStartReserved = false
         }
+
+        // Refs are visible; release the worker (see refsStored gate above).
+        await refsStored.signal()
     }
 
     /// Handles timeout recovery when processing task hangs
@@ -2220,11 +2234,26 @@ public final class GameImporter: GameImporting, ObservableObject {
             // `maxConcurrentImports` concurrent children.
             processedCount += await withTaskGroup(of: Int.self) { group in
             for fileGroup in prioritizedGroups {
+                // Stop SPAWNING on cancellation too, not just on pause. Without this,
+                // a cancelled parent that wakes from semaphore.wait() (a child signals
+                // on completion) would keep enqueueing processItem work alongside any
+                // replacement loop — the duplicate-import overlap this PR eliminates.
+                // Children check Task.isCancelled per item; this stops new children.
+                if Task.isCancelled {
+                    break
+                }
                 if await checkIfPaused() {
                     break
                 }
 
                     await semaphore.wait()
+
+                    if Task.isCancelled {
+                        // Woke from a potentially long semaphore park after cancel:
+                        // give the permit back and stop spawning.
+                        await semaphore.signal()
+                        break
+                    }
 
                     group.addTask { [weak self] in
                         defer { Task { await semaphore.signal() } }

--- a/PVLibrary/Sources/PVLibrary/Resources/systems.plist
+++ b/PVLibrary/Sources/PVLibrary/Resources/systems.plist
@@ -6213,7 +6213,6 @@
 		<string>CRT</string>
 		<key>PVSupportedExtensions</key>
 		<array>
-			<string>32X</string>
 			<string>32x</string>
 		</array>
 		<key>PVSystemIdentifier</key>
@@ -6868,9 +6867,7 @@
 			<string>com</string>
 			<string>bat</string>
 			<string>conf</string>
-			<string>CONF</string>
 			<string>cfg</string>
-			<string>CFG</string>
 			<string>img</string>
 			<string>zip</string>
 			<string>dosz</string>
@@ -8961,39 +8958,24 @@
 		<key>PVSupportedExtensions</key>
 		<array>
 			<string>d98</string>
-			<string>D98</string>
 			<string>zip</string>
-			<string>ZIP</string>
 			<string>rar</string>
-			<string>RAR</string>
 			<string>lzh</string>
-			<string>LZH</string>
 			<string>98d</string>
-			<string>98D</string>
 			<string>fdi</string>
-			<string>FDI</string>
 			<string>fdd</string>
-			<string>FDD</string>
 			<string>2hd</string>
-			<string>2HD</string>
 			<string>tfd</string>
 			<string>d88</string>
-			<string>D88</string>
 			<string>hdm</string>
-			<string>HDM</string>
-			<string>88D</string>
 			<string>88d</string>
 			<string>xdf</string>
 			<string>dup</string>
 			<string>cmd</string>
-			<string>CMD</string>
 			<string>hdi</string>
-			<string>HDI</string>
 			<string>thd</string>
 			<string>nhd</string>
-			<string>NHD</string>
 			<string>hdd</string>
-			<string>HDD</string>
 			<string>hdn</string>
 		</array>
 		<key>PVSystemIdentifier</key>
@@ -9152,7 +9134,6 @@
 		<array>
 			<string>opt</string>
 			<string>cfg</string>
-			<string>CFG</string>
 		</array>
 		<key>PVSystemIdentifier</key>
 		<string>com.provenance.retroarch</string>
@@ -9576,7 +9557,6 @@
 		<key>PVSupportedExtensions</key>
 		<array>
 			<string>wl6</string>
-			<string>WL6</string>
 			<string>n3d</string>
 			<string>sod</string>
 			<string>sdm</string>
@@ -9739,7 +9719,6 @@
 			<string>wad</string>
 			<string>iwad</string>
 			<string>pwad</string>
-			<string>WAD</string>
 		</array>
 		<key>PVSystemIdentifier</key>
 		<string>com.provenance.doom</string>

--- a/PVLibrary/Tests/PVLibraryTests/GameImporterTests.swift
+++ b/PVLibrary/Tests/PVLibraryTests/GameImporterTests.swift
@@ -18,20 +18,32 @@ class GameImporterTests: XCTestCase {
         var m3uFileContentsResult: [String] = []
         var binFileExistsResult: [URL:Bool] = [:]
         
-        func findAssociatedBinFileNames(for cueFileItem: ImportQueueItem) throws -> [String] {
+        /// Names of files the mock cue sheet "references".
+        /// Renamed from `findAssociatedBinFileNames` to track `CDFileHandling`,
+        /// which changed in 2b6096d3b5 (2025-05-11). The mock was never updated,
+        /// so this whole test target stopped compiling — and since PVLibrary
+        /// can't `swift test` (macOS platform-version mismatch), CI never caught it.
+        func parseCueSheet(cueFileURL: URL) throws -> [String] {
             return binFilesResult
         }
-        
+
         func candidateBinUrls(for binFileNames: [String], in directories: [URL]) -> [URL] {
             return binUrlsResult
         }
-        
-        func readM3UFileContents(from url: URL) throws -> [String] {
+
+        /// Renamed from `readM3UFileContents` for the same reason as `parseCueSheet`.
+        func parseM3U(from url: URL) throws -> [String] {
             return m3uFileContentsResult
         }
-        
+
         func fileExistsAtPath(_ path: URL) -> Bool {
             return binFileExistsResult[path] ?? false
+        }
+
+        /// Records cue files the importer asked to rewrite, so tests can assert on it.
+        private(set) var cleanedCueFiles: [URL] = []
+        func cleanCueFile(at url: URL) throws {
+            cleanedCueFiles.append(url)
         }
     }
     

--- a/PVLibrary/Tests/PVLibraryTests/SharedExtensionImportTests.swift
+++ b/PVLibrary/Tests/PVLibraryTests/SharedExtensionImportTests.swift
@@ -1,0 +1,107 @@
+//
+//  SharedExtensionImportTests.swift
+//  PVLibrary
+//
+//  Cue/bin association coverage: what rescues a `.bin` from being ambiguous.
+//
+//  A bare `.bin` on disk is claimed by 13 different systems, so the importer has
+//  to guess. A `.bin` referenced by a `.cue`, by contrast, is unambiguous — it
+//  belongs to that disc. These tests pin that absorption behaviour.
+//
+//  The pure systems.plist contract tests (which extensions are claimed by which
+//  systems) deliberately live in PVPrimitives instead —
+//  PVPrimitives/Tests/PVPrimitivesTests/SharedExtensionSystemMappingTests.swift —
+//  because PVPrimitives builds and tests standalone via `swift test`, whereas
+//  PVLibrary's test target currently cannot be run at all (missing PVLogging
+//  product / Realm static-dynamic conflict in package mode, and the workspace
+//  scheme has no test action).
+//
+
+@testable import PVLibrary
+import PVPrimitives
+import XCTest
+
+final class SharedExtensionImportTests: XCTestCase {
+
+    private func makeImporter(_ handler: GameImporterTests.MockCDFileHandler) -> GameImporter {
+        GameImporter(FileManager.default,
+                     GameImporterFileService(),
+                     GameImporterDatabaseService(),
+                     GameImporterSystemsService(),
+                     ArtworkImporter(),
+                     handler)
+    }
+
+    /// Builds a cue item with `systems` already populated. organizeCueAndBinFiles
+    /// only consults `PVSystem.all` (Realm) when `systems` is empty, so presetting
+    /// it keeps these tests pure — no database required.
+    private func makeCueItem(url: URL) -> ImportQueueItem {
+        let item = ImportQueueItem(url: url)
+        item.systems = [.PSX]
+        return item
+    }
+
+    /// A multi-track disc: the .cue names two .bin tracks and both are present.
+    /// The cue must end up `.queued` with both tracks resolved, and neither .bin
+    /// may survive as an independent queue item.
+    func testMultiTrackCueAbsorbsAllBinTracks() {
+        let handler = GameImporterTests.MockCDFileHandler()
+        let importer = makeImporter(handler)
+
+        let directory = URL(fileURLWithPath: "/path/to")
+        let cueURL = directory.appendingPathComponent("Game (Track 1).cue")
+        let track1 = directory.appendingPathComponent("Game (Track 1).bin")
+        let track2 = directory.appendingPathComponent("Game (Track 2).bin")
+
+        handler.binFilesResult = [track1.lastPathComponent, track2.lastPathComponent]
+        handler.binUrlsResult = [track1, track2]
+        handler.binFileExistsResult = [track1: true, track2: true]
+
+        var queue = [makeCueItem(url: cueURL),
+                     ImportQueueItem(url: track1),
+                     ImportQueueItem(url: track2)]
+        importer.organizeCueAndBinFiles(in: &queue)
+
+        let cueItems = queue.filter { $0.url.pathExtension.lowercased() == "cue" }
+        XCTAssertEqual(cueItems.count, 1, "Expected exactly one .cue item to remain at top level")
+
+        guard let cue = cueItems.first else { return }
+        XCTAssertEqual(cue.status, .queued,
+                       "All referenced .bin tracks exist, so the cue should be .queued, not .partial")
+        XCTAssertEqual(cue.fileType, .cdRom, "A .cue always implies a CD-ROM import")
+        XCTAssertEqual(Set(cue.resolvedAssociatedFileURLs), Set([track1, track2]),
+                       "Both .bin tracks should be resolved onto the .cue item")
+
+        let topLevelBins = queue.filter { $0.url.pathExtension.lowercased() == "bin" }
+        XCTAssertTrue(topLevelBins.isEmpty,
+                      "Cue-referenced .bin tracks must not remain as standalone queue items — "
+                      + "a loose .bin is ambiguous across 13 systems.")
+    }
+
+    /// If even one referenced track is missing the cue must go .partial and wait,
+    /// rather than importing a half disc.
+    func testCueGoesPartialWhenOneTrackMissing() {
+        let handler = GameImporterTests.MockCDFileHandler()
+        let importer = makeImporter(handler)
+
+        let directory = URL(fileURLWithPath: "/path/to")
+        let cueURL = directory.appendingPathComponent("Game.cue")
+        let present = directory.appendingPathComponent("Game (Track 1).bin")
+        let missing = directory.appendingPathComponent("Game (Track 2).bin")
+
+        handler.binFilesResult = [present.lastPathComponent, missing.lastPathComponent]
+        handler.binUrlsResult = [present]
+        handler.binFileExistsResult = [present: true, missing: false]
+
+        var queue = [makeCueItem(url: cueURL), ImportQueueItem(url: present)]
+        importer.organizeCueAndBinFiles(in: &queue)
+
+        guard let cue = queue.first(where: { $0.url.pathExtension.lowercased() == "cue" }) else {
+            return XCTFail("The .cue item should still be in the queue")
+        }
+        XCTAssertEqual(cue.status, .partial,
+                       "A cue missing one of its .bin tracks must be .partial, not imported")
+        XCTAssertEqual(cue.expectedAssociatedFileNames, [missing.lastPathComponent.lowercased()],
+                       "The missing track should be recorded so a later arrival can complete the cue")
+    }
+}

--- a/PVLookup/Sources/LibretroCheatDB/LibretroCheatDatabase.swift
+++ b/PVLookup/Sources/LibretroCheatDB/LibretroCheatDatabase.swift
@@ -207,7 +207,10 @@ public actor LibretroCheatDatabase {
         var results: [LibretroCheatEntry] = []
         var skippedRows = 0
 
-        for row in stmt {
+        // failableNext() instead of `for row in stmt`: the Sequence conformance's
+        // next() is `try! failableNext()`, so a mid-iteration SQLite error would
+        // SIGTRAP rather than throw. See PVSQLiteDatabase for the proven crash.
+        while let row = try stmt.failableNext() {
             guard
                 let cheatID = row[0] as? Int64,
                 let cheatName = row[1] as? String,

--- a/PVLookup/Sources/PVSQLiteDatabase/PVSQLiteDatabase.swift
+++ b/PVLookup/Sources/PVSQLiteDatabase/PVSQLiteDatabase.swift
@@ -58,7 +58,15 @@ extension PVSQLiteDatabase: SQLQueryable {
             _ = stmt.bind(bindings)
         }
 
-        for row in stmt {
+        // Iterate with failableNext() rather than `for row in stmt`: the Sequence
+        // conformance funnels through SQLite.swift's `FailableIterator.next()`, which
+        // is `try! failableNext()` — so ANY SQLite error mid-iteration (locked/busy
+        // database, interrupt) crashed the app with SIGTRAP instead of throwing.
+        // Observed in the wild once the game importer was fixed: concurrent artwork
+        // lookups during a large import trapped inside OpenVGDB.searchDatabase and
+        // took the whole app down. This loop surfaces the same error through our
+        // existing `throws` signature, which every call site already handles.
+        while let row = try stmt.failableNext() {
             var dict = SQLQueryDict()
             for (index, name) in stmt.columnNames.enumerated() {
                 dict[name] = row[index] as AnyObject

--- a/PVLookup/Sources/libretrodb/DatabaseConnection.swift
+++ b/PVLookup/Sources/libretrodb/DatabaseConnection.swift
@@ -14,7 +14,10 @@ private actor DatabaseConnection {
 
         let stmt = try db.prepare(query)
         var results: [LibretroDBROMMetadata] = []
-        for row in stmt {
+        // failableNext() instead of `for row in stmt`: the Sequence conformance's
+        // next() is `try! failableNext()`, so a mid-iteration SQLite error would
+        // SIGTRAP rather than throw. See PVSQLiteDatabase for the proven crash.
+        while let row = try stmt.failableNext() {
             var dict: [String: Any] = [:]
             for (index, name) in stmt.columnNames.enumerated() {
                 dict[name] = row[index]

--- a/PVLookup/Sources/libretrodb/libretrodb.swift
+++ b/PVLookup/Sources/libretrodb/libretrodb.swift
@@ -107,7 +107,11 @@ public final class libretrodb: ROMMetadataProvider, @unchecked Sendable {
 
             let stmt = try db.prepare(query)
             var results: [LibretroDBROMMetadata] = []
-            for row in stmt {
+            // `for row in stmt` goes through SQLite.swift's FailableIterator.next(),
+            // which is `try! failableNext()` — a mid-iteration SQLite error (locked/busy
+            // database, interrupt) would SIGTRAP the whole app instead of throwing.
+            // Same crash proven in PVSQLiteDatabase during concurrent imports.
+            while let row = try stmt.failableNext() {
                 var dict: [String: Any] = [:]
                 for (index, name) in stmt.columnNames.enumerated() {
                     dict[name] = row[index]

--- a/PVPrimitives/Tests/PVPrimitivesTests/SharedExtensionSystemMappingTests.swift
+++ b/PVPrimitives/Tests/PVPrimitivesTests/SharedExtensionSystemMappingTests.swift
@@ -1,0 +1,163 @@
+//
+//  SharedExtensionSystemMappingTests.swift
+//  PVPrimitivesTests
+//
+//  Contract tests for import formats claimed by MANY systems — the case that
+//  forces the importer to guess. `.bin` alone is claimed by 13 systems, `.cue`
+//  by 13, `.chd` by 15 and `.zip` by 48, so one wrong entry in systems.plist
+//  silently changes which system a ROM lands on.
+//
+//  These live in PVPrimitives (not PVLibrary) deliberately: they are pure plist
+//  parsing plus the `SystemIdentifier` enum, and PVPrimitives actually builds and
+//  tests standalone (`swift test`). PVLibrary's test target does not currently
+//  compile or run — see the cue/bin tests in
+//  PVLibrary/Tests/PVLibraryTests/SharedExtensionImportTests.swift.
+//
+
+import XCTest
+import PVSystems
+@testable import PVPrimitives
+
+final class SharedExtensionSystemMappingTests: XCTestCase {
+
+    private struct SystemEntry {
+        let identifier: String
+        let name: String
+        let extensions: [String]
+    }
+
+    /// systems.plist lives in PVLibrary's resources; locate it relative to this
+    /// source file so the test needs no resource-bundle plumbing.
+    private static var systemsPlistURL: URL {
+        URL(fileURLWithPath: #filePath)     // .../PVPrimitives/Tests/PVPrimitivesTests/<file>.swift
+            .deletingLastPathComponent()    // .../Tests/PVPrimitivesTests
+            .deletingLastPathComponent()    // .../Tests
+            .deletingLastPathComponent()    // .../PVPrimitives
+            .deletingLastPathComponent()    // repo root
+            .appendingPathComponent("PVLibrary/Sources/PVLibrary/Resources/systems.plist")
+    }
+
+    private func loadSystems() throws -> [SystemEntry] {
+        let url = Self.systemsPlistURL
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            XCTFail("systems.plist not found at \(url.path)")
+            return []
+        }
+        let data = try Data(contentsOf: url)
+        guard let raw = try PropertyListSerialization.propertyList(
+            from: data, options: [], format: nil) as? [[String: Any]] else {
+            XCTFail("systems.plist is not an array of dictionaries")
+            return []
+        }
+        return raw.map {
+            SystemEntry(identifier: $0["PVSystemIdentifier"] as? String ?? "",
+                        name: $0["PVSystemName"] as? String ?? "",
+                        extensions: ($0["PVSupportedExtensions"] as? [String] ?? []))
+        }
+    }
+
+    private func systems(claiming ext: String, in entries: [SystemEntry]) -> Set<String> {
+        Set(entries
+            .filter { $0.extensions.contains { $0.lowercased() == ext.lowercased() } }
+            .map(\.identifier))
+    }
+
+    // MARK: - The .bin ambiguity surface
+
+    /// `.bin` is the worst offender: a bare `.bin` could belong to any of these,
+    /// which is why system resolution has to fall through to MD5 / filename /
+    /// parent-directory disambiguation. Pin the set so a plist edit that changes
+    /// the cost or outcome of that fallback fails loudly.
+    func testBinIsClaimedByExpectedSystems() throws {
+        let entries = try loadSystems()
+        let expected: Set<String> = Set([
+            SystemIdentifier.VirtualBoy,
+            .Genesis,
+            .NAOMI,
+            .Atomiswave,
+            .NAOMI2,
+            .GBA,
+            .Atari2600,
+            .Atari7800,
+            .AtariJaguar,
+            .Atari5200,
+            .Atari8bit,
+            .Intellivision,
+            .Supervision
+        ].map(\.rawValue))
+
+        XCTAssertEqual(systems(claiming: "bin", in: entries), expected,
+                       "The set of systems claiming .bin changed. If intentional, update this "
+                       + "expectation — but confirm system resolution still disambiguates correctly.")
+    }
+
+    /// Every identifier in the plist must map to a real `SystemIdentifier` case,
+    /// otherwise resolution silently drops that system.
+    func testEveryPlistSystemMapsToSystemIdentifierEnum() throws {
+        let unmapped = try loadSystems()
+            .filter { SystemIdentifier(rawValue: $0.identifier) == nil }
+            .map { "\($0.identifier) (\($0.name))" }
+
+        XCTAssertTrue(unmapped.isEmpty,
+                      "systems.plist has identifiers with no SystemIdentifier case: \(unmapped)")
+    }
+
+    /// These formats are inherently multi-system. Assert they stay ambiguous so a
+    /// single-system fast path is never wrongly taken for them.
+    func testKnownSharedExtensionsRemainAmbiguous() throws {
+        let entries = try loadSystems()
+        for ext in ["bin", "cue", "chd", "iso", "img", "zip"] {
+            let claimants = systems(claiming: ext, in: entries)
+            XCTAssertGreaterThan(claimants.count, 1,
+                                 ".\(ext) should be claimed by more than one system (got \(claimants.sorted()))")
+        }
+    }
+
+    /// The same extension listed twice verbatim would inflate the ambiguity count
+    /// and skew the "limited systems" (<= 3) heuristic used during resolution.
+    func testNoSystemListsTheSameExtensionTwice() throws {
+        for entry in try loadSystems() {
+            XCTAssertEqual(entry.extensions.count, Set(entry.extensions).count,
+                           "\(entry.identifier) lists a duplicate extension: \(entry.extensions)")
+        }
+    }
+
+    func testNoDuplicateSystemIdentifiers() throws {
+        let ids = try loadSystems().map(\.identifier)
+        XCTAssertEqual(ids.count, Set(ids).count, "systems.plist has duplicate PVSystemIdentifier entries")
+    }
+
+    /// `PVEmulatorConfiguration.systemsFromCache(forFileExtension:)` matches with
+    /// `system.supportedExtensions.contains(fileExtension.lowercased())` — the
+    /// needle is always lowercased but the stored values are compared verbatim.
+    /// So an extension that exists ONLY in uppercase can never match, and files
+    /// with it would silently fail to resolve to any system.
+    ///
+    /// Today 21 uppercase entries exist (e.g. "CONF", "32X", pc98's "D98"/"ZIP"),
+    /// but every one has a lowercase twin, so they are dead weight rather than a
+    /// live bug. This test guards the case that WOULD be a bug.
+    func testNoExtensionIsReachableOnlyInUppercase() throws {
+        for entry in try loadSystems() {
+            let lowercased = Set(entry.extensions.filter { $0 == $0.lowercased() })
+            let unreachable = entry.extensions.filter { $0 != $0.lowercased() && !lowercased.contains($0.lowercased()) }
+            XCTAssertTrue(unreachable.isEmpty,
+                          "\(entry.identifier) has uppercase-only extensions that can never match: \(unreachable)")
+        }
+    }
+
+    /// Archives are the other big ambiguity class: `.zip` is claimed by dozens of
+    /// systems, so a zip can only be treated as a ROM (rather than extracted) when
+    /// something else — the parent system directory or an explicit user choice —
+    /// narrows it down.
+    func testZipIsClaimedByManySystemsSoItCannotBeResolvedByExtensionAlone() throws {
+        let claimants = systems(claiming: "zip", in: try loadSystems())
+        XCTAssertGreaterThan(claimants.count, 10,
+                             "Expected .zip to be broadly claimed; got \(claimants.count)")
+        // Spot-check systems that genuinely ship zip-as-ROM (arcade ROM sets).
+        let arcadeSystems: [SystemIdentifier] = [.MAME, .CPS1, .CPS2, .CPS3]
+        for arcade in arcadeSystems {
+            XCTAssertTrue(claimants.contains(arcade.rawValue),
+                          "\(arcade.rawValue) should accept .zip as the ROM itself")
+        }
+    }
+}

--- a/Scripts/spm-validate.sh
+++ b/Scripts/spm-validate.sh
@@ -21,6 +21,11 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 TARGET_MODULE="${1:-}"
 
+# NOTE: increment with `VAR=$((VAR + 1))`, never `((VAR++))`.
+# Under `set -e` (line 2), `((VAR++))` is fatal the FIRST time it runs: post-increment
+# evaluates to the OLD value, so with VAR=0 the arithmetic command's result is zero,
+# which bash reports as exit status 1 — killing the script. This silently limited the
+# script to the first module that passed, then exited 1 as if validation had failed.
 PASSED=0
 FAILED=0
 SKIPPED=0
@@ -36,13 +41,13 @@ build_and_test() {
 
     if [[ ! -d "$module_dir" ]]; then
         log "SKIP: ${module} — directory not found"
-        ((SKIPPED++))
+        SKIPPED=$((SKIPPED + 1))
         return 0
     fi
 
     if [[ ! -f "${module_dir}/Package.swift" ]]; then
         log "SKIP: ${module} — no Package.swift"
-        ((SKIPPED++))
+        SKIPPED=$((SKIPPED + 1))
         return 0
     fi
 
@@ -50,7 +55,7 @@ build_and_test() {
     if ! (cd "$module_dir" && swift build 2>&1 | tail -5); then
         log "FAIL: ${module} build failed"
         FAILURES+=("${module} (build)")
-        ((FAILED++))
+        FAILED=$((FAILED + 1))
         return 1
     fi
 
@@ -58,16 +63,16 @@ build_and_test() {
     # Some modules may not have tests yet — that's OK
     if (cd "$module_dir" && swift test 2>&1 | tail -10); then
         log "PASS: ${module}"
-        ((PASSED++))
+        PASSED=$((PASSED + 1))
     else
         # Check if failure is due to no tests vs actual test failure
         if (cd "$module_dir" && swift test 2>&1 | grep -q "no tests found"); then
             log "PASS: ${module} (no tests, build OK)"
-            ((PASSED++))
+            PASSED=$((PASSED + 1))
         else
             log "FAIL: ${module} tests failed"
             FAILURES+=("${module} (test)")
-            ((FAILED++))
+            FAILED=$((FAILED + 1))
         fi
     fi
 }


### PR DESCRIPTION
## Summary

Fixes the long-standing ROM importer hang (`N Total, 0 Processed, 0 New, 0 Errors` / `WAITING` forever) plus five more bugs found underneath it — each one unmasked by fixing the one before. All root causes were proven with runtime evidence (stack samples of the hung/crashed process, os_log traces, crash reports), not inferred.

### The chain

1. **`fix(hashing)`** — `calculateMD5Synchronously` blocked the calling thread on a `DispatchSemaphore` while dispatching the hash to two other GCD queues. Called from `GameImporter.preProcessQueue`'s `withTaskGroup` (via `isBIOS` → `ImportQueueItem.md5`), it parked **every** Swift cooperative-pool thread — nothing left to signal the semaphore. A stack sample of the hung app showed 10 threads in the identical `semaphore_wait_trap` stack. Now hashes on the calling thread via the existing `_computeMD5` — same output, same retry semantics, structurally cannot deadlock.

2. **`fix(importer)` (concurrency)** — with the deadlock gone, up to **243 concurrent `processQueue` loops** ran simultaneously, re-importing each other's in-flight files (2,735 spurious *"couldn't be moved"* failures for files that had imported fine). Four compounding causes, all fixed: a TOCTOU race in `startProcessingSafely` (check and store separated by awaits → now an atomic check-and-reserve), processing loops swallowing `CancellationError` via `try? await Task.sleep` (cancellation now honored at every loop boundary), 10s/30s "stuck task" heuristics that killed healthy tasks during any large import (removed — the 600s watchdog owns hang recovery, and its cancel actually works now), and the public `startProcessing()` force-killing the current task despite being called programmatically 112×/run (now delegates to the safe start path).

3. **`fix(importer)` (data loss)** — `cleanupFailedImportFile` **deleted the user's source file** on `noSystemMatched`/move failures, destroying valid ROMs the lookup merely didn't recognize (observed: a valid CHIP-8 zip deleted after a name collision with MAME's "tank"). Failed imports now keep their files; only byte-identical duplicate deletion remains.

4. **`fix(importer)` (fd leak)** — `FileWatcherManager.addWatcher` silently replaced existing watchers without cancelling them, so the displaced `DispatchSource`'s fd never closed; racing directory events opened 5+ sources per file. A 392-file import exhausted the fd table (`mktemp` → errno 24 `EMFILE`) and broke unrelated zip extraction. Registration is now atomic and refuses duplicates; the losing caller cancels its own source.

5. **`fix(lookup)` (crash)** — `for row in stmt` in `PVSQLiteDatabase.execute` iterates through SQLite.swift's `FailableIterator.next()`, which is `try! failableNext()` — any mid-query SQLite error became SIGTRAP. Once imports actually ran, concurrent artwork/metadata lookups **crashed the whole app ~1 minute into every large import** (two matching `.ips` reports). Errors now propagate through the existing `throws`.

6. **`chore(plists)`** — 21 uppercase extension entries that can never match (`systemsFromCache` lowercases the needle but compares stored values verbatim). All had lowercase twins — dead weight, but one *without* a twin would be a silently unsupported format. A new contract test guards that case.

### Tests

- **PVHashing**: 3 MD5 cooperative-pool concurrency regression tests — deadlocked >120s before the fix, pass in 0.07s after. Full suite 46/46 green (`swift test`).
- **PVPrimitives**: 7 shared-extension contract tests (green, `swift test`) pinning the ambiguity surface: `.bin` claimed by exactly 13 systems, `.cue`/`.chd`/`.iso`/`.img`/`.zip` stay multi-system, every plist id maps to a `SystemIdentifier` case, arcade systems accept zip-as-ROM, no uppercase-only extensions.
- **PVLibrary**: repaired `MockCDFileHandler`, which had drifted from the `CDFileHandling` protocol in May 2025 — the entire PVLibrary test target has not compiled since, and CI never noticed because PVLibrary isn't runnable under `swift test` (macOS platform-floor mismatch; package test mode also fails on a missing `PVLogging` product and a Realm static/dynamic conflict). Added cue/bin absorption tests — they compile against the current API but **cannot execute until the test target is made runnable** (known follow-up).

### Verification (392-file simulator import, iPad Pro M5 / iOS 26.5)

| Metric | Before | After |
|---|---|---|
| Items processed | 0, forever | steady monotonic drain (101 ROMs in 10 min, still going) |
| App survival | SIGTRAP ~1–5 min in | alive entire run |
| Concurrent processing loops | up to 243 | 1 |
| Spurious import failures | 2,735 | 0 (≈12 real failures, mostly genuinely corrupt fixtures) |
| Archive-extraction false failures | 338 | 0 |

Pass condition used throughout: `preProcessQueue() - file types determined, sorting and organizing` — a log line that had **never once** appeared in the broken build — plus process stack samples showing zero importer threads in `semaphore_wait_trap`.

### Known follow-ups (tracked, non-blocking)

- Artwork companion matching: a valid PNG can still fail to match its game (mixed in with genuinely corrupt fixture images that fail correctly).
- Make the PVLibrary test target executable so the new cue/bin tests actually run in CI.
- Preprocess generation-thrash: 73% of preprocessing passes are discarded under continuous queue mutation (perf only, not correctness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core import pipeline, synchronous hashing under heavy concurrency, and file-watcher lifecycle; incorrect changes could regress imports, leak FDs, or leave duplicate processing—though the PR targets proven production failures.
> 
> **Overview**
> Fixes the ROM importer **permanent hang** and a chain of bugs that only showed up once hashing could finish.
> 
> **`calculateMD5Synchronously`** no longer blocks on a semaphore while work runs on other GCD queues; it hashes on the **calling thread** via `_computeMD5` with the same 3-attempt retry behavior. That removes cooperative-pool deadlock when `preProcessQueue` hashes many files in parallel. **PVHashing** adds cooperative-pool regression tests with time limits.
> 
> **`GameImporter`** gets safer concurrency: atomic **check-and-reserve** for starting processing (no hundreds of overlapping `processQueue` loops), **`Task.isCancelled`** honored in preprocess/process loops, removal of 10s/30s “stuck” heuristics that killed healthy large imports, and **`startProcessing()`** no longer force-cancels in-flight work. **`preProcessQueue`** merges file-type classification from task-group chunks instead of mutating `workQueue` from concurrent children. **`cleanupFailedImportFile`** stops deleting files under `/Imports/` on failure so users can retry.
> 
> **`DirectoryWatcher` / `FileWatcherManager`**: duplicate watcher registration is refused; losers **cancel** their `DispatchSource` so file descriptors are not leaked.
> 
> **`PVSQLiteDatabase.execute`** uses `failableNext()` so mid-query SQLite errors throw instead of trapping via `try!`.
> 
> **`systems.plist`**: redundant uppercase-only extension duplicates removed. New **PVPrimitives** plist contract tests and **PVLibrary** cue/bin absorption tests; mock `CDFileHandling` updated to match the protocol.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74c6342970fb75a71f2219eef64db96a29ad891f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->