### PR TITLE
feat: add multi-selection to game library

### DIFF
--- a/PVUI/Sources/PVSwiftUI/Consoles/ConsoleGamesView+MultiSelect.swift
+++ b/PVUI/Sources/PVSwiftUI/Consoles/ConsoleGamesView+MultiSelect.swift
@@ -49,12 +49,15 @@ extension ConsoleGamesView {
         }
     }
 
+
     /// Wraps a game cell with a selection indicator overlay when multi-select is active.
     /// Selection checkmark is placed top-leading to avoid conflicting with the
     /// cloud sync indicator badge at top-trailing.
     @ViewBuilder
     func multiSelectOverlay(md5: String, @ViewBuilder content: () -> some View) -> some View {
-        let isSelected = gamesViewModel.selectedGameMD5s.contains(md5)
+        let normalizedID = md5.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+        let isSelected = gamesViewModel.selectedGameMD5s.contains(normalizedID)
+        let selectionLabel = isSelected ? "Selected" : "Not selected"
         ZStack(alignment: .topLeading) {
             content()
                 .overlay {
@@ -82,6 +85,13 @@ extension ConsoleGamesView {
             }
         }
         .contentShape(Rectangle())
+        .accessibilityElement(children: .contain)
+        .accessibilityValue(gamesViewModel.isMultiSelectMode ? selectionLabel : "")
+        .accessibilityAddTraits(gamesViewModel.isMultiSelectMode && isSelected ? .isSelected : [])
+        .accessibilityAction(named: Text(isSelected ? "Deselect" : "Select")) {
+            guard gamesViewModel.isMultiSelectMode else { return }
+            performSelectionToggle(md5: md5)
+        }
         .onTapGesture {
             if gamesViewModel.isMultiSelectMode {
                 performSelectionToggle(md5: md5)
@@ -123,6 +133,26 @@ extension ConsoleGamesView {
                     state.onDone = { [weak gamesViewModel] in
                         Task { @MainActor in
                             gamesViewModel?.exitMultiSelectMode()
+                        }
+                    }
+                    state.onSelectAll = { [weak gamesViewModel] in
+                        guard let gamesViewModel else { return }
+                        Task { @MainActor in
+                            let query = gamesViewModel.searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+                            let visibleGames = gamesViewModel.allGamesModels.filter {
+                                query.isEmpty || $0.title.lowercased().contains(query)
+                            }
+                            gamesViewModel.selectAllVisible(visibleGames)
+                        }
+                    }
+                    state.onDeselectAll = { [weak gamesViewModel] in
+                        guard let gamesViewModel else { return }
+                        Task { @MainActor in
+                            let query = gamesViewModel.searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+                            let visibleGames = gamesViewModel.allGamesModels.filter {
+                                query.isEmpty || $0.title.lowercased().contains(query)
+                            }
+                            gamesViewModel.deselectAllVisible(visibleGames)
                         }
                     }
                 } else {

--- a/PVUI/Sources/PVSwiftUI/Consoles/ConsoleGamesView.swift
+++ b/PVUI/Sources/PVSwiftUI/Consoles/ConsoleGamesView.swift
@@ -998,10 +998,11 @@ struct ConsoleGamesView: SwiftUI.View {
                     isActiveTabState = nowActive
                     if !nowActive {
                         /// Swiping to another console tab must not leave a pending hold
-                        /// timer or a stale focus ring behind.
+                        /// timer, stale focus ring, or hidden selection behind.
                         cancelHoldMenuTimer()
                         holdPressStart = nil
                         clearNavigationFocus()
+                        gamesViewModel.exitMultiSelectMode()
                     }
                 }
                 .sheet(item: $keyboardMenuState) { state in
@@ -1062,18 +1063,18 @@ struct ConsoleGamesView: SwiftUI.View {
     private func showGamesGrid(_ games: [PVGame]) -> some View {
         LazyVGrid(columns: columns, spacing: 10) {
             ForEach(games.filter { !$0.isInvalidated }, id: \.id) { game in
-                GameItemView(
-                    game: game,
-                    constrainHeight: false,
-                    sectionContext: .allGames,
-                    isFocused: focusBinding(
-                        itemId: game.id,
-                        section: .allGames,
-                        requiresValidityCheck: { !game.isInvalidated }
-                    )
-                ) {
-                    Task.detached { @MainActor in
-                        SceneCoordinator.shared.launchGame(game.freeze())
+                multiSelectOverlay(md5: game.md5Hash) {
+                    GameItemView(
+                        game: game,
+                        constrainHeight: false,
+                        sectionContext: .allGames,
+                        isFocused: focusBinding(
+                            itemId: game.id,
+                            section: .allGames,
+                            requiresValidityCheck: { !game.isInvalidated }
+                        )
+                    ) {
+                        gameAction(for: game.md5Hash)()
                     }
                 }
                 /// Use compound ID so view recreates when artwork URL changes
@@ -1175,19 +1176,19 @@ struct ConsoleGamesView: SwiftUI.View {
     private func showGamesList(_ games: [PVGame]) -> some View {
         LazyVStack(spacing: 0) {
             ForEach(games.filter { !$0.isInvalidated }, id: \.id) { game in
-                GameItemView(
-                    game: game,
-                    constrainHeight: true,
-                    viewType: .row,
-                    sectionContext: .allGames,
-                    isFocused: focusBinding(
-                        itemId: game.id,
-                        section: .allGames,
-                        requiresValidityCheck: { !game.isInvalidated }
-                    )
-                ) {
-                    Task.detached { @MainActor in
-                        SceneCoordinator.shared.launchGame(game.freeze())
+                multiSelectOverlay(md5: game.md5Hash) {
+                    GameItemView(
+                        game: game,
+                        constrainHeight: true,
+                        viewType: .row,
+                        sectionContext: .allGames,
+                        isFocused: focusBinding(
+                            itemId: game.id,
+                            section: .allGames,
+                            requiresValidityCheck: { !game.isInvalidated }
+                        )
+                    ) {
+                        gameAction(for: game.md5Hash)()
                     }
                 }
                 /// Use compound ID so view recreates when artwork URL changes
@@ -1469,14 +1470,16 @@ struct ConsoleGamesView: SwiftUI.View {
                         .padding()
                 } else {
                     ForEach(results, id: \.id) { game in
-                        GameItemPresentableView(
-                            game: game,
-                            constrainHeight: true,
-                            viewType: .row,
-                            sectionContext: .allGames,
-                            isFocused: focusBinding(itemId: game.id, section: .allGames)
-                        ) {
-                            launchGame(md5: game.md5)
+                        multiSelectOverlay(md5: game.md5) {
+                            GameItemPresentableView(
+                                game: game,
+                                constrainHeight: true,
+                                viewType: .row,
+                                sectionContext: .allGames,
+                                isFocused: focusBinding(itemId: game.id, section: .allGames)
+                            ) {
+                                gameAction(for: game.md5)()
+                            }
                         }
                         .id(gameIdentityKey(id: game.id, artworkURL: game.trueArtworkURL))
                         .focusableIfAvailable()
@@ -1688,15 +1691,17 @@ extension ConsoleGamesView {
 
     @ViewBuilder
     private func gameItem(_ game: GameCellModel, section: HomeSectionType) -> some View {
-        GameItemPresentableView(
-            game: game,
+        multiSelectOverlay(md5: game.md5) {
+            GameItemPresentableView(
+                game: game,
                 constrainHeight: true,
                 shelfRowHeightScale: PVCompactShelfRowHeightScale,
                 viewType: .cell,
                 sectionContext: section,
                 isFocused: focusBinding(itemId: game.id, section: section)
-        ) {
-            launchGame(md5: game.md5)
+            ) {
+                gameAction(for: game.md5)()
+            }
         }
         .id(gameIdentityKey(id: game.id, artworkURL: game.trueArtworkURL))
         .focusableIfAvailable()

--- a/PVUI/Sources/PVSwiftUI/Consoles/ConsoleGamesViewModel.swift
+++ b/PVUI/Sources/PVSwiftUI/Consoles/ConsoleGamesViewModel.swift
@@ -110,11 +110,36 @@ class ConsoleGamesViewModel: ObservableObject {
     /// Toggle a game in/out of the selection set.
     @MainActor
     func toggleSelection(md5: String) {
-        if selectedGameMD5s.contains(md5) {
-            selectedGameMD5s.remove(md5)
+        let normalizedID = normalizedSelectionID(md5)
+        guard !normalizedID.isEmpty else { return }
+        if selectedGameMD5s.contains(normalizedID) {
+            selectedGameMD5s.remove(normalizedID)
         } else {
-            selectedGameMD5s.insert(md5)
+            selectedGameMD5s.insert(normalizedID)
         }
+    }
+
+    /// Select all currently visible games. Duplicate or empty IDs are ignored.
+    @MainActor
+    func selectAllVisible(_ games: [GameCellModel]) {
+        let normalizedIDs = games.compactMap { game -> String? in
+            let id = normalizedSelectionID(game.md5)
+            return id.isEmpty ? nil : id
+        }
+        selectedGameMD5s.formUnion(normalizedIDs)
+    }
+
+    /// Deselect only currently visible games, preserving selections for non-visible games.
+    @MainActor
+    func deselectAllVisible(_ games: [GameCellModel]) {
+        let normalizedIDs = games.map { normalizedSelectionID($0.md5) }
+        selectedGameMD5s.subtract(normalizedIDs)
+    }
+
+    /// Clear selection when a filter changes so hidden games cannot remain selected.
+    @MainActor
+    func clearSelectionForFilterChange() {
+        selectedGameMD5s.removeAll()
     }
 
     /// Enter multi-select mode; clears any previous selection.
@@ -131,8 +156,22 @@ class ConsoleGamesViewModel: ObservableObject {
         selectedGameMD5s = []
     }
 
+    @MainActor
+    private func normalizedSelectionID(_ id: String) -> String {
+        id.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+    }
+
     // Properties that were @State in the View, now @Published in ViewModel
     @Published var searchText: String = "" {
+        willSet {
+            let oldQuery = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            let newQuery = newValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            if oldQuery != newQuery, isMultiSelectMode, !selectedGameMD5s.isEmpty {
+                Task { @MainActor in
+                    self.clearSelectionForFilterChange()
+                }
+            }
+        }
         didSet {
             // Debounce search updates to reduce filtering overhead
             searchDebounceTimer?.invalidate()
@@ -364,6 +403,9 @@ private extension ConsoleGamesViewModel {
                             let snapshot = collection.freeze()
                             self.rebuildGameModels(from: snapshot)
                         case .error(let error):
+                            Task { @MainActor in
+                                self.selectedGameMD5s.removeAll()
+                            }
                             ELOG("ConsoleGamesViewModel: error observing PVGame: \(error.localizedDescription)")
                         }
                     }
@@ -419,6 +461,8 @@ private extension ConsoleGamesViewModel {
             self.allGamesModels = self.sorted(all)
             self.favoritesModels = self.sorted(favs)
             self.recentlyPlayedModels = recents
+            let visibleIDs = Set(all.map { self.normalizedSelectionID($0.md5) })
+            self.selectedGameMD5s.formIntersection(visibleIDs)
         }
         }
     }

--- a/PVUI/Sources/PVSwiftUI/Consoles/GameCellModel.swift
+++ b/PVUI/Sources/PVSwiftUI/Consoles/GameCellModel.swift
@@ -119,3 +119,45 @@ public struct GameCellModel: Identifiable, Hashable {
 extension GameCellModel: GameItemPresentable {
     public var isInvalidated: Bool { false }
 }
+
+/// Pure, stable-ID selection state used by selection-state tests and reusable
+/// selection logic. IDs are normalized so Realm casing and duplicate visible
+/// cells cannot create duplicate logical selections.
+public struct ConsoleGameSelectionState: Equatable {
+    public private(set) var selectedIDs: Set<String> = []
+
+    public init(selectedIDs: Set<String> = []) {
+        self.selectedIDs = Set(selectedIDs.map(Self.normalize))
+    }
+
+    public mutating func toggle(id: String) {
+        let normalized = Self.normalize(id)
+        if !normalized.isEmpty {
+            if selectedIDs.contains(normalized) {
+                selectedIDs.remove(normalized)
+            } else {
+                selectedIDs.insert(normalized)
+            }
+        }
+    }
+
+    public mutating func selectAll(ids: some Sequence<String>) {
+        selectedIDs.formUnion(ids.map(Self.normalize).filter { !$0.isEmpty })
+    }
+
+    public mutating func deselectAll(ids: some Sequence<String>) {
+        selectedIDs.subtract(ids.map(Self.normalize))
+    }
+
+    public mutating func prune(to ids: some Sequence<String>) {
+        selectedIDs.formIntersection(Set(ids.map(Self.normalize)))
+    }
+
+    public mutating func clear() {
+        selectedIDs.removeAll()
+    }
+
+    private static func normalize(_ id: String) -> String {
+        id.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+    }
+}

--- a/PVUI/Sources/PVUIBase/SwiftUI/Components/MultiSelectToolbarState.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/Components/MultiSelectToolbarState.swift
@@ -22,6 +22,8 @@ public final class MultiSelectToolbarState: ObservableObject {
     public var onOffload: (() -> Void)?
     public var onDownload: (() -> Void)?
     public var onDone: (() -> Void)?
+    public var onSelectAll: (() -> Void)?
+    public var onDeselectAll: (() -> Void)?
 
     private init() {}
 
@@ -43,6 +45,8 @@ public final class MultiSelectToolbarState: ObservableObject {
         onOffload = nil
         onDownload = nil
         onDone = nil
+        onSelectAll = nil
+        onDeselectAll = nil
     }
 
     public func updateCount(_ count: Int) {

--- a/PVUI/Sources/PVUIBase/SwiftUI/Components/RetroWave/RetroMultiSelectToolbar.swift
+++ b/PVUI/Sources/PVUIBase/SwiftUI/Components/RetroWave/RetroMultiSelectToolbar.swift
@@ -32,6 +32,7 @@ public struct RetroMultiSelectToolbar: View {
                 HStack(spacing: 14) {
                     selectionBadge
                     Spacer()
+                    selectAllButton
                     doneButton
                 }
 
@@ -143,6 +144,30 @@ public struct RetroMultiSelectToolbar: View {
             .foregroundColor(enabled ? color : .white.opacity(0.3))
         }
         .disabled(!enabled)
+    }
+
+    // MARK: - Select all button
+
+    private var selectAllButton: some View {
+        Menu {
+            Button("Select All Visible", action: { state.onSelectAll?() })
+            Button("Deselect All Visible", action: { state.onDeselectAll?() })
+        } label: {
+            Image(systemName: "checklist")
+                .font(.system(size: 15, weight: .semibold))
+                .padding(.horizontal, 10)
+                .padding(.vertical, 8)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(Color.retroBlue.opacity(0.15))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .strokeBorder(Color.retroBlue.opacity(0.6), lineWidth: 1)
+                        )
+                )
+                .foregroundColor(.retroBlue)
+        }
+        .accessibilityLabel("Selection actions")
     }
 
     // MARK: - Done button

--- a/PVUI/Tests/PVSwiftUITests/PVSwiftUITests.swift
+++ b/PVUI/Tests/PVSwiftUITests/PVSwiftUITests.swift
@@ -137,3 +137,51 @@ struct ROMTitleNormalizerTests {
         #expect(result == "My Game")
     }
 }
+
+// MARK: - ConsoleGameSelectionState Tests
+
+@Suite("ConsoleGameSelectionState")
+struct ConsoleGameSelectionStateTests {
+
+    @Test("Toggling an ID selects it once and toggles it off")
+    func toggleIsStable() {
+        var state = ConsoleGameSelectionState()
+        state.toggle(id: "abc")
+        #expect(state.selectedIDs == ["ABC"])
+        state.toggle(id: "ABC")
+        #expect(state.selectedIDs.isEmpty)
+    }
+
+    @Test("Select all and deselect all only affect visible IDs")
+    func bulkSelectionUsesVisibleIDs() {
+        var state = ConsoleGameSelectionState()
+        state.toggle(id: "hidden")
+        state.selectAll(ids: ["one", "two", "one"])
+        #expect(state.selectedIDs == ["HIDDEN", "ONE", "TWO"])
+        state.deselectAll(ids: ["one", "two"])
+        #expect(state.selectedIDs == ["HIDDEN"])
+    }
+
+    @Test("Pruning removes deleted IDs while retaining games that remain")
+    func refreshPrunesRemovedGames() {
+        var state = ConsoleGameSelectionState()
+        state.selectAll(ids: ["keep", "remove"])
+        state.prune(to: ["KEEP", "other"])
+        #expect(state.selectedIDs == ["KEEP"])
+    }
+
+    @Test("Empty IDs are ignored by bulk selection")
+    func emptyIDsAreIgnored() {
+        var state = ConsoleGameSelectionState()
+        state.selectAll(ids: [" ", "valid", "\n"])
+        #expect(state.selectedIDs == ["VALID"])
+    }
+
+    @Test("Reset clears every selection")
+    func resetClearsSelection() {
+        var state = ConsoleGameSelectionState()
+        state.selectAll(ids: ["one", "two"])
+        state.clear()
+        #expect(state.selectedIDs.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- Add multi-selection mode to game-library grid, list, search, and shelf cells.
- Normalize selection IDs and keep selection scoped to visible/current games across filtering, refresh, and navigation.
- Add selected visuals, accessibility state, visible bulk select/deselect actions, and pure selection-state tests.

## Testing
- `git diff --check` — passed.
- Swift/Xcode tests — not run: this Windows host does not have `swift` or `xcodebuild` installed.

## Known limitations
- Full iOS build and test validation remains to be performed on macOS with Xcode.