### PR TITLE
fix(cloudkit): stop trapping on unentitled builds in diagnostic view models

### DIFF
--- a/PVUI/Sources/PVSwiftUI/Settings/ViewModels/CloudKitRecordsViewModel.swift
+++ b/PVUI/Sources/PVSwiftUI/Settings/ViewModels/CloudKitRecordsViewModel.swift
@@ -56,6 +56,7 @@ public struct CloudKitRecordItem: Identifiable, Equatable {
 
 /// View model for CloudKit Records Management
 @MainActor
+// swiftlint:disable:next type_body_length
 public class CloudKitRecordsViewModel: ObservableObject {
     // MARK: - Published Properties
 
@@ -176,6 +177,16 @@ public class CloudKitRecordsViewModel: ObservableObject {
             return
         }
 
+        guard isCloudKitAvailable else {
+            // Without this the parallel fetches below each throw CloudKitUnavailableError,
+            // every task returns nil, and the UI renders zeroes — indistinguishable from
+            // "iCloud is empty". Say what actually happened instead.
+            reportCloudKitUnavailable()
+            isLoading = false
+            loadingProgress = ""
+            return
+        }
+
         isLoading = true
         errorMessage = nil
         loadingProgress = "Fetching record counts..."
@@ -244,6 +255,12 @@ public class CloudKitRecordsViewModel: ObservableObject {
 
     /// Quick refresh - counts only, no size calculation (much faster)
     public func quickRefreshCounts() async {
+        guard isCloudKitAvailable else {
+            // Same reasoning as refreshStats: don't render zeroes as if iCloud were empty.
+            reportCloudKitUnavailable()
+            isLoading = false
+            return
+        }
         isLoading = true
         errorMessage = nil
         loadingProgress = "Quick counting records..."

--- a/PVUI/Sources/PVSwiftUI/Settings/ViewModels/CloudKitRecordsViewModel.swift
+++ b/PVUI/Sources/PVSwiftUI/Settings/ViewModels/CloudKitRecordsViewModel.swift
@@ -85,8 +85,27 @@ public class CloudKitRecordsViewModel: ObservableObject {
 
     // MARK: - Private Properties
 
-    private let container: CKContainer
-    private let database: CKDatabase
+    // Optional on purpose: `CKContainer(identifier:)` TRAPS (does not throw) when the
+    // container is missing from the process entitlements, so building it eagerly crashed
+    // the app as soon as this screen opened on a build without the CloudKit entitlement
+    // (notably sideloads signed with a different team). `iCloudConstants.container` is the
+    // entitlement-gated accessor and yields nil rather than trapping.
+    private let container: CKContainer?
+    private let database: CKDatabase?
+
+    /// False when the app has no CloudKit entitlement — the UI can explain instead of
+    /// offering actions that cannot work.
+    public var isCloudKitAvailable: Bool { container != nil }
+
+    /// Surfaces a clear message instead of silently doing nothing when unentitled.
+    private func reportCloudKitUnavailable() {
+        errorMessage = "iCloud is not available in this build (no CloudKit entitlement)."
+    }
+
+    /// Thrown by the `throws` helpers when CloudKit isn't entitled.
+    struct CloudKitUnavailableError: LocalizedError {
+        var errorDescription: String? { "iCloud is not available in this build." }
+    }
     private var queryCursor: CKQueryOperation.Cursor?
     private var lastStatsRefresh: Date?
     private let statsRefreshInterval: TimeInterval = 60  // Minimum seconds between auto-refreshes
@@ -127,8 +146,8 @@ public class CloudKitRecordsViewModel: ObservableObject {
     // MARK: - Initialization
 
     public init() {
-        self.container = CKContainer(identifier: iCloudConstants.containerIdentifier)
-        self.database = container.privateCloudDatabase
+        self.container = iCloudConstants.container
+        self.database = container?.privateCloudDatabase
 
         // Initialize stats with zero counts
         recordTypeStats = recordTypes.map { type in
@@ -299,6 +318,7 @@ public class CloudKitRecordsViewModel: ObservableObject {
 
     /// Delete a single record
     public func deleteRecord(_ record: CloudKitRecordItem) async -> Bool {
+        guard let database else { reportCloudKitUnavailable(); return false }
         isDeletingRecords = true
         errorMessage = nil
 
@@ -340,6 +360,7 @@ public class CloudKitRecordsViewModel: ObservableObject {
 
     /// Delete selected records
     public func deleteSelectedRecords() async -> Int {
+        guard let database else { reportCloudKitUnavailable(); return 0 }
         guard !selectedRecordIDs.isEmpty else { return 0 }
 
         isDeletingRecords = true
@@ -389,6 +410,7 @@ public class CloudKitRecordsViewModel: ObservableObject {
     /// Fire-and-forget delete - starts deletion in background, returns immediately
     /// This is the fastest option - doesn't wait for completion
     public func nukeAllRecords(ofType recordType: String) {
+        guard let database else { reportCloudKitUnavailable(); return }
         // Update UI immediately
         if let index = recordTypeStats.firstIndex(where: { $0.recordType == recordType }) {
             recordTypeStats[index].count = 0
@@ -404,7 +426,7 @@ public class CloudKitRecordsViewModel: ObservableObject {
         successMessage = "Delete started - records are being removed in background"
 
         // Fire and forget - run deletion in background task
-        Task.detached(priority: .utility) { [weak self] in
+        Task.detached(priority: .utility) { [weak self, database] in
             guard let self = self else { return }
             var totalDeleted = 0
             var cursor: CKQueryOperation.Cursor? = nil
@@ -415,14 +437,14 @@ public class CloudKitRecordsViewModel: ObservableObject {
                     let result: (matchResults: [(CKRecord.ID, Result<CKRecord, Error>)], queryCursor: CKQueryOperation.Cursor?)
 
                     if let existingCursor = cursor {
-                        result = try await self.database.records(
+                        result = try await database.records(
                             continuingMatchFrom: existingCursor,
                             desiredKeys: [],
                             resultsLimit: 400  // Max CloudKit allows per operation
                         )
                     } else {
                         let query = CKQuery(recordType: recordType, predicate: NSPredicate(value: true))
-                        result = try await self.database.records(
+                        result = try await database.records(
                             matching: query,
                             desiredKeys: [],
                             resultsLimit: 400
@@ -436,7 +458,7 @@ public class CloudKitRecordsViewModel: ObservableObject {
 
                     if !recordIDs.isEmpty {
                         // Batch delete - up to 400 at once
-                        _ = try? await self.database.modifyRecords(
+                        _ = try? await database.modifyRecords(
                             saving: [],
                             deleting: recordIDs,
                             savePolicy: .allKeys
@@ -472,6 +494,7 @@ public class CloudKitRecordsViewModel: ObservableObject {
 
     /// Delete all records of a specific type (deletes in batches as fetched for speed)
     public func deleteAllRecords(ofType recordType: String) async -> Int {
+        guard let database else { reportCloudKitUnavailable(); return 0 }
         isDeletingRecords = true
         errorMessage = nil
         loadingProgress = "Deleting \(recordType) records..."
@@ -621,6 +644,7 @@ public class CloudKitRecordsViewModel: ObservableObject {
     }
 
     private func fetchStatsForRecordType(_ recordType: String) async throws -> (count: Int, totalSize: Int64, lastModified: Date?) {
+        guard let database else { throw CloudKitUnavailableError() }
         var count = 0
         var totalSize: Int64 = 0
         var lastModified: Date? = nil
@@ -677,6 +701,7 @@ public class CloudKitRecordsViewModel: ObservableObject {
 
     /// Quick count-only fetch (faster, no size calculation)
     private func fetchCountForRecordType(_ recordType: String) async throws -> Int {
+        guard let database else { throw CloudKitUnavailableError() }
         var count = 0
         var cursor: CKQueryOperation.Cursor? = nil
 
@@ -714,6 +739,7 @@ public class CloudKitRecordsViewModel: ObservableObject {
     }
 
     private func fetchRecords(ofType recordType: String, cursor: CKQueryOperation.Cursor?) async throws -> (records: [CloudKitRecordItem], cursor: CKQueryOperation.Cursor?) {
+        guard let database else { throw CloudKitUnavailableError() }
         var items: [CloudKitRecordItem] = []
 
         let result: ([CKRecord.ID: Result<CKRecord, Error>], CKQueryOperation.Cursor?)

--- a/PVUI/Sources/PVUIBase/SwiftUI/CloudKitDiagnosticView.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/CloudKitDiagnosticView.swift
@@ -473,9 +473,19 @@ class CloudKitDiagnosticViewModel: ObservableObject {
     @Published var schemaStatus = "Unknown"
     @Published var schemaStatusColor = Color.gray
 
-    // CloudKit container
-    private let container = CKContainer(identifier: iCloudConstants.containerIdentifier)
-    private let privateDatabase: CKDatabase
+    // CloudKit container.
+    //
+    // Optional on purpose: `CKContainer(identifier:)` TRAPS (it does not throw) when the
+    // container is absent from the process's entitlements, so constructing it eagerly
+    // crashed the app the moment this screen opened on a build without the CloudKit
+    // entitlement — notably sideloads signed with a different team. `iCloudConstants.container`
+    // is the entitlement-gated accessor and returns nil instead of trapping.
+    private let container: CKContainer?
+    private let privateDatabase: CKDatabase?
+
+    /// False when the app has no CloudKit entitlement; the UI shows an explanation
+    /// instead of offering actions that cannot work.
+    var isCloudKitAvailable: Bool { container != nil }
 
     var containerIdentifier: String {
         iCloudConstants.containerIdentifier
@@ -488,13 +498,28 @@ class CloudKitDiagnosticViewModel: ObservableObject {
     // MARK: - Initialization
 
     init() {
-        privateDatabase = container.privateCloudDatabase
+        container = iCloudConstants.container
+        privateDatabase = container?.privateCloudDatabase
+    }
+
+    /// Sets the user-visible status used when CloudKit isn't entitled.
+    @MainActor
+    private func reportCloudKitUnavailable() {
+        accountStatus = "Unavailable (no CloudKit entitlement)"
+        accountStatusColor = .retroOrange
+        schemaStatus = "Unavailable"
+        schemaStatusColor = .retroOrange
+        isLoading = false
     }
 
     // MARK: - Methods
 
     /// Check the CloudKit account status
     func checkAccountStatus() async {
+        guard let container else {
+            await reportCloudKitUnavailable()
+            return
+        }
         do {
             let accountStatus = try await container.accountStatus()
 
@@ -537,6 +562,11 @@ class CloudKitDiagnosticViewModel: ObservableObject {
             schemaStatusColor = .gray
         }
 
+        guard let privateDatabase else {
+            await reportCloudKitUnavailable()
+            return
+        }
+
         do {
             // Try to initialize the schema
             let success = await CloudKitSchema.initializeSchema(in: privateDatabase)
@@ -569,6 +599,11 @@ class CloudKitDiagnosticViewModel: ObservableObject {
             isLoading = true
             errorMessage = nil
             successMessage = nil
+        }
+
+        guard let privateDatabase else {
+            await reportCloudKitUnavailable()
+            return
         }
 
         do {
@@ -640,6 +675,11 @@ class CloudKitDiagnosticViewModel: ObservableObject {
             isLoading = true
             errorMessage = nil
             successMessage = nil
+        }
+
+        guard let privateDatabase else {
+            await reportCloudKitUnavailable()
+            return
         }
 
         do {


### PR DESCRIPTION
Closes #3648.

## Problem

`CloudKitDiagnosticView`'s view model and `CloudKitRecordsViewModel` each constructed `CKContainer(identifier: iCloudConstants.containerIdentifier)` directly in `init()`.

`CKContainer(identifier:)` **traps** — it does not throw — when the container isn't present in the process's entitlements. So opening either Settings screen crashed the app outright on a build without the CloudKit entitlement. This mainly hits **sideloaded builds** signed with a different team, where the entitlement is absent but the UI is still reachable from Settings.

## Fix

Both now use the entitlement-gated `iCloudConstants.container`, which returns nil instead of trapping, with the derived `CKDatabase` optional alongside it.

Each entry point guards according to its return type:
- void / `Bool` / `Int` returns → report through `errorMessage` or the status fields
- `async throws` fetch helpers → throw `CloudKitUnavailableError`

The fire-and-forget delete task in `nukeAllRecords` captures the unwrapped `database` in its capture list rather than re-reading `self.database`, so optionality doesn't leak into the loop.

Both models expose `isCloudKitAvailable` so the UI can explain the situation rather than offer actions that cannot work.

## Why this was deferred previously

Per #3648: both held **non-optional stored properties** feeding a derived `CKDatabase`, so making them optional cascades through every use site (~6 and ~15). Doing that cascade is what this PR is — 10 guards across the two files. `SyncProviderFactory` and `CloudSyncStatusView.checkCloudKitAvailability` were already gated in #3646; those were function-local and self-contained.

## Verification

Workspace build green (`Provenance-Lite (AppStore)`, iOS Simulator). No direct `CKContainer(identifier:)` constructions remain outside `iCloudConstants` — the remaining textual matches are explanatory comments.

**Not yet exercised on an actual unentitled build.** The real check is to open Settings → CloudKit diagnostics on a sideload signed with a non-Provenance team and confirm it shows the unavailable state instead of crashing. Worth doing before release since that is precisely the configuration this fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defensive gating around Settings-only CloudKit tooling; entitled App Store behavior unchanged when container is non-nil.
> 
> **Overview**
> Fixes **instant crashes** when opening CloudKit Settings screens on builds **without** the CloudKit entitlement (e.g. sideloads signed with another team). Both **`CloudKitRecordsViewModel`** and **`CloudKitDiagnosticViewModel`** no longer call `CKContainer(identifier:)` in `init()` — that API **traps** if the container isn’t in entitlements.
> 
> They now initialize from **`iCloudConstants.container`**, with optional `CKContainer` / `CKDatabase`. **`isCloudKitAvailable`** lets the UI reflect missing iCloud. Deletes, fetches, and diagnostics **guard** on a non-nil database: user-facing paths set **`errorMessage`** or diagnostic status via **`reportCloudKitUnavailable()`**; **`throws`** helpers use **`CloudKitUnavailableError`**. Background **`nukeAllRecords`** captures the unwrapped **`database`** in the detached task so the delete loop doesn’t depend on optional **`self.database`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47527035000082a5c1000afb3acc4478312f9f2a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->