### PR TITLE
fix(webserver): escape all HTML metacharacters in error responses

### DIFF
--- a/.changelog/gcdwebserver-error-html-escape.md
+++ b/.changelog/gcdwebserver-error-html-escape.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Web Server Error Pages Escape All HTML — Error pages escaped only the double quote, so other markup in a requested path rendered as HTML**

--- a/PVWebServer/Sources/PVWebServer/GCDWebServer/Responses/GCDWebServerErrorResponse.m
+++ b/PVWebServer/Sources/PVWebServer/GCDWebServer/Responses/GCDWebServerErrorResponse.m
@@ -70,7 +70,14 @@
 }
 
 static inline NSString* _EscapeHTMLString(NSString* string) {
-  return [string stringByReplacingOccurrencesOfString:@"\"" withString:@"&quot;"];
+  // "&" must be escaped first, otherwise the "&" introduced by the other
+  // replacements below would themselves get escaped a second time.
+  NSString* escaped = [string stringByReplacingOccurrencesOfString:@"&" withString:@"&amp;"];
+  escaped = [escaped stringByReplacingOccurrencesOfString:@"<" withString:@"&lt;"];
+  escaped = [escaped stringByReplacingOccurrencesOfString:@">" withString:@"&gt;"];
+  escaped = [escaped stringByReplacingOccurrencesOfString:@"\"" withString:@"&quot;"];
+  escaped = [escaped stringByReplacingOccurrencesOfString:@"'" withString:@"&#39;"];
+  return escaped;
 }
 
 - (instancetype)initWithStatusCode:(NSInteger)statusCode underlyingError:(NSError*)underlyingError messageFormat:(NSString*)format arguments:(va_list)arguments {


### PR DESCRIPTION
### What does this PR do

Escape all five HTML metacharacters (`& < > " '`), with `&` handled first so the `&` introduced by the later replacements isn't re-escaped into `&amp;amp;`. Kept the same function signature and call sites; both `initWithStatusCode:...` call sites are untouched.

Not changed: no CSP/`X-Content-Type-Options`/`X-Frame-Options` headers were added anywhere in the vendored server (a separate, larger change); the fact that anonymous LAN read/write of Documents is otherwise by design for this uploader.

### Where should the reviewer start

`GCDWebServerErrorResponse.m`

### How should this be manually tested

- Confirmed the one-line implementation was unchanged at fresh `develop` HEAD (`93f49b40`); `git log --since=2026-07-01` on the file shows no prior fix attempt.
- Pulled `_EscapeHTMLString`'s replacement logic into a standalone C program (sequential, non-overlapping `stringByReplacingOccurrencesOfString:withString:` semantics) and ran it against `<script>alert(1)</script>`, `"onmouseover="alert(1)`, `' onerror='alert(1)`, plain text, and text already containing `&amp;`. All five characters were escaped correctly in every case, the `&`-first ordering did not double-escape, and plain text passed through unchanged. Command: `gcc -o escape_test escape_test.c && ./escape_test`.
- Not executed: compiling/running the real Objective-C file. No Objective-C runtime (GNUstep or Apple) is available on this Linux host, and the underlying report's own GNUstep-based measurement is out of scope for this PR.

### Any background context you want to provide

`_EscapeHTMLString()` in `GCDWebServer/Responses/GCDWebServerErrorResponse.m:72-74` replaced only `"` with `&quot;`. Its output is interpolated into a full HTML error document at lines 79-81, returned as `text/html`. `GCDWebUploader.m:247,291,295` build this error page from the `?path=` query parameter on `/list` and `/download`, both reachable with a plain `GET`.

`<`, `>`, `&` and `'` all passed through unescaped, so a path value using unquoted attributes or `<script>` markup rendered as active HTML/JS in the requester's browser on the device's own HTTP origin. This function is the only HTML-escaping helper in the vendored `GCDWebServer` tree (checked: no other `EscapeHTML`/`escapeHTML` helper exists there), so there was nothing more complete to call instead.

### What are the relevant tickets

GHSA-2px6-c4pj-g87p ([found during penetration test](https://www.turingpoint.de/en/security-assessments/pentests/) by [turingpoint](https://www.turingpoint.de), reported privately, unpublished at time of writing)

### Screenshots (important for UI changes)

n/a, no UI change.

### Questions

None.