### PR TITLE
fix(ci): align spm-validate with Xcode 26.3 (lost from #3657)

### DIFF
--- a/.github/workflows/spm-validate.yml
+++ b/.github/workflows/spm-validate.yml
@@ -36,7 +36,15 @@ jobs:
           submodules: recursive
 
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_16.app/Contents/Developer
+        # Must match agent-validation.yml (Xcode_26.3). This job was the only one left
+        # on Xcode 16, and the mismatch actively broke it:
+        #   * PVSettings cannot build at all — its pinned Defaults 9.0.8 declares
+        #     swift-tools-version 6.2.0, which Xcode 16's Swift 6.0 refuses to parse.
+        #   * PVPlists/PVHashing failed on strict-concurrency diagnostics that only
+        #     Xcode 16 emits, so they were invisible to every developer locally.
+        # Those PVHashing fixes are worth keeping on their own merits, but they were
+        # forced by a stale toolchain rather than by a real defect.
+        run: sudo xcode-select -s /Applications/Xcode_26.3.app
 
       - name: Validate modules
         run: |


### PR DESCRIPTION
Re-applies commit `73fff66846`, which was written for #3657 but did not make it into that PR's squash merge — I merged #3657 before the commit was part of it. Verified: `git merge-base --is-ancestor 73fff66846 develop` → not an ancestor, and develop's `spm-validate.yml` still pins Xcode 16.

## Why it matters

`spm-validate.yml` is the only CI job still on **Xcode 16**; `agent-validation.yml` uses **Xcode_26.3**. That mismatch actively breaks the job on develop right now:

- **PVSettings cannot build at all** — its pinned `Defaults 9.0.8` declares `swift-tools-version 6.2.0`, which Xcode 16's Swift 6.0 refuses to parse:
  ```
  error: 'defaults': package 'defaults' @ 9.0.8 is using Swift tools version 6.2.0
  but the installed version is 6.0.0
  ```
- **PVPlists/PVHashing** fail on strict-concurrency diagnostics only Xcode 16 emits, so they are invisible to every developer locally and look like phantom CI-only breakage.

The current develop run (31075538339, on 5215f2bc) failed exactly this way — `PASS: PVLogging` then `FAIL: PVPlists build failed`, with the log confirming `xcode-select -s /Applications/Xcode_16.app`.

## Evidence it's the toolchain, not the code

Running the same script locally on merged develop (Xcode 26):

```
PASS: PVLogging / PVPlists / PVHashing / PVSettings / PVFeatureFlags
Results: 5 passed, 0 failed, 0 skipped
```

First complete run in that script's history (it exited after the first module until #3650 fixed `((VAR++))` under `set -e`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only Xcode path change with no runtime, auth, or product code impact; main risk is if Xcode 26.3 is unavailable on the runner image.
> 
> **Overview**
> **Aligns `spm-validate.yml` with the rest of CI** by switching the Select Xcode step from `Xcode_16.app` to `Xcode_26.3.app`, matching `agent-validation.yml` and the main build workflow.
> 
> The workflow comment documents why the old pin was failing the job: **PVSettings** could not resolve **Defaults 9.0.8** (Swift tools 6.2 vs Swift 6.0 on Xcode 16), and **PVPlists/PVHashing** were hitting strict-concurrency errors that only showed up under the older toolchain.
> 
> No application or package source changes—only CI toolchain selection and documentation in the workflow file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f927aa1071e24df3647a411c048973e24cae16c6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->