### PR TITLE
fix(app): stop holding a background-task assertion from launch forever

### DIFF
--- a/Provenance/Main UI/ProvenanceApp.swift
+++ b/Provenance/Main UI/ProvenanceApp.swift
@@ -25,28 +25,21 @@ struct ProvenanceApp: App {
     @Environment(\.scenePhase) private var scenePhase
     @StateObject private var sceneCoordinator = SceneCoordinator.shared
 
-    /// Handles the spotlight indexing background task identifier
-    @State private var spotlightBackgroundTaskIdentifier: UIBackgroundTaskIdentifier = .invalid
-
-    init() {
-        // Register for Spotlight background processing
-        registerSpotlightBackgroundTask()
-    }
-
-    /// Register a background task for Spotlight indexing
-    private func registerSpotlightBackgroundTask() {
-        // Register a background task identifier for Spotlight indexing
-        var backgroundTaskIdentifier: UIBackgroundTaskIdentifier = .invalid
-        backgroundTaskIdentifier = UIApplication.shared.beginBackgroundTask(withName: "SpotlightIndexing") {
-            WLOG("Spotlight indexing background task expired")
-            UIApplication.shared.endBackgroundTask(backgroundTaskIdentifier)
-        }
-
-        // Store the background task identifier for later use
-        spotlightBackgroundTaskIdentifier = backgroundTaskIdentifier
-
-        ILOG("Registered background task for Spotlight indexing with identifier: \(backgroundTaskIdentifier)")
-    }
+    // NOTE: there used to be a `registerSpotlightBackgroundTask()` here, called from
+    // `init()`, that took a `beginBackgroundTask(withName: "SpotlightIndexing")`
+    // assertion at LAUNCH and never released it — the only `endBackgroundTask` was in
+    // the expiration handler, and every call that would have ended it normally lives
+    // commented-out inside `forceSpotlightReindexing()` (itself an empty stub now).
+    //
+    // The effect: from launch onward the app permanently claimed background execution
+    // for work that no longer exists. Every time it was backgrounded it burned its
+    // background allowance doing nothing until iOS expired the assertion, and an app
+    // that always appears to be running in the background is a prime jetsam target —
+    // a direct contributor to unexplained "the app force quit itself" reports.
+    //
+    // A background assertion must wrap actual work and be ended on EVERY exit path.
+    // If Spotlight indexing is re-enabled, take the assertion inside that operation
+    // and end it in a `defer`.
 
     var body: some Scene {
         WindowGroup(id: "main") {


### PR DESCRIPTION
## Summary

The app took a `beginBackgroundTask` assertion **at launch** and never released it. This is a direct contributor to the "app force-quits itself in the background" reports.

## What was happening

`ProvenanceApp.init()` called `registerSpotlightBackgroundTask()`:

```swift
init() {
    registerSpotlightBackgroundTask()   // runs at launch, in the FOREGROUND
}

private func registerSpotlightBackgroundTask() {
    backgroundTaskIdentifier = UIApplication.shared.beginBackgroundTask(withName: "SpotlightIndexing") {
        WLOG("Spotlight indexing background task expired")
        UIApplication.shared.endBackgroundTask(backgroundTaskIdentifier)   // ← the ONLY end call
    }
    ...
}
```

Every `endBackgroundTask` that would have ended it *normally* lives commented-out inside `forceSpotlightReindexing()` — and that function is now an **empty stub**, its entire body commented out. So:

- The assertion is taken at launch and held for the process lifetime.
- The work it was meant to protect no longer exists.
- The only release path is iOS expiring it.

**Effect:** on every backgrounding the app consumed its background-execution allowance doing nothing until the assertion expired. An app that continuously appears to be running in the background is a prime jetsam candidate — especially this one, which keeps emulator core memory mapped and declares `audio` in `UIBackgroundModes`.

## Fix

Removed the registration and the now-unused `@State` identifier. A comment records why, so it isn't reintroduced.

A background assertion must wrap actual work and be ended on **every** exit path. Two existing sites already do this correctly and are left untouched:

- `PVAppDelegate.applicationWillResignActive` — the `"PVSaveCoreState"` assertion wraps the autosave chain and ends in both the completion path and the expiration handler.
- `PVAppDelegate+CloudKit.swift:117` — ends at `:148` and `:161`.

If Spotlight indexing is re-enabled, follow that pattern (take the assertion inside the operation, end it in a `defer`).

## Verification

Workspace build green (`Provenance-Lite (AppStore)`, iOS Simulator). SwiftLint clean on the changed file. No remaining references to `registerSpotlightBackgroundTask` or `spotlightBackgroundTaskIdentifier`.

## Related findings (NOT in this PR)

Two other contributors to background terminations, both needing decisions rather than a bug fix:

1. **`UIBackgroundModes` declares 8 modes** (`Provenance-Info.plist:339`): `audio`, `bluetooth-central`, `external-accessory`, `fetch`, `location`, `nearby-interaction`, `processing`, `remote-notification`. `audio` in particular keeps the process resident with core memory mapped. Worth auditing which are still required.
2. **Extensions open the full Realm.** `Extensions/Spotlight/IndexRequestHandler.swift` uses `RomDatabase.sharedInstance` (`:38`, `:48`, `:58`), as does `Extensions/TopShelfv2`. Index extensions run under a hard memory ceiling, so loading the whole library there gets them jetsammed — which users experience as the app dying. Needs a lightweight read path (App Group snapshot), not a one-liner.

Both are reasoned from code and have **not** yet been confirmed against a device termination log. To confirm: Settings → Privacy & Security → Analytics → Analytics Data, look for `JetsamEvent-*` naming Provenance or an extension, and terminations with `0xdead10cc` (held a file/SQLite lock while suspended) or `0x8badf00d` (watchdog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletion-only lifecycle fix in app startup with no new background behavior; lowers risk of spurious background termination.
> 
> **Overview**
> Removes **launch-time** `beginBackgroundTask(withName: "SpotlightIndexing")` registration from `ProvenanceApp` so the process no longer keeps a background execution assertion open for Spotlight work that is disabled (`forceSpotlightReindexing()` is an empty stub).
> 
> The deleted `init()` / `registerSpotlightBackgroundTask()` path and `spotlightBackgroundTaskIdentifier` state are replaced with an in-file comment documenting the bug (assertion taken at foreground launch, only released on expiration) and the correct pattern if Spotlight indexing returns (wrap real work, end on every exit path, e.g. `defer`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61170cfba3928af68c018a6772428f8cc266820d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->