### PR TITLE
[Agent] fix(ci): health monitor never posted its report, and can't see weekly jobs

### DIFF
--- a/.github/scripts/scheduled-workflow-staleness.py
+++ b/.github/scripts/scheduled-workflow-staleness.py
@@ -225,7 +225,15 @@ def extract_cron_expressions(text: str) -> list[str]:
                 schedule_indent = indent
             continue
 
-        if indent <= schedule_indent:
+        # A sequence item may sit at the SAME indentation as the key that owns
+        # it — this is valid YAML and a common style:
+        #     on:
+        #       schedule:
+        #       - cron: '0 4 * * 0'
+        # Only a non-list-item key at or above `schedule:` ends the block.
+        # Treating indent alone as the terminator silently dropped every cron
+        # written that way, making such a workflow invisible to this check.
+        if indent <= schedule_indent and not stripped.startswith("- "):
             in_schedule = False
             if re.match(r"^schedule\s*:", stripped):
                 in_schedule = True

--- a/.github/scripts/scheduled-workflow-staleness.py
+++ b/.github/scripts/scheduled-workflow-staleness.py
@@ -271,13 +271,19 @@ def discover_scheduled_workflows(workflows_dir: Path) -> list[tuple[str, list[st
 
 # ── GitHub queries ────────────────────────────────────────────────────────
 
+class GhError(RuntimeError):
+    """A `gh` invocation failed. Never conflate this with "no data" — a
+    silently-empty result here would make e.g. `has_any_run()` return False
+    and the caller report a false-green "no runs yet" instead of surfacing
+    that the check couldn't query Actions at all (auth/rate-limit/etc)."""
+
+
 def _gh(args: list[str]) -> str:
     result = subprocess.run(
         ["gh", *args], capture_output=True, text=True, check=False
     )
     if result.returncode != 0:
-        print(f"::warning::gh {' '.join(args)} failed: {result.stderr.strip()}", file=sys.stderr)
-        return ""
+        raise GhError(f"gh {' '.join(args)} failed: {result.stderr.strip()}")
     return result.stdout.strip()
 
 
@@ -413,13 +419,29 @@ def main() -> int:
         print("error: --repo (or $REPO) is required", file=sys.stderr)
         return 2
 
+    workflows_dir = Path(args.workflows_dir)
+    if not workflows_dir.is_dir():
+        # An empty scan reads identically to "nothing is scheduled", which
+        # would render as a false-green "0 scheduled OK". A wrong path or a
+        # checkout that never happened is an internal error, not a result.
+        print(f"error: --workflows-dir {workflows_dir} is not a directory", file=sys.stderr)
+        return 2
+
     now = (
         dt.datetime.fromisoformat(args.now.replace("Z", "+00:00"))
         if args.now
         else dt.datetime.now(dt.timezone.utc)
     )
 
-    results = evaluate(args.repo, Path(args.workflows_dir), now)
+    try:
+        results = evaluate(args.repo, workflows_dir, now)
+    except GhError as exc:
+        # Propagated from _gh(): a `gh` call failed outright (auth,
+        # rate-limit, network). Abort rather than let the caller mistake a
+        # missing GITHUB_OUTPUT write for "check did not report" — see the
+        # module docstring: exits non-zero only on internal error.
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
 
     icon = {"ok": "✅", "stale": "🚨", "warn": "⚠️", "info": "ℹ️"}
     for entry in results:

--- a/.github/scripts/scheduled-workflow-staleness.py
+++ b/.github/scripts/scheduled-workflow-staleness.py
@@ -1,0 +1,456 @@
+#!/usr/bin/env python3
+"""Detect scheduled workflows whose *scheduled* runs have stopped succeeding.
+
+This is deliberately orthogonal to the 24h failure-rate check in
+repo-health.yml. A failure *rate* check can never fire for a low-frequency
+workflow: a `cron: '0 4 * * 0'` job runs once a week, so it can produce at
+most one failure in any 24h window and can never cross a "> 3 failures"
+threshold. update-catalogs.yml failed 23 out of 23 scheduled runs over five
+months and was invisible to that check by construction.
+
+Staleness asks a different question — "when did this workflow's scheduled
+path last actually work?" — and alerts when the answer is older than a
+multiple of the workflow's own cron interval.
+
+Usage:
+    scheduled-workflow-staleness.py [--repo OWNER/REPO] [--workflows-dir DIR]
+                                    [--now ISO8601] [--format text|github]
+
+Exits 0 whether or not anything is stale; the caller decides what to do with
+the report. Exits non-zero only on an internal error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# A workflow is considered stale when its last successful scheduled run is
+# older than max(STALE_MULTIPLIER x cron interval, STALE_FLOOR_SECONDS).
+#
+# The floor keeps high-frequency workflows from alarming on GitHub's own
+# scheduler jitter — scheduled runs are queued on a best-effort basis and are
+# routinely delayed (or dropped) under load. Fast workflows are already well
+# covered by the 24h failure-rate check; this check exists for the slow ones.
+STALE_MULTIPLIER = 2
+STALE_FLOOR_SECONDS = 6 * 3600
+
+# Events that exercise the workflow the way its schedule does: the full job
+# graph, with no `paths:` filter or pull-request-only conditional narrowing it
+# to a subset. A green `push` run is NOT evidence the scheduled path works —
+# that is exactly how consolidate-changelog.yml's cancelled cron run hid
+# behind a passing pull_request run.
+SUCCESS_EVENTS = ("schedule", "workflow_dispatch")
+
+# Reference instant for cron-interval derivation. Fixed, never `now`, so the
+# derived interval is identical on every run instead of jittering with the
+# clock.
+CRON_EPOCH = dt.datetime(2025, 1, 1, tzinfo=dt.timezone.utc)
+CRON_WINDOW_MINUTES = 4 * 7 * 24 * 60      # 4 weeks — covers minute..weekly
+CRON_WIDE_WINDOW_MINUTES = 400 * 24 * 60   # ~13 months — for monthly+ crons
+CRON_FALLBACK_INTERVAL = 24 * 3600
+
+MONTH_NAMES = {
+    "jan": 1, "feb": 2, "mar": 3, "apr": 4, "may": 5, "jun": 6,
+    "jul": 7, "aug": 8, "sep": 9, "oct": 10, "nov": 11, "dec": 12,
+}
+DOW_NAMES = {
+    "sun": 0, "mon": 1, "tue": 2, "wed": 3, "thu": 4, "fri": 5, "sat": 6,
+}
+
+
+# ── Cron parsing ──────────────────────────────────────────────────────────
+
+class CronError(ValueError):
+    """Raised for a cron expression we cannot interpret."""
+
+
+def _parse_field(expr: str, lo: int, hi: int, names: dict[str, int] | None = None) -> set[int]:
+    """Expand one cron field ("*/10", "1-5", "MON,WED", "4") into a value set."""
+    def to_num(token: str) -> int:
+        token = token.strip().lower()
+        if names and token in names:
+            return names[token]
+        if not re.fullmatch(r"\d+", token):
+            raise CronError(f"unrecognised value {token!r}")
+        return int(token)
+
+    values: set[int] = set()
+    for part in expr.split(","):
+        part = part.strip()
+        if not part:
+            raise CronError("empty list element")
+        step = 1
+        if "/" in part:
+            part, raw_step = part.split("/", 1)
+            if not re.fullmatch(r"\d+", raw_step) or int(raw_step) == 0:
+                raise CronError(f"bad step {raw_step!r}")
+            step = int(raw_step)
+        if part in ("*", "?"):
+            start, end = lo, hi
+        elif "-" in part.lstrip("-"):
+            raw_start, raw_end = part.split("-", 1)
+            start, end = to_num(raw_start), to_num(raw_end)
+        else:
+            start = end = to_num(part)
+            if step > 1:  # "5/15" means "from 5 to the end of the range, step 15"
+                end = hi
+        if start > end or start < lo or end > hi:
+            raise CronError(f"value out of range in {expr!r}")
+        values.update(range(start, end + 1, step))
+    if not values:
+        raise CronError(f"field {expr!r} matches nothing")
+    return values
+
+
+class CronSchedule:
+    """A 5-field cron expression, evaluated by direct matching."""
+
+    def __init__(self, expression: str) -> None:
+        fields = expression.split()
+        if len(fields) != 5:
+            raise CronError(f"expected 5 fields, got {len(fields)}: {expression!r}")
+        minute, hour, dom, month, dow = fields
+        self.expression = expression
+        self.minutes = _parse_field(minute, 0, 59)
+        self.hours = _parse_field(hour, 0, 23)
+        self.days = _parse_field(dom, 1, 31)
+        self.months = _parse_field(month, 1, 12, MONTH_NAMES)
+        # Cron allows both 0 and 7 for Sunday; normalise 7 down to 0.
+        self.weekdays = {d % 7 for d in _parse_field(dow, 0, 7, DOW_NAMES)}
+        self.dom_unrestricted = dom.strip() in ("*", "?")
+        self.dow_unrestricted = dow.strip() in ("*", "?")
+
+    def matches(self, when: dt.datetime) -> bool:
+        if when.minute not in self.minutes or when.hour not in self.hours:
+            return False
+        if when.month not in self.months:
+            return False
+        # Standard cron: when day-of-month and day-of-week are BOTH restricted
+        # they are OR'd, not AND'd.
+        day_ok = when.day in self.days
+        # datetime.isoweekday() is Mon=1..Sun=7; % 7 maps Sunday to 0 to match cron.
+        weekday_ok = (when.isoweekday() % 7) in self.weekdays
+        if self.dom_unrestricted and self.dow_unrestricted:
+            return True
+        if self.dom_unrestricted:
+            return weekday_ok
+        if self.dow_unrestricted:
+            return day_ok
+        return day_ok or weekday_ok
+
+    def interval_seconds(self) -> int:
+        """Median gap between consecutive firings, in seconds.
+
+        Derived by stepping minute-by-minute from a fixed reference instant
+        rather than by analysing the fields, so any expression a contributor
+        adds later is handled without special cases (weekday-vs-day-of-month
+        being the classic one that breaks field analysis).
+        """
+        for window in (CRON_WINDOW_MINUTES, CRON_WIDE_WINDOW_MINUTES):
+            gaps = self._gaps(window)
+            if gaps:
+                gaps.sort()
+                return gaps[len(gaps) // 2]
+        return CRON_FALLBACK_INTERVAL
+
+    def _gaps(self, window_minutes: int) -> list[int]:
+        minute = dt.timedelta(minutes=1)
+        cursor = CRON_EPOCH
+        previous: dt.datetime | None = None
+        gaps: list[int] = []
+        for _ in range(window_minutes):
+            if self.matches(cursor):
+                if previous is not None:
+                    gaps.append(int((cursor - previous).total_seconds()))
+                previous = cursor
+            cursor += minute
+        return gaps
+
+
+# ── Workflow discovery ────────────────────────────────────────────────────
+
+def _indent_of(line: str) -> int:
+    return len(line) - len(line.lstrip(" "))
+
+
+def extract_cron_expressions(text: str) -> list[str]:
+    """Return the cron expressions under the workflow's top-level `on:` key.
+
+    Hand-rolled rather than PyYAML because (a) PyYAML is not guaranteed on
+    the runner, and (b) YAML 1.1 parses the bare key `on` as the boolean
+    True, which is a trap. Comment lines are skipped, so a commented-out
+    `# - cron: ...` (testflight.yml has one) is correctly NOT reported.
+    """
+    lines = text.splitlines()
+    crons: list[str] = []
+
+    in_on = False
+    on_indent = 0
+    in_schedule = False
+    schedule_indent = 0
+
+    for raw in lines:
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        indent = _indent_of(raw)
+
+        if not in_on:
+            # Top-level `on:` — also accept the quoted forms people use to
+            # dodge the YAML-boolean footgun.
+            if indent == 0 and re.match(r"""^(on|"on"|'on')\s*:""", stripped):
+                in_on = True
+                on_indent = indent
+            continue
+
+        # Leaving the `on:` block returns us to scanning for it again.
+        if indent <= on_indent:
+            in_on = False
+            in_schedule = False
+            if indent == 0 and re.match(r"""^(on|"on"|'on')\s*:""", stripped):
+                in_on = True
+                on_indent = indent
+            continue
+
+        if not in_schedule:
+            if re.match(r"^schedule\s*:", stripped):
+                in_schedule = True
+                schedule_indent = indent
+            continue
+
+        if indent <= schedule_indent:
+            in_schedule = False
+            if re.match(r"^schedule\s*:", stripped):
+                in_schedule = True
+                schedule_indent = indent
+            continue
+
+        match = re.match(r"^-\s*cron\s*:\s*(.+)$", stripped)
+        if match:
+            value = match.group(1).strip()
+            # Strip a trailing comment, but only outside quotes.
+            if value[:1] in ("'", '"'):
+                closing = value.find(value[0], 1)
+                if closing != -1:
+                    value = value[1:closing]
+            else:
+                value = value.split("#", 1)[0].strip()
+            if value:
+                crons.append(value)
+
+    return crons
+
+
+def discover_scheduled_workflows(workflows_dir: Path) -> list[tuple[str, list[str]]]:
+    """[(filename, [cron, ...])] for every workflow with a real `schedule:`.
+
+    Only the top level of the directory is scanned — `.github/workflows/disabled/`
+    is not executed by GitHub and must not be monitored.
+    """
+    found: list[tuple[str, list[str]]] = []
+    for path in sorted(workflows_dir.glob("*.y*ml")):
+        if not path.is_file():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            print(f"::warning::cannot read {path}: {exc}", file=sys.stderr)
+            continue
+        crons = extract_cron_expressions(text)
+        if crons:
+            found.append((path.name, crons))
+    return found
+
+
+# ── GitHub queries ────────────────────────────────────────────────────────
+
+def _gh(args: list[str]) -> str:
+    result = subprocess.run(
+        ["gh", *args], capture_output=True, text=True, check=False
+    )
+    if result.returncode != 0:
+        print(f"::warning::gh {' '.join(args)} failed: {result.stderr.strip()}", file=sys.stderr)
+        return ""
+    return result.stdout.strip()
+
+
+def workflow_states(repo: str) -> dict[str, str]:
+    """{filename: state} — state is active / disabled_manually / disabled_inactivity."""
+    raw = _gh([
+        "api", f"repos/{repo}/actions/workflows", "--paginate",
+        "--jq", ".workflows[] | [.path, .state] | @tsv",
+    ])
+    states: dict[str, str] = {}
+    for line in raw.splitlines():
+        if "\t" not in line:
+            continue
+        path, state = line.split("\t", 1)
+        states[Path(path).name] = state.strip()
+    return states
+
+
+def last_success(repo: str, workflow: str) -> dt.datetime | None:
+    """Most recent successful run triggered by schedule or workflow_dispatch.
+
+    Status and event are filtered server-side, so pagination can't hide an old
+    success behind a wall of recent push runs, and in-progress runs (whose
+    `conclusion` is null) are never mistaken for anything.
+    """
+    newest: dt.datetime | None = None
+    for event in SUCCESS_EVENTS:
+        raw = _gh([
+            "run", "list", "--repo", repo, "--workflow", workflow,
+            "--event", event, "--status", "success", "--limit", "1",
+            "--json", "createdAt", "--jq", ".[0].createdAt // empty",
+        ])
+        if not raw:
+            continue
+        stamp = dt.datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        if newest is None or stamp > newest:
+            newest = stamp
+    return newest
+
+
+def has_any_run(repo: str, workflow: str) -> bool:
+    raw = _gh([
+        "run", "list", "--repo", repo, "--workflow", workflow, "--limit", "1",
+        "--json", "databaseId", "--jq", ".[0].databaseId // empty",
+    ])
+    return bool(raw)
+
+
+# ── Reporting ─────────────────────────────────────────────────────────────
+
+def humanize(seconds: int) -> str:
+    if seconds < 3600:
+        return f"{seconds // 60}m"
+    if seconds < 86400:
+        return f"{seconds // 3600}h"
+    return f"{seconds // 86400}d"
+
+
+def evaluate(repo: str, workflows_dir: Path, now: dt.datetime) -> list[dict]:
+    states = workflow_states(repo)
+    results: list[dict] = []
+
+    for filename, crons in discover_scheduled_workflows(workflows_dir):
+        try:
+            interval = min(CronSchedule(c).interval_seconds() for c in crons)
+        except CronError as exc:
+            results.append({
+                "workflow": filename, "level": "warn",
+                "detail": f"unparseable cron ({exc})",
+            })
+            continue
+
+        threshold = max(STALE_MULTIPLIER * interval, STALE_FLOOR_SECONDS)
+        state = states.get(filename, "active")
+
+        # GitHub disables scheduled workflows after 60 days of repo inactivity.
+        # That is silent rot of exactly the kind this check exists to catch.
+        if state == "disabled_inactivity":
+            results.append({
+                "workflow": filename, "level": "stale",
+                "detail": "disabled by GitHub for repo inactivity — schedule is not running",
+            })
+            continue
+        if state == "disabled_manually":
+            results.append({
+                "workflow": filename, "level": "info",
+                "detail": "disabled manually — not monitored",
+            })
+            continue
+
+        success_at = last_success(repo, filename)
+        if success_at is None:
+            if not has_any_run(repo, filename):
+                # Newly added schedule that has not had a chance to fire yet.
+                results.append({
+                    "workflow": filename, "level": "info",
+                    "detail": f"no runs yet (every {humanize(interval)})",
+                })
+            else:
+                results.append({
+                    "workflow": filename, "level": "stale",
+                    "detail": f"has run but NEVER succeeded (every {humanize(interval)})",
+                })
+            continue
+
+        age = int((now - success_at).total_seconds())
+        if age > threshold:
+            results.append({
+                "workflow": filename, "level": "stale",
+                "detail": (
+                    f"last success {humanize(age)} ago, "
+                    f"expected every {humanize(interval)}"
+                ),
+            })
+        else:
+            results.append({
+                "workflow": filename, "level": "ok",
+                "detail": f"last success {humanize(age)} ago (every {humanize(interval)})",
+            })
+
+    return results
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=os.environ.get("REPO", ""))
+    parser.add_argument("--workflows-dir", default=".github/workflows")
+    parser.add_argument("--now", default=None, help="ISO8601 override, for testing")
+    parser.add_argument("--format", choices=("text", "github"), default="text")
+    args = parser.parse_args()
+
+    if not args.repo:
+        print("error: --repo (or $REPO) is required", file=sys.stderr)
+        return 2
+
+    now = (
+        dt.datetime.fromisoformat(args.now.replace("Z", "+00:00"))
+        if args.now
+        else dt.datetime.now(dt.timezone.utc)
+    )
+
+    results = evaluate(args.repo, Path(args.workflows_dir), now)
+
+    icon = {"ok": "✅", "stale": "🚨", "warn": "⚠️", "info": "ℹ️"}
+    for entry in results:
+        print(f"  {icon[entry['level']]} {entry['workflow']}: {entry['detail']}")
+
+    stale = [e for e in results if e["level"] == "stale"]
+    warn = [e for e in results if e["level"] == "warn"]
+
+    if stale:
+        status = f"🚨 {len(stale)} stale"
+        detail = "; ".join(f"{e['workflow']} — {e['detail']}" for e in stale)
+    elif warn:
+        status = f"⚠️ {len(warn)} unparseable"
+        detail = "; ".join(f"{e['workflow']} — {e['detail']}" for e in warn)
+    else:
+        status = f"✅ {len(results)} scheduled OK"
+        detail = ""
+
+    print(f"\nstatus: {status}")
+    print(f"detail: {detail}")
+
+    if args.format == "github":
+        output_path = os.environ.get("GITHUB_OUTPUT")
+        if output_path:
+            with open(output_path, "a", encoding="utf-8") as handle:
+                handle.write(f"check6_status={status}\n")
+                handle.write(f"check6_detail={detail}\n")
+        print(json.dumps({"status": status, "detail": detail, "results": results}))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/scheduled-workflow-staleness.py
+++ b/.github/scripts/scheduled-workflow-staleness.py
@@ -256,25 +256,37 @@ def extract_cron_expressions(text: str) -> list[str]:
     return crons
 
 
-def discover_scheduled_workflows(workflows_dir: Path) -> list[tuple[str, list[str]]]:
-    """[(filename, [cron, ...])] for every workflow with a real `schedule:`.
+def workflow_files(workflows_dir: Path) -> list[Path]:
+    """Every workflow file at the top level of `workflows_dir`.
 
-    Only the top level of the directory is scanned — `.github/workflows/disabled/`
-    is not executed by GitHub and must not be monitored.
+    Only the top level is scanned — `.github/workflows/disabled/` is not
+    executed by GitHub and must not be monitored.
+    """
+    return [p for p in sorted(workflows_dir.glob("*.y*ml")) if p.is_file()]
+
+
+def discover_scheduled_workflows(
+    workflows_dir: Path,
+) -> tuple[list[tuple[str, list[str]]], list[tuple[str, str]]]:
+    """([(filename, [cron, ...])], [(filename, reason)]) for the workflow dir.
+
+    The second element lists files that could not be read. An unreadable file
+    is a workflow this check is *blind to*, not a workflow that is fine, so it
+    is returned for the caller to surface as a `warn` rather than dropped into
+    stderr where a green summary line would paper over it.
     """
     found: list[tuple[str, list[str]]] = []
-    for path in sorted(workflows_dir.glob("*.y*ml")):
-        if not path.is_file():
-            continue
+    unreadable: list[tuple[str, str]] = []
+    for path in workflow_files(workflows_dir):
         try:
             text = path.read_text(encoding="utf-8")
         except OSError as exc:
-            print(f"::warning::cannot read {path}: {exc}", file=sys.stderr)
+            unreadable.append((path.name, f"cannot read workflow file: {exc}"))
             continue
         crons = extract_cron_expressions(text)
         if crons:
             found.append((path.name, crons))
-    return found
+    return found, unreadable
 
 
 # ── GitHub queries ────────────────────────────────────────────────────────
@@ -354,7 +366,11 @@ def evaluate(repo: str, workflows_dir: Path, now: dt.datetime) -> list[dict]:
     states = workflow_states(repo)
     results: list[dict] = []
 
-    for filename, crons in discover_scheduled_workflows(workflows_dir):
+    scheduled, unreadable = discover_scheduled_workflows(workflows_dir)
+    for filename, reason in unreadable:
+        results.append({"workflow": filename, "level": "warn", "detail": reason})
+
+    for filename, crons in scheduled:
         try:
             interval = min(CronSchedule(c).interval_seconds() for c in crons)
         except CronError as exc:
@@ -435,6 +451,18 @@ def main() -> int:
         print(f"error: --workflows-dir {workflows_dir} is not a directory", file=sys.stderr)
         return 2
 
+    # A directory that exists but holds no workflow files is the same blindness
+    # wearing a different hat: a sparse/partial checkout, or a path that points
+    # at the wrong directory. Nothing was scanned, so there is no result to
+    # report — say so instead of scoring an empty scan as a pass.
+    if not workflow_files(workflows_dir):
+        print(
+            f"error: --workflows-dir {workflows_dir} contains no workflow files "
+            "(*.yml / *.yaml) — nothing was scanned",
+            file=sys.stderr,
+        )
+        return 2
+
     now = (
         dt.datetime.fromisoformat(args.now.replace("Z", "+00:00"))
         if args.now
@@ -464,6 +492,13 @@ def main() -> int:
     elif warn:
         status = f"⚠️ {len(warn)} unparseable"
         detail = "; ".join(f"{e['workflow']} — {e['detail']}" for e in warn)
+    elif not results:
+        # The directory held workflow files but not one of them declares a
+        # `schedule:`. Given this check exists because scheduled jobs rot
+        # silently, "nothing to report" is far more likely to be a scanner
+        # regression than a true absence — never dress it up as a green tick.
+        status = "⚠️ no scheduled workflows found"
+        detail = f"scanned {workflows_dir} but found no workflow with a schedule: block"
     else:
         status = f"✅ {len(results)} scheduled OK"
         detail = ""

--- a/.github/scripts/test_scheduled_workflow_staleness.py
+++ b/.github/scripts/test_scheduled_workflow_staleness.py
@@ -271,8 +271,13 @@ class MainDirectoryGuards(unittest.TestCase):
                 stdout=out,
             )
         self.assertEqual(code, 0)
-        self.assertIn("no scheduled workflows found", out.getvalue())
-        self.assertNotIn("✅", out.getvalue())
+        # Assert on the summary line specifically — a per-entry line elsewhere
+        # in stdout must not be able to pass or fail this by accident.
+        status_line = next(
+            line for line in out.getvalue().splitlines() if line.startswith("status:")
+        )
+        self.assertIn("no scheduled workflows found", status_line)
+        self.assertNotIn("✅", status_line)
 
     def test_missing_repo_exits_2(self):
         self.assertEqual(_run_main(["--repo", ""], env={"REPO": ""}), 2)

--- a/.github/scripts/test_scheduled_workflow_staleness.py
+++ b/.github/scripts/test_scheduled_workflow_staleness.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Tests for scheduled-workflow-staleness.py.
+
+Stdlib `unittest` only — the runner is not guaranteed to have pytest, for the
+same reason the script under test hand-rolls its YAML scan instead of relying
+on PyYAML.
+
+Run with:
+    python3 .github/scripts/test_scheduled_workflow_staleness.py
+"""
+
+from __future__ import annotations
+
+import contextlib
+import datetime as dt
+import importlib.util
+import io
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# The script's filename has hyphens, so it is not importable as a module name.
+_SCRIPT = Path(__file__).with_name("scheduled-workflow-staleness.py")
+_spec = importlib.util.spec_from_file_location("staleness", _SCRIPT)
+assert _spec and _spec.loader
+sws = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(sws)
+
+
+class ExtractCronExpressions(unittest.TestCase):
+    def test_nested_indent_style(self):
+        text = """name: Nightly
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+"""
+        self.assertEqual(sws.extract_cron_expressions(text), ["0 4 * * *"])
+
+    def test_same_indent_as_schedule_key(self):
+        """F3: a sequence item may sit at the SAME indent as the key owning it.
+
+        This is valid YAML. The pre-fix terminator (`indent <= schedule_indent`)
+        ended the block on the very first `- cron:` line and returned [], making
+        any workflow written this way invisible to the staleness check.
+        """
+        text = """name: Weekly
+on:
+  schedule:
+  - cron: '0 4 * * 0'
+  - cron: '30 5 * * 1'
+  push:
+    branches: [develop]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+"""
+        self.assertEqual(
+            sws.extract_cron_expressions(text), ["0 4 * * 0", "30 5 * * 1"]
+        )
+
+    def test_same_indent_block_still_terminates_on_sibling_key(self):
+        """The relaxed terminator must not swallow crons from outside `schedule:`."""
+        text = """on:
+  schedule:
+  - cron: '0 4 * * 0'
+  push:
+    branches: [develop]
+jobs:
+  build:
+    steps:
+      - cron: 'not a schedule entry'
+"""
+        self.assertEqual(sws.extract_cron_expressions(text), ["0 4 * * 0"])
+
+    def test_commented_out_cron_is_ignored(self):
+        text = """on:
+  schedule:
+    # - cron: '0 4 * * *'
+    - cron: '0 6 * * *'
+"""
+        self.assertEqual(sws.extract_cron_expressions(text), ["0 6 * * *"])
+
+    def test_quoted_on_key_is_recognised(self):
+        """YAML 1.1 parses bare `on` as True, so people quote it to dodge that."""
+        for key in ('"on"', "'on'"):
+            with self.subTest(key=key):
+                text = f"""{key}:
+  schedule:
+    - cron: '15 3 * * *'
+"""
+                self.assertEqual(sws.extract_cron_expressions(text), ["15 3 * * *"])
+
+    def test_trailing_comment_is_stripped(self):
+        text = """on:
+  schedule:
+    - cron: 0 4 * * *  # nightly
+    - cron: "0 5 * * *"  # also nightly
+"""
+        self.assertEqual(
+            sws.extract_cron_expressions(text), ["0 4 * * *", "0 5 * * *"]
+        )
+
+    def test_no_schedule_block(self):
+        text = """on:
+  push:
+    branches: [develop]
+"""
+        self.assertEqual(sws.extract_cron_expressions(text), [])
+
+
+class DiscoverScheduledWorkflows(unittest.TestCase):
+    def test_separates_scheduled_from_unscheduled(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "nightly.yml").write_text(
+                "on:\n  schedule:\n    - cron: '0 4 * * *'\n", encoding="utf-8"
+            )
+            (root / "onpush.yaml").write_text(
+                "on:\n  push:\n    branches: [develop]\n", encoding="utf-8"
+            )
+            # A `disabled/` subdirectory is not executed by GitHub and must not
+            # be monitored — only the top level is scanned.
+            nested = root / "disabled"
+            nested.mkdir()
+            (nested / "old.yml").write_text(
+                "on:\n  schedule:\n    - cron: '0 1 * * *'\n", encoding="utf-8"
+            )
+
+            found, unreadable = sws.discover_scheduled_workflows(root)
+
+        self.assertEqual(found, [("nightly.yml", ["0 4 * * *"])])
+        self.assertEqual(unreadable, [])
+
+    def test_unreadable_file_is_reported_not_dropped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            bad = root / "locked.yml"
+            bad.write_text(
+                "on:\n  schedule:\n    - cron: '0 4 * * *'\n", encoding="utf-8"
+            )
+            bad.chmod(0o000)
+            try:
+                found, unreadable = sws.discover_scheduled_workflows(root)
+            finally:
+                bad.chmod(0o644)
+
+        if not unreadable:  # running as root, where chmod 000 does not deny reads
+            self.skipTest("cannot make a file unreadable as this user")
+        self.assertEqual(found, [])
+        self.assertEqual([name for name, _ in unreadable], ["locked.yml"])
+
+    def test_missing_directory_yields_nothing(self):
+        found, unreadable = sws.discover_scheduled_workflows(Path("/nonexistent/xyz"))
+        self.assertEqual(found, [])
+        self.assertEqual(unreadable, [])
+
+
+class WorkflowFiles(unittest.TestCase):
+    def test_empty_directory(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual(sws.workflow_files(Path(tmp)), [])
+
+    def test_only_yaml_files_count(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "a.yml").write_text("on: {}\n", encoding="utf-8")
+            (root / "b.yaml").write_text("on: {}\n", encoding="utf-8")
+            (root / "README.md").write_text("nope\n", encoding="utf-8")
+            names = [p.name for p in sws.workflow_files(root)]
+        self.assertEqual(names, ["a.yml", "b.yaml"])
+
+
+class GhFailureHandling(unittest.TestCase):
+    """F1: a failed `gh` call must never be indistinguishable from 'no data'."""
+
+    @staticmethod
+    @contextlib.contextmanager
+    def _gh_returning(returncode: int, stdout: str = "", stderr: str = ""):
+        original = subprocess.run
+
+        def fake_run(*_args, **_kwargs):
+            return subprocess.CompletedProcess(
+                args=["gh"], returncode=returncode, stdout=stdout, stderr=stderr
+            )
+
+        subprocess.run = fake_run
+        try:
+            yield
+        finally:
+            subprocess.run = original
+
+    def test_gh_raises_on_nonzero_exit(self):
+        with self._gh_returning(1, stderr="HTTP 401: Bad credentials"):
+            with self.assertRaises(sws.GhError) as ctx:
+                sws._gh(["api", "repos/o/r/actions/workflows"])
+        self.assertIn("Bad credentials", str(ctx.exception))
+
+    def test_has_any_run_raises_rather_than_returning_false(self):
+        """The false-green this guards: gh fails -> False -> 'no runs yet'."""
+        with self._gh_returning(1, stderr="rate limit exceeded"):
+            with self.assertRaises(sws.GhError):
+                sws.has_any_run("o/r", "nightly.yml")
+
+    def test_last_success_raises_rather_than_returning_none(self):
+        """The bogus alert this guards: gh fails -> None -> 'NEVER succeeded'."""
+        with self._gh_returning(1, stderr="rate limit exceeded"):
+            with self.assertRaises(sws.GhError):
+                sws.last_success("o/r", "nightly.yml")
+
+    def test_gh_success_returns_stdout(self):
+        with self._gh_returning(0, stdout="  12345\n"):
+            self.assertTrue(sws.has_any_run("o/r", "nightly.yml"))
+
+    def test_evaluate_propagates_gh_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "nightly.yml").write_text(
+                "on:\n  schedule:\n    - cron: '0 4 * * *'\n", encoding="utf-8"
+            )
+            with self._gh_returning(1, stderr="HTTP 403"):
+                with self.assertRaises(sws.GhError):
+                    sws.evaluate("o/r", root, dt.datetime.now(dt.timezone.utc))
+
+    def test_main_exits_nonzero_and_writes_no_output_on_gh_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "nightly.yml").write_text(
+                "on:\n  schedule:\n    - cron: '0 4 * * *'\n", encoding="utf-8"
+            )
+            output = root / "gh_output"
+            output.write_text("", encoding="utf-8")
+            code = _run_main(
+                ["--repo", "o/r", "--workflows-dir", str(root), "--format", "github"],
+                env={"GITHUB_OUTPUT": str(output)},
+                gh=self._gh_returning(1, stderr="HTTP 403"),
+            )
+            self.assertEqual(code, 1)
+            # No check6_* written -> repo-health.yml renders "check did not report".
+            self.assertEqual(output.read_text(encoding="utf-8"), "")
+
+
+class MainDirectoryGuards(unittest.TestCase):
+    def test_missing_directory_exits_2(self):
+        self.assertEqual(
+            _run_main(["--repo", "o/r", "--workflows-dir", "/nonexistent/xyz"]), 2
+        )
+
+    def test_empty_directory_exits_2(self):
+        """F2: a dir that exists but holds no workflow files scanned nothing."""
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual(
+                _run_main(["--repo", "o/r", "--workflows-dir", tmp]), 2
+            )
+
+    def test_directory_with_no_scheduled_workflow_is_not_green(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "onpush.yml").write_text(
+                "on:\n  push:\n    branches: [develop]\n", encoding="utf-8"
+            )
+            out = io.StringIO()
+            code = _run_main(
+                ["--repo", "o/r", "--workflows-dir", tmp],
+                gh=GhFailureHandling._gh_returning(0, stdout=""),
+                stdout=out,
+            )
+        self.assertEqual(code, 0)
+        self.assertIn("no scheduled workflows found", out.getvalue())
+        self.assertNotIn("✅", out.getvalue())
+
+    def test_missing_repo_exits_2(self):
+        self.assertEqual(_run_main(["--repo", ""], env={"REPO": ""}), 2)
+
+
+def _run_main(argv, env=None, gh=None, stdout=None):
+    """Invoke the script's main() with argv/env overrides, capturing output."""
+    original_argv = sys.argv
+    original_environ = dict(sws.os.environ)
+    sys.argv = ["scheduled-workflow-staleness.py", *argv]
+    if env:
+        sws.os.environ.update(env)
+    sink = stdout if stdout is not None else io.StringIO()
+    try:
+        errsink = io.StringIO()
+        with contextlib.redirect_stdout(sink), contextlib.redirect_stderr(errsink):
+            if gh is not None:
+                with gh:
+                    return sws.main()
+            return sws.main()
+    finally:
+        sys.argv = original_argv
+        sws.os.environ.clear()
+        sws.os.environ.update(original_environ)
+
+
+class CronSchedules(unittest.TestCase):
+    def test_weekly_interval(self):
+        self.assertEqual(
+            sws.CronSchedule("0 4 * * 0").interval_seconds(), 7 * 24 * 3600
+        )
+
+    def test_daily_interval(self):
+        self.assertEqual(sws.CronSchedule("0 4 * * *").interval_seconds(), 24 * 3600)
+
+    def test_bad_expression_raises(self):
+        with self.assertRaises(sws.CronError):
+            sws.CronSchedule("0 4 * *")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/workflows/repo-health.yml
+++ b/.github/workflows/repo-health.yml
@@ -293,6 +293,11 @@ jobs:
       # over five months without a single alert.
       - name: Check 6 — stale scheduled workflows
         id: staleness
+        # Independent of checks 1-5: those run under `set -e`, and without
+        # always() a failure there would skip this step entirely, dropping
+        # staleness from a report that is otherwise built to survive a
+        # partial run.
+        if: always()
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/repo-health.yml
+++ b/.github/workflows/repo-health.yml
@@ -294,9 +294,14 @@ jobs:
       # The staleness scanner parses workflow YAML by hand, so a regression in
       # it fails *silently* — it just stops finding crons and the report goes
       # green. No other workflow runs these tests, so they run here, next to
-      # the only consumer, and go red rather than letting Check 6 report on a
-      # scanner nobody verified.
+      # the only consumer.
+      #
+      # Deliberately NOT continue-on-error: a scanner that fails its own tests
+      # is not a monitor, and the job should go red. Check 6 below is gated on
+      # this passing, so the report renders "check did not report" for
+      # staleness rather than a verdict from an unverified scanner.
       - name: Check 6a — self-test the staleness scanner
+        id: staleness_selftest
         if: always()
         run: python3 .github/scripts/test_scheduled_workflow_staleness.py
 
@@ -305,8 +310,10 @@ jobs:
         # Independent of checks 1-5: those run under `set -e`, and without
         # always() a failure there would skip this step entirely, dropping
         # staleness from a report that is otherwise built to survive a
-        # partial run.
-        if: always()
+        # partial run. The one thing it *does* depend on is its own self-test
+        # — skipping here writes no output, which the report step renders as
+        # "check did not report" instead of trusting a broken scanner.
+        if: always() && steps.staleness_selftest.outcome == 'success'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/repo-health.yml
+++ b/.github/workflows/repo-health.yml
@@ -327,9 +327,9 @@ jobs:
           # A check step that died leaves its output empty. Render that as an
           # explicit "did not run" rather than a blank cell, which reads as OK.
           for n in 1 2 3 4 5 6; do
-            eval "current=\${CHECK${n}_STATUS}"
-            if [ -z "$current" ]; then
-              eval "CHECK${n}_STATUS='❓ check did not report'"
+            var="CHECK${n}_STATUS"
+            if [ -z "${!var}" ]; then
+              printf -v "$var" '%s' '❓ check did not report'
             fi
           done
 

--- a/.github/workflows/repo-health.yml
+++ b/.github/workflows/repo-health.yml
@@ -25,6 +25,11 @@ jobs:
       REPO: ${{ github.repository }}
 
     steps:
+      # Needed by Check 6, which reads .github/workflows/*.yml to discover
+      # which workflows have a `schedule:` trigger.
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Run health checks
         id: health
         run: |
@@ -218,25 +223,51 @@ jobs:
           fi
 
           # ── Check 5: Workflow failure rate (last 24h) ─────────────────────────
+          # Catches workflows that fail *often*. By construction it cannot catch
+          # a workflow that fails rarely-but-always — a weekly cron produces at
+          # most one failure per 24h window and can never cross the threshold
+          # below. That blind spot is Check 6's job.
           echo ""
           echo "--- Check 5: Workflow failure rate ---"
 
           check5_status="✅ OK"
           check5_detail=""
+          noisy_count=0
 
-          for workflow in agent-validation.yml ai-review.yml claude-code.yml auto-rebase-on-develop.yml; do
-            failures=$(gh run list --workflow="$workflow" --repo "$REPO" --limit 50 \
-              --json conclusion,createdAt \
-              --jq "now as \$now | [.[] | select(.conclusion == \"failure\" and (\$now - (.createdAt | fromdateiso8601)) < 86400)] | length" \
+          # Discover workflows instead of hardcoding a watch list, so anything
+          # added later is covered automatically. Previously this iterated four
+          # named files and every other workflow in the repo was unmonitored.
+          all_workflows=$(gh api "repos/$REPO/actions/workflows" --paginate \
+            --jq '.workflows[] | select(.state == "active") | .path' \
+            2>/dev/null | sed 's|.*/||' | sort -u)
+
+          if [ -z "$all_workflows" ]; then
+            check5_status="⚠️ Could not enumerate workflows"
+          fi
+
+          for workflow in $all_workflows; do
+            # --status failure filters server-side, so `--limit` counts failures
+            # rather than a mix of runs, and in-progress runs (whose conclusion
+            # is null) can never be miscounted as failures.
+            failures=$(gh run list --workflow="$workflow" --repo "$REPO" \
+              --status failure --limit 100 \
+              --json createdAt \
+              --jq "now as \$now | [.[] | select((\$now - (.createdAt | fromdateiso8601)) < 86400)] | length" \
               2>/dev/null || echo "0")
-            echo "  $workflow: $failures failure(s) in 24h"
+            echo "  $workflow: ${failures:-0} failure(s) in 24h"
             if [ "${failures:-0}" -gt 3 ]; then
               check5_status="⚠️ High failure rate"
               check5_detail="$check5_detail $workflow: ${failures}/24h"
-            else
-              check5_detail="$check5_detail $workflow: ${failures:-0}/24h"
+              noisy_count=$((noisy_count + 1))
             fi
           done
+
+          # Only offenders go in the detail column — listing every workflow in
+          # the repo would swamp the report table.
+          workflow_total=$(echo "$all_workflows" | grep -c . || echo "0")
+          if [ "$noisy_count" -eq 0 ] && [ -n "$all_workflows" ]; then
+            check5_detail="${workflow_total} workflows checked, none over 3 failures/24h"
+          fi
 
           # ── Write outputs for report step ─────────────────────────────────────
           {
@@ -253,7 +284,30 @@ jobs:
             echo "check5_detail=$check5_detail"
           } >> "$GITHUB_OUTPUT"
 
+      # ── Check 6: Stale scheduled workflows ──────────────────────────────────
+      # Orthogonal to Check 5's failure *rate*: this asks when each scheduled
+      # workflow's schedule last actually succeeded, and alerts when that is
+      # older than a multiple of its own cron interval. This is the check that
+      # catches a low-frequency job failing 100% of the time — the failure mode
+      # that let update-catalogs.yml rot through 23 consecutive scheduled runs
+      # over five months without a single alert.
+      - name: Check 6 — stale scheduled workflows
+        id: staleness
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          echo "--- Check 6: Stale scheduled workflows ---"
+          python3 .github/scripts/scheduled-workflow-staleness.py \
+            --repo "$REPO" \
+            --workflows-dir .github/workflows \
+            --format github
+
       - name: Post health report to pinned issue
+        # Runs even if an earlier check step failed, so a partial report still
+        # reaches the issue instead of the whole report vanishing.
+        if: always()
         env:
           GH_TOKEN: ${{ github.token }}
           TIMESTAMP: ${{ steps.health.outputs.timestamp }}
@@ -267,7 +321,20 @@ jobs:
           CHECK4_DETAIL: ${{ steps.health.outputs.check4_detail }}
           CHECK5_STATUS: ${{ steps.health.outputs.check5_status }}
           CHECK5_DETAIL: ${{ steps.health.outputs.check5_detail }}
+          CHECK6_STATUS: ${{ steps.staleness.outputs.check6_status }}
+          CHECK6_DETAIL: ${{ steps.staleness.outputs.check6_detail }}
         run: |
+          # A check step that died leaves its output empty. Render that as an
+          # explicit "did not run" rather than a blank cell, which reads as OK.
+          for n in 1 2 3 4 5 6; do
+            eval "current=\${CHECK${n}_STATUS}"
+            if [ -z "$current" ]; then
+              eval "CHECK${n}_STATUS='❓ check did not report'"
+            fi
+          done
+
+          TIMESTAMP="${TIMESTAMP:-$(date -u '+%Y-%m-%d %H:%M UTC')}"
+
           # Build report body
           {
             echo '<!-- automation-health-report -->'
@@ -280,30 +347,64 @@ jobs:
             echo "| Rebase conflicts | ${CHECK3_STATUS} | ${CHECK3_DETAIL} |"
             echo "| Orphaned agent-work | ${CHECK4_STATUS} | ${CHECK4_DETAIL} |"
             echo "| Workflow failures (24h) | ${CHECK5_STATUS} | ${CHECK5_DETAIL} |"
+            echo "| Stale scheduled workflows | ${CHECK6_STATUS} | ${CHECK6_DETAIL} |"
             echo ''
             echo '---'
             echo '*Auto-generated every 4h by [repo-health.yml](../actions/workflows/repo-health.yml). Trigger manually via [Actions tab](../actions/workflows/repo-health.yml).*'
           } > /tmp/health_report.md
 
-          # Find or create the pinned Automation Health issue
+          # Find or create the pinned Automation Health issue.
+          #
+          # This block used to swallow every failure with `2>/dev/null || echo ""`
+          # and then print "posted to issue #unknown" while exiting green — so
+          # the report was never actually posted anywhere, and the monitor
+          # reported SUCCESS every 4h for five months while findings piled up
+          # in a log nobody reads. Failures here are now fatal and loud: if the
+          # report cannot reach the issue, this workflow is not monitoring
+          # anything and must go red.
           HEALTH_ISSUE=$(gh issue list --repo "$REPO" \
             --search "Automation Health Monitor in:title" \
             --state open --limit 1 \
-            --json number --jq '.[0].number' 2>/dev/null || echo "")
+            --json number --jq '.[0].number // empty')
 
           if [ -z "$HEALTH_ISSUE" ]; then
-            echo "Creating Automation Health issue..."
-            HEALTH_ISSUE=$(gh issue create \
-              --repo "$REPO" \
-              --title "Automation Health Monitor" \
-              --label "automation,monitoring" \
-              --body-file /tmp/health_report.md \
-              --jq '.number' 2>/dev/null || echo "")
-            echo "Created issue #$HEALTH_ISSUE"
+            echo "No open Automation Health issue found — creating one."
+            # `gh issue create` prints the issue URL on stdout; it has no --jq
+            # flag (passing one made the whole command fail). Take the trailing
+            # path component as the issue number.
+            if ! ISSUE_URL=$(gh issue create \
+                  --repo "$REPO" \
+                  --title "Automation Health Monitor" \
+                  --body-file /tmp/health_report.md); then
+              echo "::error::Failed to create the Automation Health issue — health report has nowhere to go."
+              exit 1
+            fi
+            HEALTH_ISSUE="${ISSUE_URL##*/}"
+            echo "Created issue #$HEALTH_ISSUE ($ISSUE_URL)"
+
+            # Labels are applied AFTER creation, one at a time, and are never
+            # fatal. `--label` on a label that does not exist in the repo fails
+            # the create outright; issue existence must not depend on repo
+            # label configuration.
+            for wanted in automation monitoring; do
+              gh issue edit "$HEALTH_ISSUE" --repo "$REPO" --add-label "$wanted" >/dev/null 2>&1 \
+                || echo "::notice::Label '$wanted' not applied (create it in the repo to categorise this issue)."
+            done
           else
             echo "Updating issue #$HEALTH_ISSUE..."
-            gh issue edit "$HEALTH_ISSUE" --repo "$REPO" \
-              --body-file /tmp/health_report.md 2>/dev/null || true
+            if ! gh issue edit "$HEALTH_ISSUE" --repo "$REPO" \
+                  --body-file /tmp/health_report.md; then
+              echo "::error::Failed to update issue #$HEALTH_ISSUE with the health report."
+              exit 1
+            fi
           fi
 
-          echo "Health report posted to issue #${HEALTH_ISSUE:-unknown}"
+          # Guard against a parse surprise leaving a non-numeric value behind.
+          case "$HEALTH_ISSUE" in
+            ''|*[!0-9]*)
+              echo "::error::Could not determine the health issue number (got '${HEALTH_ISSUE}')."
+              exit 1
+              ;;
+          esac
+
+          echo "Health report posted to issue #${HEALTH_ISSUE}"

--- a/.github/workflows/repo-health.yml
+++ b/.github/workflows/repo-health.yml
@@ -291,6 +291,15 @@ jobs:
       # catches a low-frequency job failing 100% of the time — the failure mode
       # that let update-catalogs.yml rot through 23 consecutive scheduled runs
       # over five months without a single alert.
+      # The staleness scanner parses workflow YAML by hand, so a regression in
+      # it fails *silently* — it just stops finding crons and the report goes
+      # green. No other workflow runs these tests, so they run here, next to
+      # the only consumer, and go red rather than letting Check 6 report on a
+      # scanner nobody verified.
+      - name: Check 6a — self-test the staleness scanner
+        if: always()
+        run: python3 .github/scripts/test_scheduled_workflow_staleness.py
+
       - name: Check 6 — stale scheduled workflows
         id: staleness
         # Independent of checks 1-5: those run under `set -e`, and without


### PR DESCRIPTION
## Summary

`repo-health.yml` reported SUCCESS every 4 hours for five months while `update-catalogs.yml` failed **all 23** of its scheduled runs (2026-03-08 → 2026-08-09, zero successes ever) and the shipped skin catalog went stale for four months.

Investigating turned up **three** defects, not two. The third is the one that made the other two moot.

## Defect 1 (new) — the report sink has never worked

The pinned "Automation Health Monitor" issue **does not exist and never has**. From the most recent run ([31294602744](https://github.com/Provenance-Emu/Provenance/actions/runs/31294602744)):

```
Creating Automation Health issue...
Created issue #
Health report posted to issue #unknown
```

Two causes, both swallowed by `2>/dev/null || echo ""`:

- `gh issue create` has **no `--jq` flag** (it prints the issue URL, not JSON). Passing `--jq '.number'` failed the whole command.
- `--label "automation,monitoring"` — neither label exists in this repo, which fails the create outright.

The step then exited **green**. This means findings that are firing *right now* have been going nowhere for five months — the same run above reported `⚠️ 7 orphaned agent-work issues` and `⚠️ High failure rate`. Fixing checks 5/6 without fixing this would have delivered nothing visible.

**Fixed:** capture the URL and strip the trailing number; create with no `--label` and apply labels afterwards, individually and non-fatally, so issue existence never depends on repo label config; failures to post are now `::error::` + `exit 1` (a monitor that can't report should go red); report step gets `if: always()` and renders `❓ check did not report` for any check whose output is empty, instead of a blank cell that reads as OK.

## Defect 2 — hardcoded watch list

Check 5 iterated four named workflows. Now discovers active workflows from the API. Also switched to `--status failure --limit 100` (server-side) — the old `--limit 50` counted *mixed* runs, so on a busy workflow the 24h window was truncated. Live proof: agent-validation.yml counted **4/24h** under the old query and **11/24h** under the new one. In-progress runs (`conclusion: null`) can no longer be miscounted.

## Defect 3 — the threshold is unreachable for low-frequency jobs

`cron: '0 4 * * 0'` runs once a week, so it can produce at most **one** failure in any 24h window and can never reach `> 3`. **A weekly job that fails 100% of the time is invisible to a failure-rate check by construction** — adding `update-catalogs.yml` to the list from defect 2 would still not have caught this.

Live confirmation of the blind spot, from the new dynamic check 5 run against this repo today:

```
update-catalogs.yml:  1 failure(s) in 24h     # failed 23/23 scheduled runs
update-changelog.yml: 0 failure(s) in 24h     # failed 100/100 runs, last one 6 days ago
```

Neither is anywhere near the threshold.

## New Check 6 — staleness, orthogonal to failure rate

Asks a different question: *when did this workflow's scheduled path last actually succeed?*

- Discovers workflows dynamically by scanning `.github/workflows/*.yml` for a real `schedule:` trigger — new scheduled workflows are covered automatically. Top level only (`disabled/` is not executed by GitHub).
- Derives each cron's interval by stepping minute-by-minute from a **fixed** reference instant and taking the median gap — no field analysis, so weekday-vs-day-of-month OR semantics and any expression added later just work, and the interval doesn't jitter between runs.
- Alerts when the last success is older than `max(2 × interval, 6h)`. The 6h floor absorbs GitHub's scheduler jitter on fast crons; those are well covered by check 5, which is kept for exactly that reason.
- Only `schedule` and `workflow_dispatch` successes count. **A green `push` run is not evidence the scheduled path works** — that is precisely how `consolidate-changelog.yml`'s cancelled cron run hid behind a passing `pull_request` run.
- Distinguishes "has run but NEVER succeeded" (alert) from "no runs yet" (info, for a newly added schedule), and alerts loudly on `disabled_inactivity` — GitHub auto-disabling a schedule after 60 days of repo inactivity is silent rot of exactly this kind.

## Verification

Local dry-run against the live repo (the check-6 logic is a standalone script, so it runs without the workflow):

```
✅ consolidate-changelog.yml: last success 12d ago (every 7d)
✅ copilot-review-poller.yml: last success 21m ago (every 10m)
✅ repo-health.yml: last success 45m ago (every 4h)
✅ update-catalogs.yml: last success 17m ago (every 7d)
🚨 update-changelog.yml: has run but NEVER succeeded (every 7d)
✅ validate-core-versions.yml: last success 5d ago (every 7d)
```

**Exactly one alert, and it's a true positive** — `update-changelog.yml` is weekly, 100 runs, **zero successes ever**. Same class of rot as update-catalogs, still unnoticed. (Out of scope here; filed separately.)

Counterfactual on the original bug: `update-catalogs.yml` has exactly **one** successful run in its entire history — the manual dispatch that verified 4954bb5dbd, 17 minutes before this dry-run. Before today it had zero, so check 6 would have alerted on its very first execution after 2026-03-08.

**The report renders**, built by running the actual report-body code from the workflow with real check-5/6 values (checks 1–4 taken verbatim from run 31294602744, since they mutate PRs):

| Check | Status | Details |
|-------|--------|---------|
| Stuck AI reviews | ✅ None |  |
| Stuck fixers | ✅ None |  |
| Rebase conflicts | ✅ None |  |
| Orphaned agent-work | ⚠️ 7 found |  #3318 (3436h) #3087 (3577h) #2571 (3748h) #2555 (3765h) #2543 (3765h) #2541 (3765h) #1944 (34921h) |
| Workflow failures (24h) | ⚠️ High failure rate |  agent-validation.yml: 11/24h |
| Stale scheduled workflows | 🚨 1 stale | update-changelog.yml — has run but NEVER succeeded (every 7d) |

Fallback path also verified — with check 2 and check 6 outputs forced empty:

```
| Stuck fixers | ❓ check did not report |  |
| Stale scheduled workflows | ❓ check did not report |  |
```

### Not verified by execution

The defect-1 sink fix is the **only** change in this PR not proven by running it. Verifying it needs a real repo to create an issue in, and I did not want to create the pinned issue on Provenance pre-merge. The evidence for it is code-level but concrete:

- `gh issue create --help` lists no `--jq` flag (confirmed on gh locally), and the live run log shows the command producing empty output and the step continuing green.
- `gh label list` confirms neither `automation` nor `monitoring` exists in this repo, so the old `--label "automation,monitoring"` could not have succeeded.
- The `${ISSUE_URL##*/}` parse and the `case ''|*[!0-9]*` numeric guard are untested against real `gh issue create` stdout.

The first run after merge proves or disproves it immediately — and now fails loudly if it's wrong, instead of printing "posted to issue #unknown" and exiting green.

### Checks run

CLAUDE.md's Pre-PR list is Swift-shaped and doesn't apply to a workflow change, so instead:

- `actionlint .github/workflows/repo-health.yml` — **clean** (baseline was also clean, so this isn't hiding pre-existing findings)
- `yaml.safe_load` on the modified workflow — parses; step graph verified
- `bash -n` on all three `run:` bodies — clean
- `python3 -m py_compile` on the new script — clean
- Cron parser unit-tested: all 6 real expressions plus `0 0 1 * *`, `0 0 * * MON`, `5 0 * * SUN,WED`, `0 0 1 * 0` (dom+dow OR semantics) produce correct intervals; 5 malformed expressions are rejected rather than silently mis-parsed
- Workflow scanner cross-checked against `PyYAML` on **all 27** workflow files — identical output. Two explicit assertions: `testflight.yml` is **excluded** (its cron is commented out — a naive `grep cron:` would falsely include it), and exactly the 6 real scheduled workflows are found. Note PyYAML parses the bare key `on` as boolean `True`, which is why the scanner is hand-rolled rather than depending on PyYAML being present on the runner.

## Notes for the maintainer

- **The workflow file is included in this branch** — my push carried the `workflow` scope, so no hand-applying needed. Actions may still not run the modified workflow from a PR context; a `workflow_dispatch` on `develop` after merge is the real end-to-end test.
- **Check 5 will be yellow on day one.** `agent-validation.yml` is genuinely at 11 failures/24h right now. That's a pre-existing condition the old hardcoded check was under-reporting, not a regression from this PR.
- **I did not create the pinned issue.** The fixed workflow creates it on its first run. Creating labels `automation` and `monitoring` beforehand is optional — the workflow no longer depends on them.
- **The job is not made red by findings**, deliberately: red should mean "the monitor is broken", and findings belong in the issue body. A permanently-red monitor gets muted. The one exception is a failure to post, which *is* the monitor being broken.
- **Self-monitoring has a blind spot:** check 6 covers `repo-health.yml` itself, but if repo-health is down it can't report that. GitHub's own failed-workflow notifications cover that case now that the post step fails loudly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
