### PR TITLE
fix(ecosystem): contain ecosystem-fetch paths to the import dir

### DIFF
--- a/.changelog/ecosystem-fetch-path-containment.md
+++ b/.changelog/ecosystem-fetch-path-containment.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Ecosystem Fetch Path Containment — Downloads from an ecosystem manifest could resolve outside the import directory; paths are now validated before any file is written**

--- a/PVLibrary/Sources/PVLibrary/Importer/Services/EcosystemIntegration/EcosystemFetchService.swift
+++ b/PVLibrary/Sources/PVLibrary/Importer/Services/EcosystemIntegration/EcosystemFetchService.swift
@@ -88,11 +88,26 @@ public actor EcosystemFetchService {
         let wanted = manifest.files.filter { $0.kind == "gameFile" }
         guard !wanted.isEmpty else { throw FetchError.badManifest }
 
+        // `md5` comes from the remote manifest and is used verbatim below to name the
+        // container directory. Require it to actually look like a hex digest before
+        // using it as a path component, so it can't smuggle "/" or "..".
+        guard payload.md5.prefix(8).allSatisfy({ $0.isHexDigit }) else {
+            throw FetchError.badManifest
+        }
+
         let containerName = "iFly-\(String(payload.md5.prefix(8)))"
         let container = Paths.romsImportPath.appendingPathComponent(containerName, isDirectory: true)
+        let containerPath = container.standardizedFileURL.path
 
         for (index, entry) in wanted.enumerated() {
             let destination = container.appendingPathComponent(entry.relativePath)
+            // `relativePath` also comes from the remote manifest with no component
+            // filtering; confirm the resolved destination is still inside the
+            // container before creating directories or writing to it.
+            let destinationPath = destination.standardizedFileURL.path
+            guard destinationPath == containerPath || destinationPath.hasPrefix(containerPath + "/") else {
+                throw FetchError.badManifest
+            }
             try FileManager.default.createDirectory(
                 at: destination.deletingLastPathComponent(),
                 withIntermediateDirectories: true


### PR DESCRIPTION
### What does this PR do

- Reject `payload.md5` unless its first 8 characters are hex digits, before it names the container directory.
- After joining `entry.relativePath` onto the container, standardize both paths and require the destination to equal the container or start with `container + "/"`, throwing the existing `FetchError.badManifest` otherwise.

Both run before any filesystem call touches the computed path. No new error case was added; `badManifest` already fits a malformed manifest. Nothing else in `download()` was touched.

Deliberately not changed: the bearer-token/manifest-fetch flow, and whether the `provenance://` callback should require user confirmation. One difference to the sibling check above: `GameImporterFileService` also calls `.resolvingSymlinksInPath()`, this patch compares standardized paths only. A symlink planted inside the container beforehand could still redirect the move, which the HTTP download path itself cannot create.

### Where should the reviewer start

`EcosystemFetchService.download()`

### How should this be manually tested

- Read the file at `develop` HEAD (`93f49b40`) to confirm the defect was present before patching; `git log --since=2026-07-01` shows one unrelated commit and no prior fix attempt.
- Ported the guard logic to a standalone Node script and ran it against PoC values (`md5=../../../aaaaaaaa`, and a valid md5 with a traversing `relativePath`): both blocked; a normal `relativePath` still resolves correctly.
- Not executed: a Swift build/test. Swift toolchains for iOS targets do not run on this Linux host.

### Any background context you want to provide

`EcosystemFetchService.download()` (`PVLibrary/.../EcosystemIntegration/EcosystemFetchService.swift:91-109`) builds a destination path from two values taken straight from a remote manifest, with no validation:

- Line 91: `containerName` embeds `payload.md5.prefix(8)` unfiltered.
- Line 95: `destination` joins `entry.relativePath` onto the container with no component filtering or containment check.
- Lines 108-109 then `removeItem` (recursive for directories) and `moveItem` at that unchecked destination.

Nothing between decoding the manifest JSON and the filesystem calls confirms the resolved path stays inside `Paths.romsImportPath`. This repository already treats this exact bug shape seriously elsewhere: `ZipBackend.swift:150` and `:284` guard zip-slip on archive extraction with a `hasPrefix` check against the destination, and `GameImporterFileService.swift:144` compares `standardizedFileURL` paths the same way before trusting a path is inside `Paths.romsImportPath`/`Paths.biosesPath`. `EcosystemFetchService` had no equivalent check for a source that is remote and attacker-influenced.

### What are the relevant tickets

GHSA-jr3v-3gjr-jg72 ([found during penetration test](https://www.turingpoint.de/en/security-assessments/pentests/) by [turingpoint](https://www.turingpoint.de), reported privately, unpublished at time of writing)

### Screenshots (important for UI changes)

n/a, no UI change.

### Questions

None.