### PR TITLE
fix(readme): always show the repository star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,11 +276,11 @@ _Provenance_ is our origin story — the word shares its meaning with _Genesis_,
 
 ## ⭐ Star History
 
-<a href="https://star-history.com/#Provenance-Emu/Provenance&Date">
+<a href="https://star-history.dera.page/#Provenance-Emu/Provenance&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)"  srcset="https://api.star-history.com/svg?repos=Provenance-Emu/Provenance&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=Provenance-Emu/Provenance&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=Provenance-Emu/Provenance&type=Date" width="80%">
+    <source media="(prefers-color-scheme: dark)"  srcset="https://star-history.dera.page/svg?repos=Provenance-Emu/Provenance&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=Provenance-Emu/Provenance&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=Provenance-Emu/Provenance&type=Date" width="80%">
   </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is currently broken. GitHub now restricts the stargazer API to repository owners, which the service we used relied on, so the chart no longer renders. This swaps the chart and its link to a mirror that uses a different data source and works without a token.