### PR TITLE
[Agent] fix(ci): changelog automation has never landed a commit

### DIFF
--- a/.changelog/README.md
+++ b/.changelog/README.md
@@ -11,7 +11,11 @@ When a PR merges to `develop`, the `consolidate-changelog.yml` workflow:
 4. Inserts entries into the right section of `CHANGELOG.md`
 5. Sorts by PR number (newest first within each section), deduplicates
 6. Deletes the processed fragment files
-7. Commits the result directly to `develop`
+7. Opens (or updates) a pull request against `develop` with the result
+
+`develop` is a protected branch, so the consolidation lands through a normal
+pull request rather than a direct push. The workflow reuses one long-lived
+branch, so you will see a single open changelog PR rather than one per merge.
 
 ## File naming
 

--- a/.github/workflows/consolidate-changelog.yml
+++ b/.github/workflows/consolidate-changelog.yml
@@ -13,6 +13,10 @@ name: Consolidate Changelog Fragments
 # • Entries are sorted (newest PR first within each section), deduplicated.
 # • Multi-line entries (indented continuation) are preserved correctly.
 # • The script is idempotent: running twice produces the same result.
+#
+# The result is delivered as a pull request against develop, reusing a single
+# long-lived branch. develop is protected and github-actions[bot] is not in its
+# bypass allowances, so a direct push is not possible.
 
 on:
   pull_request:
@@ -25,7 +29,9 @@ on:
 
 permissions:
   contents: write
-  pull-requests: read
+  # write (not read) so the job can open the consolidation pull request —
+  # develop is protected and cannot be pushed to directly.
+  pull-requests: write
 
 jobs:
   consolidate:
@@ -269,6 +275,13 @@ jobs:
 
       - name: Commit consolidated changelog
         if: steps.check.outputs.count != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          # Single long-lived branch, reused every run, so repeated
+          # consolidations update one pull request instead of opening a new one
+          # after every merge to develop.
+          PR_BRANCH: chore/changelog-consolidation
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -283,25 +296,65 @@ jobs:
           fi
 
           # Build a compact summary of which PRs were absorbed
+          # `paste -sd ', '` treats ", " as a *cyclic* delimiter list and emits
+          # "#1,#2 #3,#4". Join on a single comma and space it afterwards. The
+          # explicit "-" is required by BSD paste and accepted by GNU, so this
+          # line behaves identically on a runner and on a maintainer's Mac.
           absorbed=$(git diff --cached --name-only \
             | grep '^\.changelog/' \
             | grep -v 'README' \
             | sed 's|\.changelog/||; s|\.md||' \
             | sort -n \
             | sed 's/^/#/' \
-            | paste -sd ', ')
+            | paste -sd ',' - \
+            | sed 's/,/, /g')
 
-          msg="chore(changelog): absorb fragments${absorbed:+ ($absorbed)}"
+          absorbed_count=$(git diff --cached --name-only \
+            | grep -c '^\.changelog/[^/]*\.md$' || true)
 
-          git commit -m "$(printf '%s\n\nCo-Authored-By: github-actions[bot] <github-actions[bot]@users.noreply.github.com>' "$msg")"
+          # Keep the subject short and put the PR list in the body. With the
+          # backlog that accumulated while this workflow could not push, the
+          # inline form reached 1701 characters — unusable as a subject line.
+          msg="chore(changelog): absorb ${absorbed_count} fragment(s)"
 
-          # Push with retry in case of a race with auto-rebase
-          for attempt in 1 2 3; do
-            git pull --rebase origin develop 2>/dev/null || true
-            if git push origin develop; then
-              echo "Pushed successfully."
-              break
+          git commit -m "$msg" \
+            -m "Absorbed: ${absorbed:-none}" \
+            -m "Co-Authored-By: github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+
+          # develop is a protected branch ("Changes must be made through a pull
+          # request") and github-actions[bot] is NOT in its bypass allowances —
+          # only the user JoeMatt is. A direct `git push origin develop` can
+          # therefore never succeed here, which is why this workflow absorbed
+          # nothing for five months while reporting green: the old retry loop
+          # broke on success and fell through on exhaustion, so an exhausted
+          # loop was indistinguishable from a successful push.
+          #
+          # Route the result through a pull request instead, which is the only
+          # path into develop that exists.
+          git push --force origin "HEAD:refs/heads/${PR_BRANCH}" || {
+            echo "::error::Could not push the consolidated changelog to ${PR_BRANCH}."
+            exit 1
+          }
+          echo "Pushed consolidation to ${PR_BRANCH}."
+
+          existing=$(gh pr list --repo "$REPO" --head "$PR_BRANCH" --state open \
+            --json number --jq '.[0].number // empty')
+
+          if [ -n "$existing" ]; then
+            # The force-push above already updated the PR's head.
+            echo "Updated existing PR #${existing}."
+            echo "PR: $(gh pr view "$existing" --repo "$REPO" --json url --jq .url)"
+          else
+            if ! pr_url=$(gh pr create --repo "$REPO" \
+                  --base develop \
+                  --head "$PR_BRANCH" \
+                  --title "chore(changelog): absorb ${absorbed_count} pending fragment(s)" \
+                  --body "$(printf '%s\n\n%s\n\n%s' \
+                    "Absorbs \`.changelog/*.md\` fragments into \`CHANGELOG.md\`." \
+                    "Absorbed: ${absorbed:-none}" \
+                    "Opened automatically by [consolidate-changelog.yml](../actions/workflows/consolidate-changelog.yml). Safe to merge as-is; the consolidation script is idempotent.")"); then
+              echo "::error::Could not open the changelog consolidation pull request."
+              exit 1
             fi
-            echo "Push attempt $attempt failed, retrying..."
-            sleep $((attempt * 3))
-          done
+            echo "Opened $pr_url"
+          fi

--- a/.github/workflows/consolidate-changelog.yml
+++ b/.github/workflows/consolidate-changelog.yml
@@ -2,8 +2,8 @@ name: Consolidate Changelog Fragments
 
 # Merges .changelog/NNNN.md fragment files into CHANGELOG.md [Unreleased].
 #
-# Runs automatically when a PR merges to develop (so the fragment is absorbed
-# immediately) and weekly on Mondays alongside update-changelog.yml.
+# Runs automatically when fragments land on develop (so they are absorbed
+# immediately) and weekly on Mondays as a backstop.
 # Can also be triggered manually to absorb any pending fragments.
 #
 # Design goals
@@ -19,9 +19,16 @@ name: Consolidate Changelog Fragments
 # bypass allowances, so a direct push is not possible.
 
 on:
-  pull_request:
-    types: [closed]
+  # Triggered by the push to develop rather than by `pull_request: [closed]`.
+  # On a pull_request event from a fork the GITHUB_TOKEN is read-only, so the
+  # branch push and PR creation below could not run; a push event always has a
+  # writable token. It also catches fragments landed by a direct push to
+  # develop (which the repo admin can do), and matches how the other
+  # post-merge workflows here are wired.
+  push:
     branches: [develop]
+    paths:
+      - '.changelog/**'
   schedule:
     # Every Monday at 07:30 UTC (30 min after update-changelog.yml)
     - cron: '30 7 * * 1'
@@ -36,10 +43,6 @@ permissions:
 jobs:
   consolidate:
     name: Absorb fragments into CHANGELOG.md
-    # For PR events: only when the PR was actually merged (not just closed).
-    if: |
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -353,7 +356,7 @@ jobs:
                     "Absorbs \`.changelog/*.md\` fragments into \`CHANGELOG.md\`." \
                     "Absorbed: ${absorbed:-none}" \
                     "⚠️ Do not hand-edit the \`${PR_BRANCH}\` branch. It is rebuilt and force-pushed on every run, so any manual commit on it is silently discarded. Fix the fragment in \`.changelog/\` on develop instead, or edit \`CHANGELOG.md\` after this merges." \
-                    "Opened automatically by [consolidate-changelog.yml](../actions/workflows/consolidate-changelog.yml). The consolidation script is idempotent, so this can be merged as-is.")"); then
+                    "Opened automatically by [consolidate-changelog.yml](${GITHUB_SERVER_URL}/${REPO}/actions/workflows/consolidate-changelog.yml). The consolidation script is idempotent, so this can be merged as-is.")"); then
               echo "::error::Could not open the changelog consolidation pull request."
               exit 1
             fi

--- a/.github/workflows/consolidate-changelog.yml
+++ b/.github/workflows/consolidate-changelog.yml
@@ -349,10 +349,11 @@ jobs:
                   --base develop \
                   --head "$PR_BRANCH" \
                   --title "chore(changelog): absorb ${absorbed_count} pending fragment(s)" \
-                  --body "$(printf '%s\n\n%s\n\n%s' \
+                  --body "$(printf '%s\n\n%s\n\n%s\n\n%s' \
                     "Absorbs \`.changelog/*.md\` fragments into \`CHANGELOG.md\`." \
                     "Absorbed: ${absorbed:-none}" \
-                    "Opened automatically by [consolidate-changelog.yml](../actions/workflows/consolidate-changelog.yml). Safe to merge as-is; the consolidation script is idempotent.")"); then
+                    "⚠️ Do not hand-edit the \`${PR_BRANCH}\` branch. It is rebuilt and force-pushed on every run, so any manual commit on it is silently discarded. Fix the fragment in \`.changelog/\` on develop instead, or edit \`CHANGELOG.md\` after this merges." \
+                    "Opened automatically by [consolidate-changelog.yml](../actions/workflows/consolidate-changelog.yml). The consolidation script is idempotent, so this can be merged as-is.")"); then
               echo "::error::Could not open the changelog consolidation pull request."
               exit 1
             fi

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,19 +1,47 @@
 name: Update Changelog
 
-# Keeps CHANGELOG.md [Unreleased] section current by summarising recent commits
-# every Monday morning and after manual dispatch.
+# ⚠️ SCHEDULE DISABLED — superseded by consolidate-changelog.yml.
 #
-# The job reads conventional-commit messages merged to develop since the last
-# tagged release and appends new entries to the [Unreleased] block.
-# It will NOT overwrite entries already in [Unreleased] — it only appends lines
-# that don't already appear there (dedup by PR number).
+# This workflow scraped conventional-commit subjects and appended them to the
+# CHANGELOG.md [Unreleased] block. It has NEVER worked: 100 out of 100 runs
+# failed, with zero successes, from its first run on 2026-03-16 onwards.
 #
-# Runs as github-actions[bot]; pushes directly to develop.
+# Three independent defects, all verified:
+#
+#  1. It ends in `git push origin develop`. develop is protected ("Changes must
+#     be made through a pull request") and github-actions[bot] is not in its
+#     bypass allowances, so this push can never succeed. Every run died here.
+#
+#  2. The since-ref is computed with
+#       git tag --sort=-version:refname | grep -E '^v?[0-9]+\.[0-9]+' | head -1
+#     which returns `v2.0` (2025-08-31) rather than the newest release `3.3.1`
+#     (2026-03-29), because the `v` prefix sorts after bare digits. The window
+#     is therefore 5515 commits instead of 795.
+#
+#  3. Scripts/changelog_update_file.py dedups by PR number, but its filter
+#     keeps every entry that has NO PR number:
+#         if not prs_in_line or not prs_in_line.issubset(existing_prs):
+#     979 of the 1126 collected entries have no `(#N)` ref, so they are
+#     re-appended on every run. Measured on the real repo, CHANGELOG.md grows
+#     1265 → 2375 → 3357 → 4339 lines over three consecutive runs, unbounded.
+#
+# Defect 1 has been accidentally shielding the repo from defect 3. Fixing only
+# the push would start corrupting CHANGELOG.md by ~982 lines per week.
+#
+# The fragment-based flow in consolidate-changelog.yml (added 4 days after this
+# one) replaces it and fixes both content defects by design: PR numbers come
+# from the fragment filename, and consolidation is idempotent. See
+# .changelog/README.md.
+#
+# The schedule is commented out rather than the file deleted so a maintainer
+# can decide whether to remove it outright. workflow_dispatch is kept so the
+# generator can still be run deliberately — but note that defects 2 and 3 are
+# NOT fixed here, so a manual run still produces a corrupting diff.
 
 on:
-  schedule:
-    # Every Monday at 07:00 UTC
-    - cron: '0 7 * * 1'
+  # schedule:
+  #   # Every Monday at 07:00 UTC — disabled, see the note above.
+  #   - cron: '0 7 * * 1'
   workflow_dispatch:
     inputs:
       since_ref:


### PR DESCRIPTION
## Summary

`update-changelog.yml` has failed **100 out of 100** runs with zero successes ever. Investigating it turned up that its sibling `consolidate-changelog.yml` is broken by the *same* root cause — but reports **SUCCESS** while doing nothing.

**Neither changelog workflow has ever landed a single commit on `develop`:**

```
$ git log origin/develop --grep="absorb fragments" | wc -l          # consolidate
0
$ git log origin/develop --grep="update \[Unreleased\]" | wc -l     # update
0
$ ls .changelog/*.md | grep -vc README
278                                                                  # fragments piled up since March
```

## Root cause (shared)

Both end in `git push origin develop`. That branch is protected and `github-actions[bot]` is **not** in its bypass allowances:

```
$ gh api repos/:owner/:repo/branches/develop/protection \
    --jq '.required_pull_request_reviews.bypass_pull_request_allowances'
{"apps":[],"teams":[],"users":["JoeMatt"]}
```

So the push is not flaky — it is **impossible**, and always has been:

```
remote: error: GH006: Protected branch update failed for refs/heads/develop.
remote: - Changes must be made through a pull request.
 ! [remote rejected]     develop -> develop (protected branch hook declined)
```

Confirmed identical on all 8 `update-changelog` runs still within log retention.

## Why nobody noticed the second one

`consolidate-changelog.yml`'s retry loop `break`s on success and simply falls through on exhaustion — an exhausted loop is indistinguishable from a successful push, and the step exits 0. From its **last "successful"** scheduled run:

```
Fragment files found: 273
remote: error: GH006: Protected branch update failed ...
Push attempt 1 failed, retrying...
remote: error: GH006: Protected branch update failed ...
Push attempt 2 failed, retrying...
remote: error: GH006: Protected branch update failed ...
Push attempt 3 failed, retrying...
```

Run conclusion: **success**. Same swallow-the-error pattern as the health monitor in #3662.

## Fix 1 — `consolidate-changelog.yml`: route through a PR

This workflow is well built: I extracted its embedded consolidation script and ran it against the real 278 fragments — `CHANGELOG.md` 1265 → 1708 lines, all fragments deleted, and a **second run was a clean no-op** ("No fragment files found"). Genuinely idempotent, as its header claims. Only the delivery was broken.

Now commits to a single long-lived branch (`chore/changelog-consolidation`), force-pushes it, and opens a PR — or lets the force-push update the existing one, so you get **one** changelog PR rather than one per merge to develop. Push/PR failures are now `::error::` + `exit 1`. Requires `pull-requests: write` (was `read`).

Two latent bugs become real once this actually runs, so they're fixed here:

- **`paste -sd ', '` cycles its delimiters.** It emits `#1,#2 #3,#4`, not `#1, #2, #3, #4` — verified on both GNU and BSD paste. Joined on a single comma and spaced afterward. (Also added the explicit `-`, required by BSD and accepted by GNU, so the line is testable on a Mac.)
- **A 1701-character commit subject.** With the accumulated backlog, the inline PR list produced exactly that. Measured. The list moves to the commit body; the subject is now `chore(changelog): absorb 278 fragment(s)` — 41 chars.

## Fix 2 — `update-changelog.yml`: disabled, not repaired

It has **three** independent defects, not one:

1. The protected-branch push above.
2. **The since-ref is wrong.** `git tag --sort=-version:refname | grep -E '^v?[0-9]+\.[0-9]+' | head -1` returns `v2.0` (2025-08-31), not the newest release `3.3.1` (2026-03-29), because the `v` prefix sorts after bare digits. Window: **5515 commits instead of 795**.
3. **The dedup keeps everything without a PR number.** `if not prs_in_line or not prs_in_line.issubset(existing_prs)` — the first clause admits every entry lacking a `(#N)` ref. **979 of 1126** collected entries have none.

Defect 3 measured by running the real script three times on the real `CHANGELOG.md`:

```
start:            1265 lines
after run #1:     2375 lines
after run #2:     3357 lines
after run #3:     4339 lines     ('### Fixed' headings: 19)
```

Unbounded, ~982 lines per run.

**Defect 1 has been accidentally shielding the repo from defect 3.** Fixing only the push — the obvious one-line change — would have started corrupting `CHANGELOG.md` by ~982 lines every Monday. That's why this one is disabled rather than patched.

The `cron:` is commented out with the full analysis recorded inline; `workflow_dispatch` is kept so it can still be run deliberately (with the caveat, stated in the file, that defects 2 and 3 remain).

### Recommendation: this workflow looks obsolete — your call

Circumstantial but consistent: `consolidate-changelog.yml` was added **4 days later** (2026-03-13 vs 2026-03-09), and `.changelog/README.md` documents the fragment flow as canonical — "drops a small Markdown file here **instead of editing CHANGELOG.md directly**". The fragment design fixes both content defects structurally: PR numbers come from the filename, and consolidation is idempotent. I'd delete `update-changelog.yml` outright, but that's a maintainer decision, so I only disabled the schedule.

## Verification

- `actionlint` on both workflows — **clean**
- `yaml.safe_load` on both; trigger/permission graph asserted (`update-changelog` now `['workflow_dispatch']` only; `consolidate` has `pull-requests: write`)
- `bash -n` on the rewritten commit step — clean
- Consolidation script extracted and run against the real 278 fragments: correct output, fragments deleted, **second run is a no-op** (idempotence verified, not assumed)
- Commit-message construction run end-to-end against the real fragment set: 41-char subject, list correctly comma-separated
- `update-changelog`'s pipeline reproduced verbatim to measure defects 2 and 3 (5515-commit window; 979/1126 entries with no PR ref; 3-run growth curve above)

CLAUDE.md's Pre-PR checklist is Swift-shaped and doesn't apply to a workflow change; the above is what I ran instead of swiftlint/swift build.

## Notes for the maintainer

- **Workflow files are included in this branch** — my push carried the `workflow` scope, so nothing needs hand-applying. (Agent PRs generally cannot push `.github/workflows/*` without the `workflows` permission; flagging it in case it matters for a re-push.)
- **The first consolidation PR will be large** — 278 fragments, ~584 insertions / 1593 deletions across 279 files. That's the backlog draining in one go, not a bug. Subsequent ones will be small.
- **This does not restore direct-to-develop automation** — nothing can, short of adding the Actions app to the bypass allowances in repo settings. The PR route is the only path in.
- **Every consolidation PR will need your review.** `.github/CODEOWNERS` is `* @JoeMatt` and `require_code_owner_reviews` is on, so the bot PR cannot self-serve. Expected, but worth knowing the flow is assisted, not fully automatic.
- **Do not hand-edit `chore/changelog-consolidation`.** It is rebuilt and force-pushed on every run, so a manual fixup commit on that branch is silently discarded. This is inherent to reusing one branch (chosen over one-PR-per-merge to keep noise down); the generated PR body now carries this warning too.
- **Related:** #3662 adds the staleness check that flagged this workflow. Once both land, a scheduled workflow that stops succeeding gets caught within ~2 intervals. Note that `update-changelog.yml` correctly drops off that check's radar here, since its cron is now commented out and the scanner ignores commented crons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
