### PR TITLE
fix(webserver): escape directory names in the uploader breadcrumb

### DIFF
--- a/.changelog/gcdwebuploader-breadcrumb-xss.md
+++ b/.changelog/gcdwebuploader-breadcrumb-xss.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Web Uploader Breadcrumb Escapes Directory Names — Directory names are now encoded before being inserted into the path breadcrumb**

--- a/PVWebServer/Sources/PVWebServer/Resources/GCDWebUploader.bundle/Contents/Resources/js/index.js
+++ b/PVWebServer/Sources/PVWebServer/Resources/GCDWebUploader.bundle/Contents/Resources/js/index.js
@@ -121,13 +121,13 @@ function _reload(path) {
         var components = path.split("/").slice(1, -1);
         for (var i = 0; i < components.length - 1; ++i) {
           var subpath = "/" + components.slice(0, i + 1).join("/") + "/";
-          $("#path").append('<li data-path="' + subpath + '"><a>' + components[i] + '</a></li>');
+          $("#path").append('<li data-path="' + tmpl.encode(subpath) + '"><a>' + tmpl.encode(components[i]) + '</a></li>');
         }
         $("#path > li").click(function(event) {
           _reload($(this).data("path"));
           event.preventDefault();
         });
-        $("#path").append('<li class="active">' + components[components.length - 1] + '</li>');
+        $("#path").append('<li class="active">' + tmpl.encode(components[components.length - 1]) + '</li>');
       }
       _path = path;
     }


### PR DESCRIPTION
### What does this PR do

`tmpl.min.js` (which defines `tmpl.encode()`, covering the same `< > & " '` and `\x00` set as the sibling `encMap`) is already loaded before `index.js` in `index.html`, and `index.js` already calls `tmpl(...)` elsewhere, so `tmpl.encode()` was available with no new script tag. Wrapped the directory-name text and the `data-path` attribute value in `tmpl.encode()` on both lines. No other line in the file was touched, and `_device` (an app-controlled string, not part of this finding) was left as-is.

### Where should the reviewer start

`GCDWebUploader.bundle` `index.js`

### How should this be manually tested

- Confirmed the two `.append()` calls were unchanged, unescaped, at fresh `develop` HEAD (`93f49b40`); `git log --since=2026-07-01` on the file shows no prior fix attempt.
- Loaded the real, shipped `tmpl.min.js` in Node (with a minimal `document` stub covering only `tmpl.load`, which the fix never calls) and ran `tmpl.encode()` against `<img src=x onerror=alert(1)>`, `"><script>alert(document.domain)</script>`, `' onmouseover='alert(1)`, a normal folder name, and text already containing `&`. All payload shapes were neutralized; the normal name and pre-existing `&amp;` passed through correctly.
- `node --check index.js` passes on the patched file.
- Not executed: loading the patched bundle in an actual browser against a running server. That full round trip (as in the underlying report) needs the compiled iOS/tvOS app, which cannot run on this Linux host.

### Any background context you want to provide

`GCDWebUploader.bundle/.../js/index.js:124` and `:130` build the path breadcrumb by concatenating each directory component, and the `data-path` attribute value, straight into `jQuery.append()`, which parses its argument as HTML. Directory names come from the server's own `/list` response and can be planted via `POST /create` (`GCDWebUploader.m:203`), which applies no character filter beyond what the filesystem itself rejects.

Every sibling render path in this same UI already encodes: the file-listing row uses the `tmpl` template's `{%=o.name%}` placeholder (`index.html:189`), whose `encMap` covers `< > & " '` and `\x00`; and the project's own Swift replacement, `PVModernWebServer.swift:1952,1954`, escapes this identical breadcrumb with `esc(p)`/`esc(acc)`, including the attribute value. The breadcrumb in this legacy uploader was the one path that skipped encoding.

### What are the relevant tickets

GHSA-g8f5-p4v7-6f42 ([found during penetration test](https://www.turingpoint.de/en/security-assessments/pentests/) by [turingpoint](https://www.turingpoint.de), reported privately, unpublished at time of writing)

### Screenshots (important for UI changes)

n/a, no UI change.

### Questions

None.